### PR TITLE
Fixed a bug: issue #14, s3fs -u should return 0 if there are no lost multiparts

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2712,7 +2712,7 @@ static bool abort_uncomp_mp_list(uncomp_mp_list_t& list)
   char buff[1024];
 
   if(0 >= list.size()){
-    return false;
+    return true;
   }
   memset(buff, 0, sizeof(buff));
 


### PR DESCRIPTION
Issue #14 
Fixed this issue, s3fs should return 0 on no list of multiparty uploading.
