### PR TITLE
Unlock during early return in TruncateCache

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -347,6 +347,7 @@ bool StatCache::TruncateCache(void)
   pthread_mutex_lock(&StatCache::stat_cache_lock);
 
   if(stat_cache.empty()){
+    pthread_mutex_unlock(&StatCache::stat_cache_lock);
     return true;
   }
 


### PR DESCRIPTION
Found via Coverity.  Regression from
dfa63345edb496986fecd70fca28ff8aba476f2a.