### PR TITLE
Always set stats cache for opened file

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -33,8 +33,9 @@ struct stat_cache_entry {
   headers_t         meta;
   bool              isforce;
   bool              noobjcache;  // Flag: cache is no object for no listing.
+  unsigned long     notruncate;  // 0<:   not remove automatically at checking truncate
 
-  stat_cache_entry() : hit_count(0), isforce(false), noobjcache(false) {
+  stat_cache_entry() : hit_count(0), isforce(false), noobjcache(false), notruncate(0L) {
     memset(&stbuf, 0, sizeof(struct stat));
     cache_date.tv_sec  = 0;
     cache_date.tv_nsec = 0;
@@ -112,7 +113,10 @@ class StatCache
     bool AddNoObjectCache(std::string& key);
 
     // Add stat cache
-    bool AddStat(std::string& key, headers_t& meta, bool forcedir = false);
+    bool AddStat(std::string& key, headers_t& meta, bool forcedir = false, bool no_truncate = false);
+
+    // Change no truncate flag
+    void ChangeNoTruncateFlag(std::string key, bool no_truncate);
 
     // Delete stat cache
     bool DelStat(const char* key);


### PR DESCRIPTION
Fixed https://github.com/s3fs-fuse/s3fs-fuse/issues/370.

When copying a file(object), FUSE will call continuously s3fs_write evey 4KB(depending on the OS).
At this time FUSE will confirm the xattr of security.capability, if it is deemed necessary.
As a result, s3fs_getxattr will also be called in 64KB units.
And the HEAD request is sent to the S3 by evey s3fs_getxattr call, when s3fs is gave max_stat_cache_size=0 option or s3fs cached out the stats data for the file.
This causes a decrease in performance.

For solving this problem, s3fs is changed that the stats information for the file is always cached while the file is open.
After closing the file, the cache life depends on the setting of the max_stat_cache_size and it will be cleared.

