### PR TITLE
Elide duplicate lookups of std::map via iterators

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3472,8 +3472,9 @@ int S3fsMultiCurl::MultiRead(void)
       return -EIO;
     }
     hCurl    = msg->easy_handle;
-    if(cMap_req.end() != cMap_req.find(hCurl)){
-      s3fscurl = cMap_req[hCurl];
+    s3fscurlmap_t::iterator iter;
+    if(cMap_req.end() != (iter = cMap_req.find(hCurl))){
+      s3fscurl = iter->second;
     }else{
       s3fscurl = NULL;
     }
@@ -3691,12 +3692,13 @@ bool AdditionalHeader::Load(const char* file)
       charcntlist.push_back(keylen);
     }
     // set addheader
-    if(addheader.end() == addheader.find(key)){
+    addheader_t::iterator aiter;
+    if(addheader.end() == (aiter = addheader.find(key))){
       headerpair_t hpair;
       hpair[head]    = value;
       addheader[key] = hpair;
     }else{
-      (addheader[key])[head] = value;
+      aiter->second[head] = value;
     }
     // set flag
     if(!is_enable){
@@ -3730,10 +3732,11 @@ bool AdditionalHeader::AddHeader(headers_t& meta, const char* path) const
     }
     // make target suffix(same character count) & find
     string suffix(&path[nPathLen - (*iter)]);
-    if(addheader.end() == addheader.find(suffix)){
+    addheader_t::const_iterator aiter;
+    if(addheader.end() == (aiter = addheader.find(suffix))){
       continue;
     }
-    for(headerpair_t::const_iterator piter = addheader.at(suffix).begin(); piter != addheader.at(suffix).end(); ++piter){
+    for(headerpair_t::const_iterator piter = aiter->second.begin(); piter != aiter->second.end(); ++piter){
       // Adding header
       meta[(*piter).first] = (*piter).second;
     }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2845,7 +2845,8 @@ static int set_xattrs_to_header(headers_t& meta, const char* name, const char* v
   string   strxattrs;
   xattrs_t xattrs;
 
-  if(meta.end() == meta.find("x-amz-meta-xattr")){
+  headers_t::iterator iter;
+  if(meta.end() == (iter = meta.find("x-amz-meta-xattr"))){
     if(XATTR_REPLACE == (flags & XATTR_REPLACE)){
       // there is no xattr header but flags is replace, so failure.
       return -ENOATTR;
@@ -2855,16 +2856,17 @@ static int set_xattrs_to_header(headers_t& meta, const char* name, const char* v
       // found xattr header but flags is only creating, so failure.
       return -EEXIST;
     }
-    strxattrs = meta["x-amz-meta-xattr"];
+    strxattrs = iter->second;
   }
 
   // get map as xattrs_t
   parse_xattrs(strxattrs, xattrs);
 
   // add name(do not care overwrite and empty name/value)
-  if(xattrs.end() != xattrs.find(string(name))){
+  xattrs_t::iterator xiter;
+  if(xattrs.end() != (xiter = xattrs.find(string(name)))){
     // found same head. free value.
-    delete xattrs[string(name)];
+    delete xiter->second;
   }
 
   PXATTRVAL pval = new XATTRVAL;
@@ -3077,11 +3079,12 @@ static int s3fs_listxattr(const char* path, char* list, size_t size)
   }
 
   // get xattrs
-  if(meta.end() == meta.find("x-amz-meta-xattr")){
+  headers_t::iterator iter;
+  if(meta.end() == (iter = meta.find("x-amz-meta-xattr"))){
     // object does not have xattrs
     return 0;
   }
-  string strxattrs = meta["x-amz-meta-xattr"];
+  string strxattrs = iter->second;
 
   parse_xattrs(strxattrs, xattrs);
 
@@ -3182,7 +3185,7 @@ static int s3fs_removexattr(const char* path, const char* name)
   if(xiter->second){
     delete xiter->second;
   }
-  xattrs.erase(strname);
+  xattrs.erase(xiter);
 
   // build new xattr
   if(!xattrs.empty()){


### PR DESCRIPTION
Also remove use of C++11 `std::map::at`.