### PR TITLE
Use 127.0.0.1 not localhost in s3proxy wait loop

### DIFF
--- a/test/small-integration-test.sh
+++ b/test/small-integration-test.sh
@@ -60,7 +60,7 @@ then
     # wait for S3Proxy to start
     for i in $(seq 30);
     do
-        if exec 3<>"/dev/tcp/localhost/8080";
+        if exec 3<>"/dev/tcp/127.0.0.1/8080";
         then
             exec 3<&-  # Close for read
             exec 3>&-  # Close for write


### PR DESCRIPTION
localhost doesn't always resolve to 127.0.0.1 which can bash loop that waits for s3proxy to start will fail.