### PR TITLE
Update curl.cpp

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3498,7 +3498,7 @@ struct curl_slist* AdditionalHeader::AddHeader(struct curl_slist* list, const ch
     return list;
   }
   for(headers_t::iterator iter = meta.begin(); iter != meta.end(); ++iter){
-    string slistval = (*iter).first + ": " + (*iter).second;
+    string slistval = (*iter).first + ":" + (*iter).second;
     // Adding header
     list = curl_slist_sort_insert(list, slistval.c_str());
   }


### PR DESCRIPTION
The space causes signature mismatch when using "ahbe_conf" file to add additional headers.When s3 use the" x-amaz" header to calculates the signature, the format is as follow:
PUT

application/octet-stream
Wed, 05 Nov 2014 03:05:08 GMT
x-amz-acl:private
x-amz-meta-gid:0
x-amz-meta-mode:33188
x-amz-meta-mtime:1415156708
x-amz-meta-uid:0
There is no space after colon.
