### PR TITLE
Remove prefix option in s3fs man page - issue#87

### DIFF
--- a/doc/man/s3fs.1
+++ b/doc/man/s3fs.1
@@ -53,9 +53,6 @@ the default canned acl to apply to all written S3 objects, e.g., "public-read".
 Any created files will have this canned acl.
 Any updated files will also have this canned acl applied!
 .TP
-\fB\-o\fR prefix (default="") (coming soon!)
-a prefix to append to all S3 objects.
-.TP
 \fB\-o\fR retries (default="2")
 number of times to retry a failed S3 transaction.
 .TP


### PR DESCRIPTION
Fixed issue#87.

Although there are descriptions of prefix option in the S3fs man page, this is the old description, description of the features that are not yet implemented.
In the future, because it is a description do not plan to be implemented, it has been deleted.
For more information, please look at the Issue # 87.