### PR TITLE
s3fs can print version with short commit hash - #228

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@
 ######################################################################
 SUBDIRS=src test doc
 
-EXTRA_DIST=doc
+EXTRA_DIST=doc default_commit_hash
 
 dist-hook:
 	rm -rf `find $(distdir)/doc -type d -name .svn`

--- a/autogen.sh
+++ b/autogen.sh
@@ -19,6 +19,28 @@
 # 
 #  See the file ChangeLog for a revision history. 
 
+echo "--- Make commit hash file -------"
+
+SHORTHASH="unknown"
+type git > /dev/null 2>&1
+if [ $? -eq 0 -a -d .git ]; then
+	RESULT=`git rev-parse --short HEAD`
+	if [ $? -eq 0 ]; then
+		SHORTHASH=${RESULT}
+	fi
+fi
+echo ${SHORTHASH} > default_commit_hash
+
+echo "--- Finished commit hash file ---"
+
+echo "--- Start autotools -------------"
+
 aclocal \
+&& autoheader \
 && automake --add-missing \
 && autoconf
+
+echo "--- Finished autotools ----------"
+
+exit 0
+

--- a/configure.ac
+++ b/configure.ac
@@ -226,7 +226,6 @@ dnl ----------------------------------------------
 dnl check functions
 dnl ----------------------------------------------
 dnl malloc_trim function
-#AC_CHECK_FUNCS(malloc_trim, , )
 AC_CHECK_FUNCS([malloc_trim])
 
 dnl ----------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,7 @@ dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
 AC_INIT(s3fs, 1.79)
+AC_CONFIG_HEADER([config.h])
 
 AC_CANONICAL_SYSTEM
 AM_INIT_AUTOMAKE([foreign])
@@ -30,6 +31,9 @@ AC_PROG_CC
 
 CXXFLAGS="$CXXFLAGS -Wall -D_FILE_OFFSET_BITS=64"
 
+dnl ----------------------------------------------
+dnl For OSX
+dnl ----------------------------------------------
 case "$target" in
    *-darwin* )
       # Do something specific for mac
@@ -219,12 +223,41 @@ AM_CONDITIONAL([USE_GNUTLS_NETTLE], [test "$auth_lib" = nettle])
 AM_CONDITIONAL([USE_SSL_NSS], [test "$auth_lib" = nss])
 
 dnl ----------------------------------------------
-dnl end of ssl library
+dnl check functions
 dnl ----------------------------------------------
-
 dnl malloc_trim function
-AC_CHECK_FUNCS(malloc_trim, , )
+#AC_CHECK_FUNCS(malloc_trim, , )
+AC_CHECK_FUNCS([malloc_trim])
 
+dnl ----------------------------------------------
+dnl output files
+dnl ----------------------------------------------
 AC_CONFIG_FILES(Makefile src/Makefile test/Makefile doc/Makefile)
+
+dnl ----------------------------------------------
+dnl short commit hash
+dnl ----------------------------------------------
+AC_CHECK_PROG([GITCMD], [git —version], [yes], [no])
+AC_CHECK_FILE([.git], [DOTGITDIR=yes], [DOTGITDIR=no])
+
+AC_MSG_CHECKING([github short commit hash])
+if test “x${GITCMD}” = “xyes” -a “x${DOTGITDIR}” = “xyes”; then
+    GITCOMMITHASH=`git rev-parse --short HEAD`
+elif test -f default_commit_hash; then
+    GITCOMMITHASH=`cat default_commit_hash`
+else
+    GITCOMMITHASH="unknown"
+fi
+AC_MSG_RESULT([${GITCOMMITHASH}])
+
+AC_DEFINE_UNQUOTED([COMMIT_HASH_VAL], ["${GITCOMMITHASH}"], [short commit hash value on github])
+
+dnl ----------------------------------------------
+dnl put
+dnl ----------------------------------------------
 AC_OUTPUT
+
+dnl ----------------------------------------------
+dnl end configuration
+dnl ----------------------------------------------
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,6 +39,6 @@ s3fs_LDADD = $(DEPS_LIBS)
 
 noinst_PROGRAMS = test_string_util
 
-test_string_util_SOURCES = string_util.cpp test_string_util.cpp
+test_string_util_SOURCES = string_util.cpp test_string_util.cpp test_util.h
 
 TESTS = test_string_util

--- a/src/common.h
+++ b/src/common.h
@@ -17,8 +17,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+
 #ifndef S3FS_COMMON_H_
 #define S3FS_COMMON_H_
+
+#include "../config.h"
 
 //
 // Macro

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3231,8 +3231,8 @@ static int s3fs_removexattr(const char* path, const char* name)
 
 static void* s3fs_init(struct fuse_conn_info* conn)
 {
-  FPRN("init");
-  LOWSYSLOGPRINT(LOG_ERR, "init v%s (%s)", VERSION, s3fs_crypt_lib_name());
+  FPRN("init v%s(commit:%s) with %s", VERSION, COMMIT_HASH_VAL, s3fs_crypt_lib_name());
+  LOWSYSLOGPRINT(LOG_ERR, "init v%s(commit:%s) with %s", VERSION, COMMIT_HASH_VAL, s3fs_crypt_lib_name());
 
   // ssl init
   if(!s3fs_init_global_ssl()){

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -1039,12 +1039,12 @@ void show_help (void)
 void show_version(void)
 {
   printf(
-  "Amazon Simple Storage Service File System V%s with %s\n"
+  "Amazon Simple Storage Service File System V%s(commit:%s) with %s\n"
   "Copyright (C) 2010 Randy Rizun <rrizun@gmail.com>\n"
   "License GPL2: GNU GPL version 2 <http://gnu.org/licenses/gpl.html>\n"
   "This is free software: you are free to change and redistribute it.\n"
   "There is NO WARRANTY, to the extent permitted by law.\n",
-  VERSION, s3fs_crypt_lib_name());
+  VERSION, COMMIT_HASH_VAL, s3fs_crypt_lib_name());
   return;
 }
 


### PR DESCRIPTION
Added commit short hash in version string.
autogen.sh puts default_commit_hash in source root directory, and configure.ac makes config.h with it.
Because Makefile which is made by s3fs configure can build tar ball including source codes, it does not have .git directory.
But we should print commit hash base of source files which is made, when developer who has only tar ball builds binary.
So default_commit_hash file is included in tar ball, it can be printed.