### PR TITLE
Fallback to v2 signatures correctly.

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -300,7 +300,7 @@ class S3fsCurl
     static const char* GetIAMRole(void) { return S3fsCurl::IAM_role.c_str(); }
     static bool SetMultipartSize(off_t size);
     static off_t GetMultipartSize(void) { return S3fsCurl::multipart_size; }
-    static bool SetSignatureV4(bool isset = true) { bool bresult = S3fsCurl::is_sigv4; S3fsCurl::is_sigv4 = isset; return bresult; }
+    static bool SetSignatureV4(bool isset) { bool bresult = S3fsCurl::is_sigv4; S3fsCurl::is_sigv4 = isset; return bresult; }
     static bool IsSignatureV4(void) { return S3fsCurl::is_sigv4; }
 
     // methods

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3068,7 +3068,7 @@ static int s3fs_check_service(void)
       // retry to use sigv2
       LOWSYSLOGPRINT(LOG_ERR, "Could not connect, so retry to connect by signature version 2.");
       FPRN("Could not connect, so retry to connect by signature version 2.");
-      S3fsCurl::SetSignatureV4();
+      S3fsCurl::SetSignatureV4(false);
 
       // retry to check
       s3fscurl.DestroyCurlHandle();


### PR DESCRIPTION
Missing parameter to SetSignatureV4() call in the fallback code path
results in not actually falling back.