### PR TITLE
Changed and cleaned the logic for debug message.

### DIFF
--- a/doc/man/s3fs.1
+++ b/doc/man/s3fs.1
@@ -201,6 +201,14 @@ If this option is specified with nocopapi, the s3fs ignores it.
 .TP
 \fB\-o\fR use_path_request_style (use legacy API calling style)
 Enble compatibility with S3-like APIs which do not support the virtual-host request style, by using the older path request style.
+.TP
+\fB\-o\fR dbglevel (default="crit")
+Set the debug message level. set value as crit(critical), err(error), warn(warning), info(information) to debug level. default debug level is critical.
+If s3fs run with "-d" option, the debug level is set information.
+When s3fs catch the signal SIGUSR2, the debug level is bumpup.
+.TP
+\fB\-o\fR curldbg - put curl debug message
+Put the debug message from libcurl when this option is specified.
 .SH FUSE/MOUNT OPTIONS
 .TP
 Most of the generic mount options described in 'man mount' are supported (ro, rw, suid, nosuid, dev, nodev, exec, noexec, atime, noatime, sync async, dirsync).  Filesystems are mounted with '\-onodev,nosuid' by default, which can only be overridden by a privileged user.

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -164,11 +164,11 @@ bool StatCache::GetStat(string& key, struct stat* pst, headers_t* meta, bool ove
       }
       if(is_delete_cache){
         // not hit by different ETag
-        DPRNNN("stat cache not hit by ETag[path=%s][time=%jd][hit count=%lu][ETag(%s)!=(%s)]",
+        S3FS_PRN_DBG("stat cache not hit by ETag[path=%s][time=%jd][hit count=%lu][ETag(%s)!=(%s)]",
           strpath.c_str(), (intmax_t)(ent->cache_date), ent->hit_count, petag ? petag : "null", ent->meta["ETag"].c_str());
       }else{
         // hit 
-        DPRNNN("stat cache hit [path=%s][time=%jd][hit count=%lu]", strpath.c_str(), (intmax_t)(ent->cache_date), ent->hit_count);
+        S3FS_PRN_DBG("stat cache hit [path=%s][time=%jd][hit count=%lu]", strpath.c_str(), (intmax_t)(ent->cache_date), ent->hit_count);
 
         if(pst!= NULL){
           *pst= ent->stbuf;
@@ -245,7 +245,7 @@ bool StatCache::AddStat(std::string& key, headers_t& meta, bool forcedir)
   if(CacheSize< 1){
     return true;
   }
-  DPRNNN("add stat cache entry[path=%s]", key.c_str());
+  S3FS_PRN_INFO3("add stat cache entry[path=%s]", key.c_str());
 
   pthread_mutex_lock(&StatCache::stat_cache_lock);
 
@@ -307,7 +307,7 @@ bool StatCache::AddNoObjectCache(string& key)
   if(CacheSize < 1){
     return true;
   }
-  DPRNNN("add no object cache entry[path=%s]", key.c_str());
+  S3FS_PRN_INFO3("add no object cache entry[path=%s]", key.c_str());
 
   pthread_mutex_lock(&StatCache::stat_cache_lock);
 
@@ -364,7 +364,7 @@ bool StatCache::TruncateCache(void)
     }
   }
   if(stat_cache.end() != iter_to_delete){
-    DPRNNN("truncate stat cache[path=%s]", (*iter_to_delete).first.c_str());
+    S3FS_PRN_DBG("truncate stat cache[path=%s]", (*iter_to_delete).first.c_str());
     if((*iter_to_delete).second){
       delete (*iter_to_delete).second;
     }
@@ -382,7 +382,7 @@ bool StatCache::DelStat(const char* key)
   if(!key){
     return false;
   }
-  DPRNNN("delete stat cache entry[path=%s]", key);
+  S3FS_PRN_INFO3("delete stat cache entry[path=%s]", key);
 
   pthread_mutex_lock(&StatCache::stat_cache_lock);
 

--- a/src/common.h
+++ b/src/common.h
@@ -28,56 +28,80 @@
 //
 #define SAFESTRPTR(strptr) (strptr ? strptr : "")
 
-// for debug
-#define	FPRINT_NEST_SPACE_0  ""
-#define	FPRINT_NEST_SPACE_1  "  "
-#define	FPRINT_NEST_SPACE_2  "    "
-#define	FPRINT_NEST_CHECK(NEST) \
-        (0 == NEST ? FPRINT_NEST_SPACE_0 : 1 == NEST ? FPRINT_NEST_SPACE_1 : FPRINT_NEST_SPACE_2)
+//
+// Debug level
+//
+enum s3fs_log_level{
+ S3FS_LOG_CRIT = 0,          // LOG_CRIT
+ S3FS_LOG_ERR  = 1,          // LOG_ERR
+ S3FS_LOG_WARN = 3,          // LOG_WARNING
+ S3FS_LOG_INFO = 7,          // LOG_INFO
+ S3FS_LOG_DBG  = 15          // LOG_DEBUG
+};
 
-#define LOWFPRINT(NEST, ...) \
-        printf("%s%s(%d): ", FPRINT_NEST_CHECK(NEST), __func__, __LINE__); \
-        printf(__VA_ARGS__); \
-        printf("\n"); \
+//
+// Debug macros
+//
+#define IS_S3FS_LOG_CRIT()   (S3FS_LOG_CRIT == debug_level)
+#define IS_S3FS_LOG_ERR()    (S3FS_LOG_ERR  == (debug_level & S3FS_LOG_DBG))
+#define IS_S3FS_LOG_WARN()   (S3FS_LOG_WARN == (debug_level & S3FS_LOG_DBG))
+#define IS_S3FS_LOG_INFO()   (S3FS_LOG_INFO == (debug_level & S3FS_LOG_DBG))
+#define IS_S3FS_LOG_DBG()    (S3FS_LOG_DBG  == (debug_level & S3FS_LOG_DBG))
 
-#define FPRINT(NEST, ...) \
-        if(foreground){ \
-          LOWFPRINT(NEST, __VA_ARGS__); \
-        }
+#define S3FS_LOG_LEVEL_TO_SYSLOG(level) \
+        ( S3FS_LOG_DBG  == (level & S3FS_LOG_DBG) ? LOG_DEBUG   : \
+          S3FS_LOG_INFO == (level & S3FS_LOG_DBG) ? LOG_INFO    : \
+          S3FS_LOG_WARN == (level & S3FS_LOG_DBG) ? LOG_WARNING : \
+          S3FS_LOG_ERR  == (level & S3FS_LOG_DBG) ? LOG_ERR     : LOG_CRIT )
 
-#define FPRINT2(NEST, ...) \
-        if(foreground2){ \
-          LOWFPRINT(NEST, __VA_ARGS__); \
-        }
+#define S3FS_LOG_LEVEL_STRING(level) \
+        ( S3FS_LOG_DBG  == (level & S3FS_LOG_DBG) ? "[DBG] " : \
+          S3FS_LOG_INFO == (level & S3FS_LOG_DBG) ? "[INF] " : \
+          S3FS_LOG_WARN == (level & S3FS_LOG_DBG) ? "[WAN] " : \
+          S3FS_LOG_ERR  == (level & S3FS_LOG_DBG) ? "[ERR] " : "[CRT] " )
 
-#define LOWSYSLOGPRINT(LEVEL, ...) \
-        syslog(LEVEL, __VA_ARGS__);
+#define S3FS_LOG_NEST_MAX    4
+#define S3FS_LOG_NEST(nest)  (nest < S3FS_LOG_NEST_MAX ? s3fs_log_nest[nest] : s3fs_log_nest[S3FS_LOG_NEST_MAX - 1])
 
-#define SYSLOGPRINT(LEVEL, ...) \
-        if(LEVEL <= LOG_CRIT || debug){ \
-          LOWSYSLOGPRINT(LEVEL, __VA_ARGS__); \
-        }
+#define S3FS_LOW_LOGPRN(level, fmt, ...) \
+       if(S3FS_LOG_CRIT == level || (S3FS_LOG_CRIT != debug_level && level == (debug_level & level))){ \
+         if(foreground){ \
+           fprintf(stdout, "%s%s(%d): " fmt "%s\n", S3FS_LOG_LEVEL_STRING(level), __func__, __LINE__, __VA_ARGS__); \
+         }else{ \
+           syslog(S3FS_LOG_LEVEL_TO_SYSLOG(level), "%s(%d): " fmt "%s", __func__, __LINE__, __VA_ARGS__); \
+         } \
+       }
 
-#define DPRINT(LEVEL, NEST, ...) \
-        FPRINT(NEST, __VA_ARGS__); \
-        SYSLOGPRINT(LEVEL, __VA_ARGS__);
+#define S3FS_LOW_LOGPRN2(level, nest, fmt, ...) \
+       if(S3FS_LOG_CRIT == level || (S3FS_LOG_CRIT != debug_level && level == (debug_level & level))){ \
+         if(foreground){ \
+           fprintf(stdout, "%s%s" fmt "%s\n", S3FS_LOG_LEVEL_STRING(level), S3FS_LOG_NEST(nest), __VA_ARGS__); \
+         }else{ \
+           syslog(S3FS_LOG_LEVEL_TO_SYSLOG(level), "%s" fmt "%s", S3FS_LOG_NEST(nest), __VA_ARGS__); \
+         } \
+       }
 
-#define DPRINT2(LEVEL, ...) \
-        FPRINT2(2, __VA_ARGS__); \
-        SYSLOGPRINT(LEVEL, __VA_ARGS__);
+#define S3FS_LOW_LOGPRN_EXIT(fmt, ...) \
+       if(foreground){ \
+         fprintf(stderr, "s3fs: " fmt "%s\n", __VA_ARGS__); \
+       }else{ \
+         syslog(S3FS_LOG_CRIT, "s3fs: " fmt "%s", __VA_ARGS__); \
+       }
 
-// print debug message
-#define FPRN(...)      FPRINT(0, __VA_ARGS__)
-#define FPRNN(...)     FPRINT(1, __VA_ARGS__)
-#define FPRNNN(...)    FPRINT(2, __VA_ARGS__)
-#define FPRNINFO(...)  FPRINT2(2, __VA_ARGS__)
-
-// print debug message with putting syslog
-#define DPRNCRIT(...)  DPRINT(LOG_CRIT, 0, __VA_ARGS__)
-#define DPRN(...)      DPRINT(LOG_ERR, 0, __VA_ARGS__)
-#define DPRNN(...)     DPRINT(LOG_DEBUG, 1, __VA_ARGS__)
-#define DPRNNN(...)    DPRINT(LOG_DEBUG, 2, __VA_ARGS__)
-#define DPRNINFO(...)  DPRINT2(LOG_INFO, __VA_ARGS__)
+// [NOTE]
+// small trick for VA_ARGS
+//
+#define S3FS_PRN_EXIT(fmt, ...)   S3FS_LOW_LOGPRN_EXIT(fmt, ##__VA_ARGS__, "")
+#define S3FS_PRN_CRIT(fmt, ...)   S3FS_LOW_LOGPRN(S3FS_LOG_CRIT, fmt, ##__VA_ARGS__, "")
+#define S3FS_PRN_ERR(fmt, ...)    S3FS_LOW_LOGPRN(S3FS_LOG_ERR,  fmt, ##__VA_ARGS__, "")
+#define S3FS_PRN_WARN(fmt, ...)   S3FS_LOW_LOGPRN(S3FS_LOG_WARN, fmt, ##__VA_ARGS__, "")
+#define S3FS_PRN_DBG(fmt, ...)    S3FS_LOW_LOGPRN(S3FS_LOG_DBG,  fmt, ##__VA_ARGS__, "")
+#define S3FS_PRN_INFO(fmt, ...)   S3FS_LOW_LOGPRN2(S3FS_LOG_INFO, 0, fmt, ##__VA_ARGS__, "")
+#define S3FS_PRN_INFO0(fmt, ...)  S3FS_LOG_INFO(fmt, __VA_ARGS__)
+#define S3FS_PRN_INFO1(fmt, ...)  S3FS_LOW_LOGPRN2(S3FS_LOG_INFO, 1, fmt, ##__VA_ARGS__, "")
+#define S3FS_PRN_INFO2(fmt, ...)  S3FS_LOW_LOGPRN2(S3FS_LOG_INFO, 2, fmt, ##__VA_ARGS__, "")
+#define S3FS_PRN_INFO3(fmt, ...)  S3FS_LOW_LOGPRN2(S3FS_LOG_INFO, 3, fmt, ##__VA_ARGS__, "")
+#define S3FS_PRN_CURL(fmt, ...)   S3FS_LOW_LOGPRN2(S3FS_LOG_CRIT, 0, fmt, ##__VA_ARGS__, "")
 
 //
 // Typedef
@@ -107,17 +131,17 @@ typedef std::map<std::string, PXATTRVAL> xattrs_t;
 //
 // Global valiables
 //
-extern bool debug;
-extern bool foreground;
-extern bool foreground2;
-extern bool nomultipart;
-extern bool pathrequeststyle;
-extern std::string program_name;
-extern std::string service_path;
-extern std::string host;
-extern std::string bucket;
-extern std::string mount_prefix;
-extern std::string endpoint;
+extern bool           foreground;
+extern bool           nomultipart;
+extern bool           pathrequeststyle;
+extern std::string    program_name;
+extern std::string    service_path;
+extern std::string    host;
+extern std::string    bucket;
+extern std::string    mount_prefix;
+extern std::string    endpoint;
+extern s3fs_log_level debug_level;
+extern const char*    s3fs_log_nest[S3FS_LOG_NEST_MAX];
 
 #endif // S3FS_COMMON_H_
 

--- a/src/curl.h
+++ b/src/curl.h
@@ -248,6 +248,8 @@ class S3fsCurl
     static bool SetIAMCredentials(const char* response);
     static bool PushbackSseKeys(std::string& onekey);
 
+    static int CurlDebugFunc(CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr);
+
     // methods
     bool ResetHandle(void);
     bool RemakeHandle(void);

--- a/src/gnutls_auth.cpp
+++ b/src/gnutls_auth.cpp
@@ -217,7 +217,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
       break;
     }else if(-1 == bytes){
       // error
-      DPRNNN("file read error(%d)", errno);
+      S3FS_PRN_ERR("file read error(%d)", errno);
       return NULL;
     }
     md5_update(&ctx_md5, bytes, buf);
@@ -261,7 +261,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
 
   memset(buf, 0, 512);
   if(GPG_ERR_NO_ERROR != (err = gcry_md_open(&ctx_md5, GCRY_MD_MD5, 0))){
-    DPRNN("MD5 context creation failure: %s/%s", gcry_strsource(err), gcry_strerror(err));
+    S3FS_PRN_ERR("MD5 context creation failure: %s/%s", gcry_strsource(err), gcry_strerror(err));
     return NULL;
   }
 
@@ -273,7 +273,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
       break;
     }else if(-1 == bytes){
       // error
-      DPRNNN("file read error(%d)", errno);
+      S3FS_PRN_ERR("file read error(%d)", errno);
       return NULL;
     }
     gcry_md_write(ctx_md5, buf, bytes);
