### PR TITLE
Address Coverity errors

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2328,6 +2328,9 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
     // duplicate fd
     if(-1 == (fd2 = dup(fd)) || -1 == fstat(fd2, &st) || 0 != lseek(fd2, 0, SEEK_SET) || NULL == (file = fdopen(fd2, "rb"))){
       DPRN("Could not duplicate file discriptor(errno=%d)", errno);
+      if(-1 != fd2){
+        close(fd2);
+      }
       return -errno;
     }
     b_infile = file;

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -491,7 +491,7 @@ void PageList::Dump(void)
 // FdEntity methods
 //------------------------------------------------
 FdEntity::FdEntity(const char* tpath, const char* cpath)
-          : is_lock_init(false), path(SAFESTRPTR(tpath)), cachepath(SAFESTRPTR(cpath)), fd(-1), file(NULL), is_modify(false)
+          : is_lock_init(false), refcnt(0), path(SAFESTRPTR(tpath)), cachepath(SAFESTRPTR(cpath)), fd(-1), file(NULL), is_modify(false)
 {
   try{
     pthread_mutex_init(&fdent_lock, NULL);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -216,12 +216,12 @@ static int s3fs_removexattr(const char* path, const char* name);
 //-------------------------------------------------------------------
 static bool is_special_name_folder_object(const char* path)
 {
-  string    strpath = path;
-  headers_t header;
-
   if(!path || '\0' == path[0]){
     return false;
   }
+
+  string    strpath = path;
+  headers_t header;
 
   strpath = path;
   if(string::npos == strpath.find("_$folder$", 0)){
@@ -703,7 +703,7 @@ static int put_headers(const char* path, headers_t& meta, bool is_copy)
   // files larger than 5GB must be modified via the multipart interface
   // *** If there is not target object(a case of move command),
   //     get_object_attribute() returns error with initilizing buf.
-  get_object_attribute(path, &buf);
+  (void)get_object_attribute(path, &buf);
 
   if(buf.st_size >= FIVE_GB){
     // multipart

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -589,7 +589,10 @@ int mkdirp(const string& path, mode_t mode)
   stringstream ss(path);
   while (getline(ss, component, '/')) {
     base += "/" + component;
-    mkdir(base.c_str(), mode);
+    int result = mkdir(base.c_str(), mode);
+    if(0 != result){
+      return result;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
Fixed an uninitialized member, misordered NULL check, resource leak,
and unconsumed return value.