### PR TITLE
Rewrite AutoLock

### DIFF
--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -425,51 +425,14 @@ void free_mvnodes(MVNODE *head)
 //-------------------------------------------------------------------
 // Class AutoLock
 //-------------------------------------------------------------------
-AutoLock::AutoLock(pthread_mutex_t* pmutex) : auto_mutex(pmutex), is_locked(false)
+AutoLock::AutoLock(pthread_mutex_t* pmutex) : auto_mutex(pmutex)
 {
-  Lock();
+  pthread_mutex_lock(auto_mutex);
 }
 
 AutoLock::~AutoLock()
 {
-  Unlock();
-}
-
-bool AutoLock::Lock(void)
-{
-  if(!auto_mutex){
-    return false;
-  }
-  if(is_locked){
-    // already locked
-    return true;
-  }
-  try{
-    pthread_mutex_lock(auto_mutex);
-    is_locked = true;
-  }catch(exception& e){
-    is_locked = false;
-    return false;
-  }
-  return true;
-}
-
-bool AutoLock::Unlock(void)
-{
-  if(!auto_mutex){
-    return false;
-  }
-  if(!is_locked){
-    // already unlocked
-    return true;
-  }
-  try{
-    pthread_mutex_unlock(auto_mutex);
-    is_locked = false;
-  }catch(exception& e){
-    return false;
-  }
-  return true;
+  pthread_mutex_unlock(auto_mutex);
 }
 
 //-------------------------------------------------------------------

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -88,14 +88,10 @@ class AutoLock
 {
   private:
     pthread_mutex_t* auto_mutex;
-    bool             is_locked;
 
   public:
-    explicit AutoLock(pthread_mutex_t* pmutex = NULL);
+    explicit AutoLock(pthread_mutex_t* pmutex);
     ~AutoLock();
-
-    bool Lock(void);
-    bool Unlock(void);
 };
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
Previously `AutoLock::Lock` allowed subsequent callers to proceed
without the lock.  Further `is_locked` was not always protected by
`auto_mutex`.  Finally `AutoLock` eagerly released `auto_mutex` when
recursively unlocking.  s3fs does not need recursive locks so we
rewrite and simplify `AutoLock`.  Partially surfaced by Coverity.