### PR TITLE
Return EIO on failed read

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3280,8 +3280,8 @@ int S3fsMultiCurl::MultiRead(void)
           if(NULL != (retrycurl = RetryCallback(s3fscurl))){
             cMap_all[retrycurl->hCurl] = retrycurl;
           }else{
-            // do not care, but set...
-            isRetry = false;
+            // Could not set up callback.
+            return -EIO;
           }
         }
         if(s3fscurl != retrycurl){


### PR DESCRIPTION
Previously S3fsMultiCurl::MultiRead did not report read errors since
it did not treat failed callback setup as a fatal operation error.
Failed callback setups usually result from exceeding the number of
allowed retries.  Previously cp did not report an error during a
network outage but now does:

```
$ cp ~/s3-path/s3-file .
cp: error reading ‘/home/gaul/s3-path/s3-file’: Input/output error
cp: failed to extend ‘./s3-file’: Input/output error
```
