### PR TITLE
fixed a bug about configure.ac. issue #50

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,12 @@ AS_IF(
   )
 )
 
+dnl
+dnl For PKG_CONFIG before checking nss/gnutls.
+dnl this is redundant checking, but we need checking before following.
+dnl
+PKG_CHECK_MODULES([common_lib_checking], [fuse >= 2.8.4 libcurl >= 7.0 libxml-2.0 >= 2.6])
+
 AC_MSG_CHECKING([compile s3fs with])
 case "${auth_lib}" in
 openssl)


### PR DESCRIPTION
Fixed a bug about issue #50 
- configure.ac could not use PKG_CONFIG when gnutls and mss libraries is specified(--with-gnutls/--with-nss).
