### PR TITLE
Fixed local timezone was incorrectly being applied to IAM and Last-Modified dates.

### DIFF
--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -752,7 +752,7 @@ time_t cvtIAMExpireStringToTime(const char* s)
   }
   memset(&tm, 0, sizeof(struct tm));
   strptime(s, "%Y-%m-%dT%H:%M:%S", &tm);
-  return mktime(&tm);      // GMT
+  return timegm(&tm); // GMT
 }
 
 time_t get_lastmodified(const char* s)
@@ -763,7 +763,7 @@ time_t get_lastmodified(const char* s)
   }
   memset(&tm, 0, sizeof(struct tm));
   strptime(s, "%a, %d %b %Y %H:%M:%S %Z", &tm);
-  return mktime(&tm);      // GMT
+  return timegm(&tm); // GMT
 }
 
 time_t get_lastmodified(headers_t& meta)


### PR DESCRIPTION
This issue was causing last modified file times to show incorrectly in cases where the last modified time was retrieved from the "Last-Modified" header. This can happen when files are added to a bucket outside of s3fs and do not have the "x-amz-meta-mtime" header.

`timegm` should be used to convert to `time_t` in UTC, rather than `mktime`.
