### PR TITLE
Clean up mount point on errors in s3fs_init()

### DIFF
--- a/test/small-integration-test.sh
+++ b/test/small-integration-test.sh
@@ -49,7 +49,7 @@ function exit_handler {
     then
         kill $S3PROXY_PID
     fi
-    retry 30 fusermount -u $TEST_BUCKET_MOUNT_POINT_1
+    retry 30 grep $TEST_BUCKET_MOUNT_POINT_1 /proc/mounts && fusermount -u $TEST_BUCKET_MOUNT_POINT_1
 }
 trap exit_handler EXIT
 


### PR DESCRIPTION
There are error conditions that don't get caught until s3fs_init() runs.  Currently, s3fs_init calls exit().  This leaves the mount point behind and results in "Transport endpoint not connected" errors.  

With this change, s3fs_init()  will exit the fuse loop cleanly.   This allows libfuse to close its session with the kernel module.   The mount point will be unmounted.



