### PR TITLE
support for facilitate_chroot

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -103,6 +103,7 @@ static bool nocopyapi             = false;
 static bool norenameapi           = false;
 static bool nonempty              = false;
 static bool allow_other           = false;
+static bool facilitate_chroot     = false;
 static uid_t s3fs_uid             = 0;
 static gid_t s3fs_gid             = 0;
 static mode_t s3fs_umask          = 0;
@@ -3383,7 +3384,8 @@ static int set_moutpoint_attribute(struct stat& mpst)
 {
   mp_uid  = geteuid();
   mp_gid  = getegid();
-  mp_mode = S_IFDIR | (allow_other ? (S_IRWXU | S_IRWXG | S_IRWXO) : S_IRWXU);
+  mp_mode = S_IFDIR | (allow_other && !facilitate_chroot ? (S_IRWXU | S_IRWXG | S_IRWXO) :
+  		(allow_other && facilitate_chroot ? (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) : S_IRWXU));
 
   FPRNNN("PROC(uid=%u, gid=%u) - MountPoint(uid=%u, gid=%u, mode=%04o)",
          (unsigned int)mp_uid, (unsigned int)mp_gid, (unsigned int)(mpst.st_uid), (unsigned int)(mpst.st_gid), mpst.st_mode);
@@ -3520,6 +3522,10 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
     if(0 == strcmp(arg, "allow_other")){
       allow_other = true;
       return 1; // continue for fuse option
+    }
+    if(0 == strcmp(arg, "facilitate_chroot")){
+      facilitate_chroot = true;
+      return 0;
     }
     if(0 == STR2NCMP(arg, "default_acl=")){
       const char* acl = strchr(arg, '=') + sizeof(char);


### PR DESCRIPTION
Used in tandem with `-o allow_other`, `-o facilitate_chroot` sets the permissions on the mount dir to 755 instead of 777 in order to provide support for backing a chroot jail.