### PR TITLE
Using %20 instead of the plus (+) sign for encoding spaces

### DIFF
--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -130,7 +130,9 @@ string urlEncode(const string &s)
     } else if (s[i] == '.' || s[i] == '-' || s[i] == '*' || s[i] == '_') {
       result += s[i];
     } else if (s[i] == ' ') {
-      result += '+';
+      result += '%';
+      result += '2';
+      result += '0';
     } else {
       result += "%";
       result += hexAlphabet[static_cast<unsigned char>(s[i]) / 16];


### PR DESCRIPTION
I am testing s3fs against a third party s3 storage solution and noticed s3fs-fuse using the plus character to encode spaces in URI. Avoiding the discussion about weither or not this should be ok. I believe the proper way of encoding spaces is the method specified in the HTTP standard, using "%20". 

While Amazon accepts these requests they also say not to use them. 

from Amazon @ http://docs.aws.amazon.com/general/latest/gr/signature-version-2.html

Note:
Be sure to URI encode the GET request. For example, blank spaces in your HTTP GET request should be encoded as %20. Although an unencoded space is normally allowed by the HTTP protocol specification, the use of unencoded characters creates an invalid signature in your Query request. Do not encode spaces as a plus sign (+) as this will cause errors.
