### PR TITLE
Small fixes to integration tests

### DIFF
--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -12,6 +12,7 @@ then
 	echo "Missing credentials file: $S3FS_CREDENTIALS_FILE"
 	exit 1
 fi
+chmod 600 "$S3FS_CREDENTIALS_FILE"
 
 S3PROXY_VERSION="1.3.0"
 S3PROXY_BINARY="s3proxy-${S3PROXY_VERSION}-jar-with-dependencies.jar"

--- a/test/small-integration-test.sh
+++ b/test/small-integration-test.sh
@@ -6,7 +6,7 @@ REQUIRE_ROOT=require-root.sh
 source integration-test-common.sh
 
 java -jar "$S3PROXY_BINARY" --properties s3proxy.conf &
-S3PROXY_PID="$?"
+S3PROXY_PID="$!"
 
 # wait for S3Proxy to start
 for i in $(seq 30);
@@ -34,7 +34,7 @@ $S3FS $TEST_BUCKET_1 $TEST_BUCKET_MOUNT_POINT_1 \
 
 ./integration-test-main.sh $TEST_BUCKET_MOUNT_POINT_1
 
-umount $TEST_BUCKET_MOUNT_POINT_1
+fusermount -u $TEST_BUCKET_MOUNT_POINT_1
 
 kill $S3PROXY_PID
 


### PR DESCRIPTION
Use S3Proxy pid instead of self pid, ensure correct passwd
permissions, and use fusermount instead of umount so that non-root can
run tests.