### PR TITLE
Add simple unit tests for trim functions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,3 +37,8 @@ endif
 
 s3fs_LDADD = $(DEPS_LIBS)
 
+noinst_PROGRAMS = test_string_util
+
+test_string_util_SOURCES = string_util.cpp test_string_util.cpp
+
+TESTS = test_string_util

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3625,6 +3625,45 @@ bool MakeUrlResource(const char* realpath, string& resourcepath, string& url)
   return true;
 }
 
+string prepare_url(const char* url)
+{
+  FPRNINFO("URL is %s", url);
+
+  string uri;
+  string host;
+  string path;
+  string url_str = str(url);
+  string token =  str("/" + bucket);
+  int bucket_pos = url_str.find(token);
+  int bucket_length = token.size();
+  int uri_length = 0;
+
+  if(!strncasecmp(url_str.c_str(), "https://", 8)){
+    uri_length = 8;
+  } else if(!strncasecmp(url_str.c_str(), "http://", 7)) {
+    uri_length = 7;
+  }
+  uri  = url_str.substr(0, uri_length);
+
+  if(!pathrequeststyle){
+    host = bucket + "." + url_str.substr(uri_length, bucket_pos - uri_length).c_str();
+    path = url_str.substr((bucket_pos + bucket_length));
+  }else{
+    host = url_str.substr(uri_length, bucket_pos - uri_length).c_str();
+    string part = url_str.substr((bucket_pos + bucket_length));
+    if('/' != part[0]){
+      part = "/" + part;
+    }
+    path = "/" + bucket + part;
+  }
+
+  url_str = uri + host + path;
+
+  FPRNINFO("URL changed is %s", url_str.c_str());
+
+  return str(url_str);
+}
+
 /*
 * Local variables:
 * tab-width: 4

--- a/src/curl.h
+++ b/src/curl.h
@@ -422,6 +422,7 @@ unsigned char* md5hexsum(int fd, off_t start, ssize_t size);
 std::string md5sum(int fd, off_t start, ssize_t size);
 struct curl_slist* curl_slist_sort_insert(struct curl_slist* list, const char* data);
 bool MakeUrlResource(const char* realpath, std::string& resourcepath, std::string& url);
+std::string prepare_url(const char* url);
 
 #endif // S3FS_CURL_H_
 

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -169,45 +169,6 @@ bool get_keyword_value(string& target, const char* keyword, string& value)
   return true;
 }
 
-string prepare_url(const char* url)
-{
-  FPRNINFO("URL is %s", url);
-
-  string uri;
-  string host;
-  string path;
-  string url_str = str(url);
-  string token =  str("/" + bucket);
-  int bucket_pos = url_str.find(token);
-  int bucket_length = token.size();
-  int uri_length = 0;
-
-  if(!strncasecmp(url_str.c_str(), "https://", 8)){
-    uri_length = 8;
-  } else if(!strncasecmp(url_str.c_str(), "http://", 7)) {
-    uri_length = 7;
-  }
-  uri  = url_str.substr(0, uri_length);
-
-  if(!pathrequeststyle){
-    host = bucket + "." + url_str.substr(uri_length, bucket_pos - uri_length).c_str();
-    path = url_str.substr((bucket_pos + bucket_length));
-  }else{
-    host = url_str.substr(uri_length, bucket_pos - uri_length).c_str();
-    string part = url_str.substr((bucket_pos + bucket_length));
-    if('/' != part[0]){
-      part = "/" + part;
-    }
-    path = "/" + bucket + part;
-  }
-
-  url_str = uri + host + path;
-
-  FPRNINFO("URL changed is %s", url_str.c_str());
-
-  return str(url_str);
-}
-
 /**
  * Returns the current date
  * in a format suitable for a HTTP request header.

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -25,6 +25,7 @@
  */
 #include <string.h>
 #include <syslog.h>
+#include <sys/types.h>
 
 #include <string>
 #include <sstream>
@@ -47,7 +48,6 @@ std::string lower(std::string s);
 std::string IntToStr(int);
 std::string get_date();
 std::string urlEncode(const std::string &s);
-std::string prepare_url(const char* url);
 bool get_keyword_value(std::string& target, const char* keyword, std::string& value);
 
 #endif // S3FS_STRING_UTIL_H_

--- a/src/test_string_util.cpp
+++ b/src/test_string_util.cpp
@@ -1,0 +1,44 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright 2014 Andrew Gaul <andrew@gaul.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <string>
+
+#include "string_util.h"
+#include "test_util.h"
+
+int main(int argc, char *argv[])
+{
+  ASSERT_EQUALS(std::string("1234"), trim("  1234  "));
+  ASSERT_EQUALS(std::string("1234"), trim("1234  "));
+  ASSERT_EQUALS(std::string("1234"), trim("  1234"));
+  ASSERT_EQUALS(std::string("1234"), trim("1234"));
+
+  ASSERT_EQUALS(std::string("1234  "), trim_left("  1234  "));
+  ASSERT_EQUALS(std::string("1234  "), trim_left("1234  "));
+  ASSERT_EQUALS(std::string("1234"), trim_left("  1234"));
+  ASSERT_EQUALS(std::string("1234"), trim_left("1234"));
+
+  ASSERT_EQUALS(std::string("  1234"), trim_right("  1234  "));
+  ASSERT_EQUALS(std::string("1234"), trim_right("1234  "));
+  ASSERT_EQUALS(std::string("  1234"), trim_right("  1234"));
+  ASSERT_EQUALS(std::string("1234"), trim_right("1234"));
+
+  return 0;
+}

--- a/src/test_util.h
+++ b/src/test_util.h
@@ -1,0 +1,34 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright 2014 Andrew Gaul <andrew@gaul.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <cstdlib>
+#include <iostream>
+
+template <typename T> void assert_equals(const T &x, const T &y, const char *file, int line)
+{
+  if (x != y) {
+    std::cerr << x << " != " << y << " at " << file << ":" << line << std::endl;
+    std::exit(1);
+  }
+}
+
+#define ASSERT_EQUALS(x, y) \
+  assert_equals((x), (y), __FILE__, __LINE__)
+


### PR DESCRIPTION
Subsequent commits will use this infrastructure.  Also reparent
prepare_url which relies on unrelated bucket, foreground2, and
pathrequeststyle symbols.