### PR TITLE
Fixed codes about clock_gettime for osx(2)

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -46,8 +46,11 @@ using namespace std;
 //-------------------------------------------------------------------
 // Utility
 //-------------------------------------------------------------------
-#if defined(CLOCK_MONOTONIC_COARSE)
-#define CLOCK_MONOTONIC_COARSE  6
+#ifndef CLOCK_MONOTONIC
+#define CLOCK_MONOTONIC         CLOCK_REALTIME
+#endif
+#ifndef CLOCK_MONOTONIC_COARSE
+#define CLOCK_MONOTONIC_COARSE  CLOCK_MONOTONIC
 #endif
 
 #ifndef HAVE_CLOCK_GETTIME


### PR DESCRIPTION
There is a problem with the #355, it has been modified again.