### PR TITLE
Fix typos in docs for max_stat_cache_size (the default is actually 1000)

### DIFF
--- a/doc/man/s3fs.1
+++ b/doc/man/s3fs.1
@@ -102,7 +102,7 @@ time to wait for connection before giving up.
 \fB\-o\fR readwrite_timeout (default="30" seconds)
 time to wait between read/write activity before giving up.
 .TP
-\fB\-o\fR max_stat_cache_size (default="10000" entries (about 4MB))
+\fB\-o\fR max_stat_cache_size (default="1000" entries (about 4MB))
 maximum number of entries in the stat cache
 .TP
 \fB\-o\fR stat_cache_expire (default is no expire)

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -889,7 +889,7 @@ void show_help (void)
     "   readwrite_timeout (default=\"30\" seconds)\n"
     "      - time to wait between read/write activity before giving up\n"
     "\n"
-    "   max_stat_cache_size (default=\"10000\" entries (about 4MB))\n"
+    "   max_stat_cache_size (default=\"1000\" entries (about 4MB))\n"
     "      - maximum number of entries in the stat cache\n"
     "\n"
     "   stat_cache_expire (default is no expire)\n"


### PR DESCRIPTION
Line 50 of src/cache.cpp defines the default:

```
StatCache::StatCache() : IsExpireTime(false), ExpireTime(0), CacheSize(1000), IsCacheNoObject(false)
```