@@ -344,7 +344,7 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
       break;
     }else if(-1 == bytes){
       // error
-      DPRNNN("file read error(%d)", errno);
+      S3FS_PRN_ERR("file read error(%d)", errno);
       return NULL;
     }
     sha256_update(&ctx_sha256, bytes, buf);
@@ -375,7 +375,7 @@ bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char*
   gcry_md_hd_t   ctx_sha256;
   gcry_error_t   err;
   if(GPG_ERR_NO_ERROR != (err = gcry_md_open(&ctx_sha256, GCRY_MD_SHA256, 0))){
-    DPRNN("SHA256 context creation failure: %s/%s", gcry_strsource(err), gcry_strerror(err));
+    S3FS_PRN_ERR("SHA256 context creation failure: %s/%s", gcry_strsource(err), gcry_strerror(err));
     free(*digest);
     return false;
   }
@@ -409,7 +409,7 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
 
   memset(buf, 0, 512);
   if(GPG_ERR_NO_ERROR != (err = gcry_md_open(&ctx_sha256, GCRY_MD_SHA256, 0))){
-    DPRNN("SHA256 context creation failure: %s/%s", gcry_strsource(err), gcry_strerror(err));
+    S3FS_PRN_ERR("SHA256 context creation failure: %s/%s", gcry_strsource(err), gcry_strerror(err));
     return NULL;
   }
 
