### PR TITLE
Fixed url-encoding for ampersand etc on sigv4 - Improvement/#149

### DIFF
--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -125,10 +125,6 @@ string urlEncode(const string &s)
   for (unsigned i = 0; i < s.length(); ++i) {
     if (s[i] == '/') { // Note- special case for fuse paths...
       result += s[i];
-    }else if (s[i] == '=') { // Note- special case for s3...
-      result += s[i];
-    }else if (s[i] == '&') { // Note- special case for s3...
-      result += s[i];
     } else if (isalnum(s[i])) {
       result += s[i];
     } else if (s[i] == '.' || s[i] == '-' || s[i] == '*' || s[i] == '_') {
@@ -158,6 +154,8 @@ string urlEncode2(const string &s)
     if (s[i] == '=') { // Note- special case for fuse paths...
       result += s[i];
     }else if (s[i] == '&') { // Note- special case for s3...
+      result += s[i];
+    }else if(s[i] == '%'){
       result += s[i];
     } else if (isalnum(s[i])) {
       result += s[i];


### PR DESCRIPTION
s3fs could not list/remove a directory name which has ampersand(&), equal(=) on sigv4.
This patch is based by PR: URL-encode ampersand(#149) by @andrewgaul.
