### PR TITLE
Override install, so that the make install does not install rename_before_close under /test

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -33,3 +33,4 @@ test_PROGRAMS=rename_before_close
 
 rename_before_close_SOURCES = rename_before_close.c
 
+install:


### PR DESCRIPTION
During the packaging of s3fs-fuse in Arch Linux I noticed that *make install* installs rename_before_close under /test/rename_before_close. This PR just overrides the test Makefile's install, but I am not sure if this is the correct solution (I'm barely am auto tools expert)

