### PR TITLE
Support buckets with mixed-case names

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -121,7 +121,10 @@ static string url_to_host(const std::string &url)
 
 static string get_bucket_host()
 {
+  if(!pathrequeststyle){
     return bucket + "." + url_to_host(host);
+  }
+  return url_to_host(host) + "/" + bucket;
 }
 
 #if 0 // noused

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4050,9 +4050,9 @@ int main(int argc, char* argv[])
     exit(EXIT_FAILURE);
   }
 
-  // bucket names cannot contain upper case characters
-  if(lower(bucket) != bucket){
-    fprintf(stderr, "%s: BUCKET %s, upper case characters are not supported\n",
+  // bucket names cannot contain upper case characters in virtual-hosted style
+  if((!pathrequeststyle) && (lower(bucket) != bucket)){
+    fprintf(stderr, "%s: BUCKET %s, name not compatible with virtual-hosted style\n",
       program_name.c_str(), bucket.c_str());
     exit(EXIT_FAILURE);
   }


### PR DESCRIPTION
Buckets with mixed-case names can't be accessed with the virtual-hosted style API due to DNS limitations.  S3FS has an option for pathrequeststyle which is used for the URL, but it was not applied when building the endpoint passed through the Host header.  Fix this, and relax the validation on bucket names when using this style.

See: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro