### PR TITLE
Added the _netdev option to the fstab example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ s3fs mybucket /path/to/mountpoint -o passwd_file=/path/to/passwd -d -d -f -o f2 
 You can also mount on boot by entering the following line to `/etc/fstab`:
 
 ```
-s3fs#mybucket /path/to/mountpoint fuse allow_other 0 0
+s3fs#mybucket /path/to/mountpoint fuse _netdev,allow_other 0 0
 ```
 
 Limitations


### PR DESCRIPTION
Although the network device option (_netdev) may not work everywhere, the option likely does no harm on systems where it's not supported. By adding this option to the example, it will inform users of the necessity for post-network activation and how that might be accomplished.