### PR TITLE
CURL handles not properly initialized to use DNS or SSL session caching.

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -329,13 +329,13 @@ bool S3fsCurl::InitShareCurl(void)
     DPRN("curl_share_setopt(UNLOCKFUNC) returns %d(%s)", nSHCode, curl_share_strerror(nSHCode));
     return false;
   }
-  if(!S3fsCurl::is_dns_cache){
+  if(S3fsCurl::is_dns_cache){
     if(CURLSHE_OK != (nSHCode = curl_share_setopt(S3fsCurl::hCurlShare, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS))){
       DPRN("curl_share_setopt(DNS) returns %d(%s)", nSHCode, curl_share_strerror(nSHCode));
       return false;
     }
   }
-  if(!S3fsCurl::is_ssl_session_cache){
+  if(S3fsCurl::is_ssl_session_cache){
     if(CURLSHE_OK != (nSHCode = curl_share_setopt(S3fsCurl::hCurlShare, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION))){
       DPRN("curl_share_setopt(SSL SESSION) returns %d(%s)", nSHCode, curl_share_strerror(nSHCode));
       return false;


### PR DESCRIPTION
When initializing CURL handles, the is_dns_cache and is_ssl_session_cache flags were not checked properly. As a result, the handles were not set-up properly for DNS or SSL session caching.