### PR TITLE
Enable integration tests for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,16 @@
 language: cpp
+sudo: required
 dist: trusty
 cache: apt
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq libfuse-dev cppcheck
+ - sudo apt-get install -qq cppcheck libfuse-dev openjdk-7-jdk
 script:
  - ./autogen.sh
  - ./configure
  - make
  - make cppcheck
  - make check -C src
- # Travis granted s3fs access to their upcoming alpha testing stack which may
- # allow us to use FUSE.
- # TODO: Travis changed their infrastructure some time in June 2015 such that
- # this does not work currently
- #- modprobe fuse
- #- make check -C test
+ - modprobe fuse
+ - make check -C test
+ - cat test/test-suite.log


### PR DESCRIPTION
This may allow s3fs to run its integration tests which require FUSE:

http://blog.travis-ci.com/2015-08-19-using-docker-on-travis-ci/