### PR TITLE
Added support for path API request style.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -69,6 +69,7 @@ extern bool debug;
 extern bool foreground;
 extern bool foreground2;
 extern bool nomultipart;
+extern bool pathrequeststyle;
 extern std::string program_name;
 extern std::string service_path;
 extern std::string host;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -83,6 +83,7 @@ bool debug                        = false;
 bool foreground                   = false;
 bool foreground2                  = false;
 bool nomultipart                  = false;
+bool pathrequeststyle             = false;
 std::string program_name;
 std::string service_path          = "/";
 std::string host                  = "http://s3.amazonaws.com";
@@ -3672,6 +3673,10 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
          found  = host.find_last_of('/');
          length = host.length();
       }
+      return 0;
+    }
+    if(0 == strcmp(arg, "use_path_request_style")){
+      pathrequeststyle = true;
       return 0;
     }
 

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -312,7 +312,7 @@ MVNODE *create_mvnode(const char *old_path, const char *new_path, bool is_dir, b
     return NULL;
   }
 
-  if(NULL == (p_new_path = strdup(new_path))){ 
+  if(NULL == (p_new_path = strdup(new_path))){
     free(p);
     free(p_old_path);
     printf("create_mvnode: could not allocation memory for p_new_path\n");
@@ -330,7 +330,7 @@ MVNODE *create_mvnode(const char *old_path, const char *new_path, bool is_dir, b
 }
 
 //
-// Add sorted MVNODE data(Ascending order) 
+// Add sorted MVNODE data(Ascending order)
 //
 MVNODE *add_mvnode(MVNODE** head, MVNODE** tail, const char *old_path, const char *new_path, bool is_dir, bool normdir)
 {
@@ -671,9 +671,9 @@ mode_t get_mode(headers_t& meta, const char* path, bool checkdir, bool forcedir)
     }
   }
   // Checking the bitmask, if the last 3 bits are all zero then process as a regular
-  // file type (S_IFDIR or S_IFREG), otherwise return mode unmodified so that S_IFIFO, 
+  // file type (S_IFDIR or S_IFREG), otherwise return mode unmodified so that S_IFIFO,
   // S_IFSOCK, S_IFCHR, S_IFLNK and S_IFBLK devices can be processed properly by fuse.
-  if(!(mode & S_IFMT)){ 
+  if(!(mode & S_IFMT)){
     if(!isS3sync){
       if(checkdir){
         if(forcedir){
@@ -823,7 +823,7 @@ void show_usage (void)
 void show_help (void)
 {
   show_usage();
-  printf( 
+  printf(
     "\n"
     "Mount an Amazon S3 bucket as a file system.\n"
     "\n"
@@ -966,6 +966,11 @@ void show_help (void)
     "        touch, mv, etc), but this option does not use copy-api for\n"
     "        only rename command(ex. mv). If this option is specified with\n"
     "        nocopapi, the s3fs ignores it.\n"
+    "\n"
+    "   use_path_request_style (use legacy API calling style)\n"
+    "        Enble compatibility with S3-like APIs which do not support\n"
+    "        the virtual-host request style, by using the older path request\n"
+    "        style.\n"
     "\n"
     "FUSE/mount Options:\n"
     "\n"

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -186,8 +186,18 @@ string prepare_url(const char* url)
     uri_length = 8;
   }
   uri  = url_str.substr(0, uri_length);
-  host = bucket + "." + url_str.substr(uri_length, bucket_pos - uri_length).c_str();
-  path = url_str.substr((bucket_pos + bucket_length));
+
+  if(!pathrequeststyle){
+    host = bucket + "." + url_str.substr(uri_length, bucket_pos - uri_length).c_str();
+    path = url_str.substr((bucket_pos + bucket_length));
+  }else{
+    host = url_str.substr(uri_length, bucket_pos - uri_length).c_str();
+    string part = url_str.substr((bucket_pos + bucket_length));
+    if('/' != part[0]){
+      part = "/" + part;
+    }
+    path = "/" + bucket + part;
+  }
 
   url_str = uri + host + path;
 
@@ -207,4 +217,3 @@ string get_date()
   strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", gmtime(&t));
   return buf;
 }
-


### PR DESCRIPTION
Rather than using virtual host style requests, path style requests can be used
instead.

i.e. rather than **bucketname**.s3.amazon.com/... the s3fs will be able to request
from s3.amazon.com/**bucketname**/...

This is useful for S3 compatible APIs which don't support the virtual host style
request.

It is enabled with the new option, `use_path_style_request`.

It would resolve issue #34.
##### Usage example:

```
/usr/bin/s3fs data ~/netcdf -o url="https://swift.rc.nectar.org.au:8888/" -o use_path_request_style -o allow_other -o uid=500 -o gid=500
```