@@ -421,7 +421,7 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
       break;
     }else if(-1 == bytes){
       // error
-      DPRNNN("file read error(%d)", errno);
+      S3FS_PRN_ERR("file read error(%d)", errno);
       return NULL;
     }
     gcry_md_write(ctx_sha256, buf, bytes);

--- a/src/nss_auth.cpp
+++ b/src/nss_auth.cpp
@@ -182,7 +182,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
       break;
     }else if(-1 == bytes){
       // error
-      DPRNNN("file read error(%d)", errno);
+      S3FS_PRN_ERR("file read error(%d)", errno);
       return NULL;
     }
     PK11_DigestOp(md5ctx, buf, bytes);
@@ -262,7 +262,7 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
       break;
     }else if(-1 == bytes){
       // error
-      DPRNNN("file read error(%d)", errno);
+      S3FS_PRN_ERR("file read error(%d)", errno);
       PK11_DestroyContext(sha256ctx, PR_TRUE);
       return NULL;
     }

--- a/src/openssl_auth.cpp
+++ b/src/openssl_auth.cpp
@@ -105,7 +105,7 @@ static struct CRYPTO_dynlock_value* s3fs_dyn_crypt_mutex(const char* file, int l
   struct CRYPTO_dynlock_value* dyndata;
 
   if(NULL == (dyndata = static_cast<struct CRYPTO_dynlock_value*>(malloc(sizeof(struct CRYPTO_dynlock_value))))){
-    DPRNCRIT("Could not allocate memory for CRYPTO_dynlock_value");
+    S3FS_PRN_CRIT("Could not allocate memory for CRYPTO_dynlock_value");
     return NULL;
   }
   pthread_mutex_init(&(dyndata->dyn_mutex), NULL);
@@ -134,14 +134,14 @@ static void s3fs_destroy_dyn_crypt_mutex(struct CRYPTO_dynlock_value* dyndata, c
 bool s3fs_init_crypt_mutex(void)
 {
   if(s3fs_crypt_mutex){
-    FPRNNN("s3fs_crypt_mutex is not NULL, destroy it.");
+    S3FS_PRN_DBG("s3fs_crypt_mutex is not NULL, destroy it.");
     if(!s3fs_destroy_crypt_mutex()){
-      DPRN("Failed to s3fs_crypt_mutex");
+      S3FS_PRN_ERR("Failed to s3fs_crypt_mutex");
       return false;
     }
   }
   if(NULL == (s3fs_crypt_mutex = static_cast<pthread_mutex_t*>(malloc(CRYPTO_num_locks() * sizeof(pthread_mutex_t))))){
-    DPRNCRIT("Could not allocate memory for s3fs_crypt_mutex");
+    S3FS_PRN_CRIT("Could not allocate memory for s3fs_crypt_mutex");
     return false;
   }
   for(int cnt = 0; cnt < CRYPTO_num_locks(); cnt++){
@@ -250,7 +250,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
       break;
     }else if(-1 == bytes){
       // error
-      DPRNNN("file read error(%d)", errno);
+      S3FS_PRN_ERR("file read error(%d)", errno);
       return NULL;
     }
     MD5_Update(&md5ctx, buf, bytes);
@@ -328,7 +328,7 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
       break;
     }else if(-1 == bytes){
       // error
-      DPRNNN("file read error(%d)", errno);
+      S3FS_PRN_ERR("file read error(%d)", errno);
       EVP_MD_CTX_destroy(sha256ctx);
       return NULL;
     }


### PR DESCRIPTION
Added new option "dbglevel" for debug message level.
Older version has only on/off for message, thus new one has critical/error/warning/info/debug mode.
The default level is critical.
And added signal handler for SIGUSR2, bumpup the debug level when s3fs catches this signal.

About message puts:
Older version could not put curl debug message and forground's message to syslog.
But new s3fs is able to put those.
If s3fs is run with "-f" option(means forground), all messages puts stdout and no message puts syslog.
The other without "-f"(means background), all messages puts syslog.
Then we can debug s3fs it runs background.(if you need to changeb debug level after starting s3fs, you can send SIGUSR2 to s3fs).

Then I hope this change helps us for debugging s3fs on background and at booting( like issue #273 ).