### PR TITLE
URL-encode ampersand

### DIFF
--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -127,8 +127,6 @@ string urlEncode(const string &s)
       result += s[i];
     }else if (s[i] == '=') { // Note- special case for s3...
       result += s[i];
-    }else if (s[i] == '&') { // Note- special case for s3...
-      result += s[i];
     } else if (isalnum(s[i])) {
       result += s[i];
     } else if (s[i] == '.' || s[i] == '-' || s[i] == '*' || s[i] == '_') {


### PR DESCRIPTION
Previously s3fs could not list a directory if it contained a file with
an ampersand character when using AWSv4 authentication.