### PR TITLE
Supported extended attributes

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -82,6 +82,13 @@
 typedef std::map<std::string, std::string> headers_t;
 
 //
+// Header "x-amz-meta-xattr" is for extended attributes.
+// This header is url encoded string which is json formated.
+//   x-amz-meta-xattr:urlencod({"xattr-1":"value-1","xattr-2":"value-2","xattr-3":"value-3"})
+//
+typedef std::map<std::string, std::string> xattrs_t;
+
+//
 // Global valiables
 //
 extern bool debug;

--- a/src/common.h
+++ b/src/common.h
@@ -84,9 +84,22 @@ typedef std::map<std::string, std::string> headers_t;
 //
 // Header "x-amz-meta-xattr" is for extended attributes.
 // This header is url encoded string which is json formated.
-//   x-amz-meta-xattr:urlencod({"xattr-1":"value-1","xattr-2":"value-2","xattr-3":"value-3"})
+//   x-amz-meta-xattr:urlencod({"xattr-1":"base64(value-1)","xattr-2":"base64(value-2)","xattr-3":"base64(value-3)"})
 //
-typedef std::map<std::string, std::string> xattrs_t;
+typedef struct xattr_value{
+  unsigned char* pvalue;
+  size_t         length;
+
+  xattr_value(unsigned char* pval = NULL, size_t len = 0) : pvalue(pval), length(len) {}
+  ~xattr_value()
+  {
+    if(pvalue){
+      free(pvalue);
+    }
+  }
+}XATTRVAL, *PXATTRVAL;
+
+typedef std::map<std::string, PXATTRVAL> xattrs_t;
 
 //
 // Global valiables

--- a/src/common_auth.cpp
+++ b/src/common_auth.cpp
@@ -30,7 +30,7 @@ using namespace std;
 //-------------------------------------------------------------------
 // Utility Function
 //-------------------------------------------------------------------
-char* s3fs_base64(unsigned char* input, size_t length)
+char* s3fs_base64(const unsigned char* input, size_t length)
 {
   static const char* base = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
   char* result;
@@ -58,6 +58,61 @@ char* s3fs_base64(unsigned char* input, size_t length)
   }
   result[wpos] = '\0';
 
+  return result;
+}
+
+inline unsigned char char_decode64(const char ch)
+{
+  unsigned char by;
+  if('A' <= ch && ch <= 'Z'){                   // A - Z
+    by = static_cast<unsigned char>(ch - 'A');
+  }else if('a' <= ch && ch <= 'z'){             // a - z
+    by = static_cast<unsigned char>(ch - 'a' + 26);
+  }else if('0' <= ch && ch <= '9'){             // 0 - 9
+    by = static_cast<unsigned char>(ch - '0' + 52);
+  }else if('+' == ch){                         // +
+    by = 62;
+  }else if('/' == ch){                         // /
+    by = 63;
+  }else if('=' == ch){                         // =
+    by = 64;
+  }else{                                       // something wrong
+    by = 64;
+  }
+  return by;
+}
+
+unsigned char* s3fs_decode64(const char* input, size_t* plength)
+{
+  unsigned char* result;
+  if(!input || 0 == strlen(input) || !plength){
+    return NULL;
+  }
+  if(NULL == (result = (unsigned char*)malloc((strlen(input) + 1)))){
+    return NULL; // ENOMEM
+  }
+
+  unsigned char parts[4];
+  size_t input_len = strlen(input);
+  size_t rpos;
+  size_t wpos;
+  for(rpos = 0, wpos = 0; rpos < input_len; rpos += 4){
+    parts[0] = char_decode64(input[rpos]);
+    parts[1] = (rpos + 1) < input_len ? char_decode64(input[rpos + 1]) : 64;
+    parts[2] = (rpos + 2) < input_len ? char_decode64(input[rpos + 2]) : 64;
+    parts[3] = (rpos + 3) < input_len ? char_decode64(input[rpos + 3]) : 64;
+
+    result[wpos++] = ((parts[0] << 2) & 0xfc) | ((parts[1] >> 4) & 0x03);
+    if(64 == parts[2]){
+      break;
+    }
+    result[wpos++] = ((parts[1] << 4) & 0xf0) | ((parts[2] >> 2) & 0x0f);
+    if(64 == parts[3]){
+      break;
+    }
+    result[wpos++] = ((parts[2] << 6) & 0xc0) | (parts[3] & 0x3f);
+  }
+  *plength = wpos;
   return result;
 }
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3119,24 +3119,26 @@ static int s3fs_removexattr(const char* path, const char* name)
   }
 
   // get xattrs
