### PR TITLE
Update README.md to better explain mount upon boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you encounter any errors, enable debug output:
 s3fs mybucket /path/to/mountpoint -o passwd_file=/path/to/passwd -d -d -f -o f2 -o curldbg
 ```
 
-You can also automatically mount via fstab:
+You can also mount on boot by entering the following line to `/etc/fstab`:
 
 ```
 s3fs#mybucket /path/to/mountpoint fuse allow_other 0 0


### PR DESCRIPTION
As a novice Linux user, I didn't know I had to add a line into /etc/fstab for automatic mount upon boot. It took me some minutes to research and notice the right process (at first, I even entered s3fs#mybucket into the command line).

This change will (hopefully) save time to unseasoned users.