### PR TITLE
version number up to v1.76 for new.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT(s3fs, 1.74)
+AC_INIT(s3fs, 1.76)
 
 AC_CANONICAL_SYSTEM
 AM_INIT_AUTOMAKE()


### PR DESCRIPTION
v1.75 package has configure.ac which has old version number v1.74, this problem is reported by #8.
This patch is fixed it, and change number up for v1.76.
