### PR TITLE
Fixed a bug about mtime - #299

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -802,17 +802,6 @@ int FdEntity::Open(headers_t* pmeta, ssize_t size, time_t time)
     }
   }
 
-  // set mtime
-  if(-1 != time){
-    if(0 != SetMtime(time)){
-      S3FS_PRN_ERR("failed to set mtime. errno(%d)", errno);
-      fclose(pfile);
-      pfile = NULL;
-      fd    = -1;
-      return (0 == errno ? -EIO : -errno);
-    }
-  }
-
   // reset cache stat file
   if(need_save_csf){
     CacheFileStat cfstat(path.c_str());
@@ -832,6 +821,17 @@ int FdEntity::Open(headers_t* pmeta, ssize_t size, time_t time)
   }else{
     orgmeta.clear();
     size_orgmeta = 0;
+  }
+
+  // set mtime(set "x-amz-meta-mtime" in orgmeta)
+  if(-1 != time){
+    if(0 != SetMtime(time)){
+      S3FS_PRN_ERR("failed to set mtime. errno(%d)", errno);
+      fclose(pfile);
+      pfile = NULL;
+      fd    = -1;
+      return (0 == errno ? -EIO : -errno);
+    }
   }
 
   return 0;
@@ -1846,19 +1846,19 @@ FdEntity* FdManager::Open(const char* path, headers_t* pmeta, ssize_t size, time
   return ent;
 }
 
-FdEntity* FdManager::ExistOpen(const char* path, int existfd)
+FdEntity* FdManager::ExistOpen(const char* path, int existfd, bool ignore_existfd)
 {
-  S3FS_PRN_DBG("[path=%s][fd=%d]", SAFESTRPTR(path), existfd);
+  S3FS_PRN_DBG("[path=%s][fd=%d][ignore_existfd=%s]", SAFESTRPTR(path), existfd, ignore_existfd ? "true" : "false");
 
   // search by real path
   FdEntity* ent = Open(path, NULL, -1, -1, false, false);
 
-  if(!ent && -1 != existfd){
+  if(!ent && (ignore_existfd || (-1 != existfd))){
     // search from all fdentity because of not using cache.
     AutoLock auto_lock(&FdManager::fd_manager_lock);
 
     for(fdent_map_t::iterator iter = fent.begin(); iter != fent.end(); ++iter){
-      if((*iter).second && (*iter).second->GetFd() == existfd && (*iter).second->IsOpen()){
+      if((*iter).second && (*iter).second->IsOpen() && (ignore_existfd || ((*iter).second->GetFd() == existfd))){
         // found opend fd in map
         if(0 == strcmp((*iter).second->GetPath(), path)){
           ent = (*iter).second;

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -212,7 +212,7 @@ class FdManager
 
     FdEntity* GetFdEntity(const char* path, int existfd = -1);
     FdEntity* Open(const char* path, headers_t* pmeta = NULL, ssize_t size = -1, time_t time = -1, bool force_tmpfile = false, bool is_create = true);
-    FdEntity* ExistOpen(const char* path, int existfd = -1);
+    FdEntity* ExistOpen(const char* path, int existfd = -1, bool ignore_existfd = false);
     void Rename(const std::string &from, const std::string &to);
     bool Close(FdEntity* ent);
     bool ChangeEntityToTempPath(FdEntity* ent, const char* path);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -774,7 +774,7 @@ static int put_headers(const char* path, headers_t& meta, bool is_copy)
   }
 
   FdEntity* ent = NULL;
-  if(NULL == (ent = FdManager::get()->ExistOpen(path))){
+  if(NULL == (ent = FdManager::get()->ExistOpen(path, -1, !(FdManager::get()->IsCacheDir())))){
     // no opened fd
     if(FdManager::get()->IsCacheDir()){
       // create cache file if be needed


### PR DESCRIPTION
s3fs had a bug(#299) that was s3fs could not set mtime to the file when the file was created with specifying mtime.
The bug occurred only if you started s3fs without cache files(not specified use_case option).

FUSE calls create/utimens/flush interface for s3fs when the file is created with mtime.
But utimens interface does not have file descriptor.
s3fs should search a fd from file path which is opened local file(cache).
But s3fs did not search it when s3fs was run without use_cache option.
This patch fixed it.

Be careful following:
If a file is created with mtime by some clients at same time on s3fs without use_cache, probably mtime for the file will be undefined.
This result is the same as the file content is undefined, s3fs is not guaranteed.