### PR TITLE
Fixed a bug about stat_cache_expire - #382

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -104,7 +104,9 @@ inline int CompareStatCacheTime(struct timespec& ts1, struct timespec& ts2)
 
 inline bool IsExpireStatCacheTime(const struct timespec& ts, const time_t& expire)
 {
-  return ((ts.tv_sec + expire) < time(NULL));
+  struct timespec nowts;
+  SetStatCacheTime(nowts);
+  return ((ts.tv_sec + expire) < nowts.tv_sec);
 }
 
 //


### PR DESCRIPTION
If you specify a stat_cache_expire option, s3fs are compared in CLOCK_MONOTONIC_COARSE and time () function, all has become a cash-out.  
This is a modification of the bug had been reported to the #382.