### PR TITLE
Fix pthread portability problem

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -619,13 +619,7 @@ FdEntity::FdEntity(const char* tpath, const char* cpath)
   try{
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
-#ifdef PTHREAD_MUTEX_RECURSIVE_NP
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP);   // recursive mutex
-#elif PTHREAD_MUTEX_RECURSIVE
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);   // recursive mutex
-#else
-#error "Either PTHREAD_MUTEX_RECURSIVE_NP or PTHREAD_MUTEX_RECURSIVE must be defined."
-#endif
     pthread_mutex_init(&fdent_lock, &attr);
     is_lock_init = true;
   }catch(exception& e){

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -619,7 +619,13 @@ FdEntity::FdEntity(const char* tpath, const char* cpath)
   try{
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
+#ifdef PTHREAD_MUTEX_RECURSIVE_NP
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP);   // recursive mutex
+#elif PTHREAD_MUTEX_RECURSIVE
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);   // recursive mutex
+#else
+#error "Either PTHREAD_MUTEX_RECURSIVE_NP or PTHREAD_MUTEX_RECURSIVE must be defined."
+#endif
     pthread_mutex_init(&fdent_lock, &attr);
     is_lock_init = true;
   }catch(exception& e){


### PR DESCRIPTION
I compiled s3fs-fuse on my Mac and got the following errors:

    fdcache.cpp:622:38: error: use of undeclared identifier 'PTHREAD_MUTEX_RECURSIVE_NP'
        pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP);   // recursive mutex
                                         ^

This pull request fixes this problem.