-  if(meta.end() == meta.find("x-amz-meta-xattr")){
+  headers_t::iterator hiter = meta.find("x-amz-meta-xattr");
+  if(meta.end() == hiter){
     // object does not have xattrs
     return -ENOATTR;
   }
-  string strxattrs = meta["x-amz-meta-xattr"];
+  string strxattrs = hiter->second;
 
   parse_xattrs(strxattrs, xattrs);
 
   // check name xattrs
-  string strname = name;
-  if(xattrs.end() == xattrs.find(strname)){
+  string             strname = name;
+  xattrs_t::iterator xiter   = xattrs.find(strname);
+  if(xattrs.end() == xiter){
     free_xattrs(xattrs);
     return -ENOATTR;
   }
 
   // make new header_t after deleting name xattr
-  if(xattrs[strname]){
-    delete xattrs[strname];
+  if(xiter->second){
+    delete xiter->second;
   }
   xattrs.erase(strname);
 

--- a/src/s3fs_auth.h
+++ b/src/s3fs_auth.h
@@ -26,7 +26,8 @@
 //
 // in common_auth.cpp
 //
-char* s3fs_base64(unsigned char* input, size_t length);
+char* s3fs_base64(const unsigned char* input, size_t length);
+unsigned char* s3fs_decode64(const char* input, size_t* plength);
 std::string s3fs_get_content_md5(int fd);
 std::string s3fs_md5sum(int fd, off_t start, ssize_t size);
 std::string s3fs_sha256sum(int fd, off_t start, ssize_t size);

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
 
@@ -185,12 +186,12 @@ string urlDecode(const string& s)
       if(s.length() <= ++i){
         break;       // wrong format.
       }
-      ch += ('0' <= s[i] && s[i] <= '9') ? (s[i] - '0') : ('A' <= s[i] && s[i] <= 'F') ? (s[i] - 'A' + 0x10) : ('a' <= s[i] && s[i] <= 'f') ? (s[i] - 'a' + 0x10) : 0x00;
+      ch += ('0' <= s[i] && s[i] <= '9') ? (s[i] - '0') : ('A' <= s[i] && s[i] <= 'F') ? (s[i] - 'A' + 0x0a) : ('a' <= s[i] && s[i] <= 'f') ? (s[i] - 'a' + 0x0a) : 0x00;
       if(s.length() <= ++i){
         break;       // wrong format.
       }
       ch *= 16;
-      ch += ('0' <= s[i] && s[i] <= '9') ? (s[i] - '0') : ('A' <= s[i] && s[i] <= 'F') ? (s[i] - 'A' + 0x10) : ('a' <= s[i] && s[i] <= 'f') ? (s[i] - 'a' + 0x10) : 0x00;
+      ch += ('0' <= s[i] && s[i] <= '9') ? (s[i] - '0') : ('A' <= s[i] && s[i] <= 'F') ? (s[i] - 'A' + 0x0a) : ('a' <= s[i] && s[i] <= 'f') ? (s[i] - 'a' + 0x0a) : 0x00;
       result += ch;
     }
   }

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -174,6 +174,49 @@ string urlEncode2(const string &s)
   return result;
 }
 
+string urlDecode(const string& s)
+{
+  string result;
+  for(unsigned i = 0; i < s.length(); ++i){
+    if(s[i] != '%'){
+      result += s[i];
+    }else{
+      char ch = 0;
+      if(s.length() <= ++i){
+        break;       // wrong format.
+      }
+      ch += ('0' <= s[i] && s[i] <= '9') ? (s[i] - '0') : ('A' <= s[i] && s[i] <= 'F') ? (s[i] - 'A' + 0x10) : ('a' <= s[i] && s[i] <= 'f') ? (s[i] - 'a' + 0x10) : 0x00;
+      if(s.length() <= ++i){
+        break;       // wrong format.
+      }
+      ch *= 16;
+      ch += ('0' <= s[i] && s[i] <= '9') ? (s[i] - '0') : ('A' <= s[i] && s[i] <= 'F') ? (s[i] - 'A' + 0x10) : ('a' <= s[i] && s[i] <= 'f') ? (s[i] - 'a' + 0x10) : 0x00;
+      result += ch;
+    }
+  }
+  return result;
+}
+
+bool takeout_str_dquart(string& str)
+{
+  size_t pos;
+
+  // '"' for start
+  if(string::npos != (pos = str.find_first_of("\""))){
+    str = str.substr(pos + 1);
+
+    // '"' for end
+    if(string::npos == (pos = str.find_last_of("\""))){
+      return false;
+    }
+    str = str.substr(0, pos);
+    if(string::npos != str.find_first_of("\"")){
+      return false;
+    }
+  }
+  return true;
+}
+
 //
 // ex. target="http://......?keyword=value&..."
 //

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -52,6 +52,8 @@ std::string get_date_string(time_t tm);
 std::string get_date_iso8601(time_t tm);
 std::string urlEncode(const std::string &s);
 std::string urlEncode2(const std::string &s);
+std::string urlDecode(const std::string& s);
+bool takeout_str_dquart(std::string& str);
 bool get_keyword_value(std::string& target, const char* keyword, std::string& value);
 
 #endif // S3FS_STRING_UTIL_H_


### PR DESCRIPTION
Supports extended attributes.
s3fs saves extended attributes to object's header "x-amz-meta-xattr" which is formatted as  encoded json.
```
x-amz-meta-xattr: url encoded string({"key":"base64(value)","key":"base64(value)",....})
```
This change solves issues #166 and #169.