### PR TITLE
Annotate constructors as explicit

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -90,7 +90,7 @@ typedef struct xattr_value{
   unsigned char* pvalue;
   size_t         length;
 
-  xattr_value(unsigned char* pval = NULL, size_t len = 0) : pvalue(pval), length(len) {}
+  explicit xattr_value(unsigned char* pval = NULL, size_t len = 0) : pvalue(pval), length(len) {}
   ~xattr_value()
   {
     if(pvalue){

--- a/src/curl.h
+++ b/src/curl.h
@@ -211,7 +211,7 @@ class S3fsCurl
 
   public:
     // constructor/destructor
-    S3fsCurl(bool ahbe = false);
+    explicit S3fsCurl(bool ahbe = false);
     ~S3fsCurl();
 
   private:

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -35,7 +35,7 @@ class CacheFileStat
   public:
     static bool DeleteCacheFileStat(const char* path);
 
-    CacheFileStat(const char* tpath = NULL);
+    explicit CacheFileStat(const char* tpath = NULL);
     ~CacheFileStat();
 
     bool Open(void);
@@ -76,7 +76,7 @@ class PageList
   public:
     static void FreeList(fdpage_list_t& list);
 
-    PageList(off_t size = 0, bool is_init = false);
+    explicit PageList(off_t size = 0, bool is_init = false);
     ~PageList();
 
     off_t Size(void) const;
@@ -112,7 +112,7 @@ class FdEntity
     bool SetAllStatus(bool is_enable);
 
   public:
-    FdEntity(const char* tpath = NULL, const char* cpath = NULL);
+    explicit FdEntity(const char* tpath = NULL, const char* cpath = NULL);
     ~FdEntity();
 
     void Close(void);

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -91,7 +91,7 @@ class AutoLock
     bool             is_locked;
 
   public:
-    AutoLock(pthread_mutex_t* pmutex = NULL);
+    explicit AutoLock(pthread_mutex_t* pmutex = NULL);
     ~AutoLock();
 
     bool Lock(void);


### PR DESCRIPTION
This prevents implicit conversions.