### PR TITLE
Fix a bug of truncating empty file

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2595,7 +2595,7 @@ int S3fsCurl::PreGetObjectRequest(const char* tpath, int fd, off_t start, ssize_
 {
   S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%zd]", SAFESTRPTR(tpath), (intmax_t)start, size);
 
-  if(!tpath || -1 == fd || 0 > start || 0 >= size){
+  if(!tpath || -1 == fd || 0 > start || 0 > size){
     return -1;
   }
 
@@ -2611,7 +2611,7 @@ int S3fsCurl::PreGetObjectRequest(const char* tpath, int fd, off_t start, ssize_
   requestHeaders  = NULL;
   responseHeaders.clear();
 
-  if(-1 != start && -1 != size){
+  if(-1 != start && 0 < size){
     string range = "bytes=";
     range       += str(start);
     range       += "-";

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -41,6 +41,24 @@ function test_truncate_file {
     rm_test_file
 }
 
+function test_truncate_empty_file {
+    echo "Testing truncate empty file ..."
+    # Write an empty test file
+    touch ${TEST_TEXT_FILE}
+
+    # Truncate the file to 1024 length
+    t_size=1024
+    truncate ${TEST_TEXT_FILE} -s $t_size
+
+    # Verify file is zero length
+    size=$(stat -c %s ${TEST_TEXT_FILE})
+    if [ $t_size -ne $size ]
+    then
+        echo "error: expected ${TEST_TEXT_FILE} to be $t_size length, got $size"
+        exit 1
+    fi
+    rm_test_file
+}
 
 function test_mv_file {
     describe "Testing mv file function ..."
@@ -377,6 +395,7 @@ function test_write_after_seek_ahead {
 function add_all_tests {
     add_tests test_append_file 
     add_tests test_truncate_file 
+    add_tests test_truncate_empty_file
     add_tests test_mv_file
     add_tests test_mv_directory
     add_tests test_redirects

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -55,7 +55,7 @@ function test_truncate_empty_file {
     if [ $t_size -ne $size ]
     then
         echo "error: expected ${TEST_TEXT_FILE} to be $t_size length, got $size"
-        exit 1
+        return 1
     fi
     rm_test_file
 }


### PR DESCRIPTION
The following steps report error, which should NOT:

```bash
ubuntu@ip-172-31-29-108:~/s3fs-fuse$ touch /tmp/s3fs/a
ubuntu@ip-172-31-29-108:~/s3fs-fuse$ ll /tmp/s3fs/a
-rw-rw-r-- 1 ubuntu ubuntu 0 Apr 22 06:48 /tmp/s3fs/a
ubuntu@ip-172-31-29-108:~/s3fs-fuse$ truncate /tmp/s3fs/a -s 1024
truncate: failed to truncate ‘/tmp/s3fs/a’ at 1024 bytes: Operation not permitted
```

This patch fixes this bug.