### PR TITLE
320: delete stat cache entry in s3fs_fsync so st_size is refreshed

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2169,6 +2169,9 @@ static int s3fs_fsync(const char* path, int datasync, struct fuse_file_info* fi)
   }
   S3FS_MALLOCTRIM(0);
 
+  // Issue 320: Delete stat cache entry because st_size may have changed.
+  StatCache::getStatCacheData()->DelStat(path);
+
   return result;
 }
 


### PR DESCRIPTION
@ggtakec 

My proposed solution to #320 is for `s3fs_fsync` to delete the stat cache entry. Then, any subsequent operations will need to refresh the stat cache with a HEAD request. This will negatively impact performance in that it will cause more round trips. However, this is the simplest way to make `s3fs_fsync` correct. Someone who understands more about how the stat cache works could try to surgically update the stat cache to reflect the new file size in `s3fs_fsync`.

With this change, the test program from the #320 description outputs

```
/vagrant/testmount/testfile
stat size 12
```