### PR TITLE
Update README.md: Bugfix password file permissions errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Enter your S3 identity and credential in a file `/path/to/passwd`:
 echo MYIDENTITY:MYCREDENTIAL > /path/to/passwd
 ```
 
+Make sure the file has proper permissions (if you get 'permissions' error when mounting) `/path/to/passwd`:
+
+```
+chmod 600 /path/to/passwd
+```
+
 Run s3fs with an existing bucket `mybucket` and directory `/path/to/mountpoint`:
 
 ```


### PR DESCRIPTION
received "should not have others permissions" when mounting
did chmod 640 and received "should not have group permissions"
used chmod 600 after creating the password file and had no problems