### PR TITLE
Fixed a bug(googlecode issue 405), enable_content_md5 Input/output error

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3426,6 +3426,14 @@ unsigned char* md5hexsum(int fd, off_t start, ssize_t size)
   ssize_t bytes;
   unsigned char* result;
 
+  if(-1 == size){
+    struct stat st;
+    if(-1 == fstat(fd, &st)){
+      return NULL;
+    }
+    size = static_cast<ssize_t>(st.st_size);
+  }
+
   // seek to top of file.
   if(-1 == lseek(fd, start, SEEK_SET)){
     return NULL;
@@ -3457,7 +3465,6 @@ unsigned char* md5hexsum(int fd, off_t start, ssize_t size)
     free(result);
     return NULL;
   }
-
   return result;
 }
 


### PR DESCRIPTION
Fixed a bug.
The bug is "enable_content_md5 Input/output error" which is Issue 405 on GoogleCode(https://code.google.com/p/s3fs/issues/detail?id=405).
