### PR TITLE
Fix clock_gettime autotools detection on Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -229,6 +229,7 @@ dnl malloc_trim function
 AC_CHECK_FUNCS([malloc_trim])
 
 dnl clock_gettime function(osx)
+AC_SEARCH_LIBS([clock_gettime],[rt posix4]) 
 AC_CHECK_FUNCS([clock_gettime])
 
 dnl ----------------------------------------------


### PR DESCRIPTION
On Debian 7.8, AC_CHECK_FUNCS([glock_gettime]) returns false without adding rt to the search libs.  