### PR TITLE
Fixed a bug #18(losing check retry error)

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3127,8 +3127,12 @@ int S3fsMultiCurl::MultiRead(void)
 
         // For retry
         if(RetryCallback){
-          retrycurl = RetryCallback(s3fscurl);
-          cMap_all[retrycurl->hCurl] = retrycurl;
+          if(NULL != (retrycurl = RetryCallback(s3fscurl))){
+            cMap_all[retrycurl->hCurl] = retrycurl;
+          }else{
+            // do not care, but set...
+            isRetry = false;
+          }
         }
         if(s3fscurl != retrycurl){
           s3fscurl->DestroyCurlHandle();


### PR DESCRIPTION
FIxed a bug.
When s3fs failed remaking a request from failed a request for retrying, s3fs forgot checking return pointer as NULL.
