### PR TITLE
Skip xattr tests if utilities are missing

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -323,6 +323,9 @@ function test_special_characters {
 }
 
 function test_extended_attributes {
+    command -v setfattr >/dev/null 2>&1 || \
+        { echo "Skipping extended attribute tests" ; return; }
+
     echo "Testing extended attributes ..."
 
     rm -f $TEST_TEXT_FILE


### PR DESCRIPTION
The `attr` package isn't installed by default on many distributions. 