### PR TITLE
Retry to send request at CURLE_SSL_CONNECT_ERROR

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1572,6 +1572,11 @@ int S3fsCurl::RequestPerform(void)
         sleep(2);
         break;
 
+      case CURLE_SSL_CONNECT_ERROR:
+        DPRN("### CURLE_SSL_CONNECT_ERROR");
+        sleep(2);
+        break;
+
       case CURLE_SSL_CACERT:
         // try to locate cert, if successful, then set the
         // option and continue


### PR DESCRIPTION
Issues about SSL connect error, s3fs should try to re-connect and re-send a request.
