### PR TITLE
url: handle scheme omission

### DIFF
--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -180,10 +180,12 @@ string prepare_url(const char* url)
   string token =  str("/" + bucket);
   int bucket_pos = url_str.find(token);
   int bucket_length = token.size();
-  int uri_length = 7;
+  int uri_length = 0;
 
   if(!strncasecmp(url_str.c_str(), "https://", 8)){
     uri_length = 8;
+  } else if(!strncasecmp(url_str.c_str(), "http://", 7)) {
+    uri_length = 7;
   }
   uri  = url_str.substr(0, uri_length);
 


### PR DESCRIPTION
When the scheme is omitted in URL overriding (for example `example.com`
instead of `https://example.com`), s3fs is modifying the URL by
inserting `s3.` in the middle of the name  (`examples3..com`).

This can be a bit difficult to troubleshoot and curl seems to handle
schema-less requests just fine. So, just handle this case correctly.
