### PR TITLE
Fixed a bug issue #40

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2272,8 +2272,20 @@ static int list_bucket(const char* path, S3ObjList& head, const char* delimiter)
         next_marker = (char*)tmpch;
         xmlFree(tmpch);
       }else{
-        DPRN("Could not find next marker, thus break loop.");
-        truncated = false;
+        // If did not specify "delimiter", s3 did not return "NextMarker".
+        // On this case, can use lastest name for next marker.
+        //
+        string lastname;
+        if(!head.GetLastName(lastname)){
+          DPRN("Could not find next marker, thus break loop.");
+          truncated = false;
+        }else{
+          next_marker = s3_realpath.substr(1);
+          if(0 == s3_realpath.length() || '/' != s3_realpath[s3_realpath.length() - 1]){
+            next_marker += "/";
+          }
+          next_marker += lastname;
+        }
       }
     }
     S3FS_XMLFREEDOC(doc);

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -229,6 +229,26 @@ bool S3ObjList::IsDir(const char* name) const
   return ps3obj->is_dir;
 }
 
+bool S3ObjList::GetLastName(std::string& lastname) const
+{
+  bool result = false;
+  lastname = "";
+  for(s3obj_t::const_iterator iter = objects.begin(); iter != objects.end(); iter++){
+    if((*iter).second.orgname.length()){
+      if(0 > strcmp(lastname.c_str(), (*iter).second.orgname.c_str())){
+        lastname = (*iter).second.orgname;
+        result = true;
+      }
+    }else{
+      if(0 > strcmp(lastname.c_str(), (*iter).second.normalname.c_str())){
+        lastname = (*iter).second.normalname;
+        result = true;
+      }
+    }
+  }
+  return result;
+}
+
 bool S3ObjList::GetNameList(s3obj_list_t& list, bool OnlyNormalized, bool CutSlash) const
 {
   s3obj_t::const_iterator iter;

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -51,6 +51,7 @@ class S3ObjList
     std::string GetETag(const char* name) const;
     bool IsDir(const char* name) const;
     bool GetNameList(s3obj_list_t& list, bool OnlyNormalized = true, bool CutSlash = true) const;
+    bool GetLastName(std::string& lastname) const;
 
     static bool MakeHierarchizedList(s3obj_list_t& list, bool haveSlash);
 };


### PR DESCRIPTION
#40 is a bug.

List bucket request for rename(moving) does not have delimiter parameter, so that s3fs can not send 2'nd request because the response does not have "nextmarker" when there are over 1000 object.
This patches is that s3fs sends 2'nd request on that case.
