### PR TITLE
Remove stat file cache dir if specified del_cache - #337

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -124,6 +124,23 @@ bool CacheFileStat::DeleteCacheFileStat(const char* path)
   return true;
 }
 
+// [NOTE]
+// If remove stat file directory, it should do before removing
+// file cache directory.
+//
+bool CacheFileStat::DeleteCacheFileStatDirectory(void)
+{
+  string top_path = FdManager::GetCacheDir();
+
+  if(top_path.empty() || bucket.empty()){
+    return true;
+  }
+  top_path       += "/.";
+  top_path       += bucket;
+  top_path       += ".stat";
+  return delete_files_in_dir(top_path.c_str(), true);
+}
+
 //------------------------------------------------
 // CacheFileStat methods
 //------------------------------------------------

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -38,6 +38,7 @@ class CacheFileStat
   public:
     static bool DeleteCacheFileStat(const char* path);
     static bool CheckCacheFileStatTopDir(void);
+    static bool DeleteCacheFileStatDirectory(void);
 
     explicit CacheFileStat(const char* tpath = NULL);
     ~CacheFileStat();

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3315,6 +3315,11 @@ static void* s3fs_init(struct fuse_conn_info* conn)
 {
   S3FS_PRN_CRIT("init v%s(commit:%s) with %s", VERSION, COMMIT_HASH_VAL, s3fs_crypt_lib_name());
 
+  // cache(remove cache dirs at first)
+  if(is_remove_cache && (!CacheFileStat::DeleteCacheFileStatDirectory() || !FdManager::DeleteCacheDirectory())){
+    S3FS_PRN_DBG("Could not inilialize cache directory.");
+  }
+
   // ssl init
   if(!s3fs_init_global_ssl()){
     S3FS_PRN_CRIT("could not initialize for ssl libraries.");
@@ -3350,10 +3355,7 @@ static void* s3fs_init(struct fuse_conn_info* conn)
      conn->want |= FUSE_CAP_ATOMIC_O_TRUNC;
   }
   #endif
-  // cache
-  if(is_remove_cache && !FdManager::DeleteCacheDirectory()){
-    S3FS_PRN_DBG("Could not inilialize cache directory.");
-  }
+
   return NULL;
 }
 
@@ -3365,8 +3367,8 @@ static void s3fs_destroy(void*)
   if(!S3fsCurl::DestroyS3fsCurl()){
     S3FS_PRN_WARN("Could not release curl library.");
   }
-  // cache
-  if(is_remove_cache && !FdManager::DeleteCacheDirectory()){
+  // cache(remove at last)
+  if(is_remove_cache && (!CacheFileStat::DeleteCacheFileStatDirectory() || !FdManager::DeleteCacheDirectory())){
     S3FS_PRN_WARN("Could not remove cache directory.");
   }
   // ssl


### PR DESCRIPTION
For fixing #337

When del_cache option is specified, s3fs remove file cache directory only.
But this fix is removing stat cache directory.
And changed timing for removing those directories at s3fs_init().
