### PR TITLE
Fix for leaks during stat cache entry expiry / truncation (#340)

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -496,10 +496,12 @@ bool StatCache::TruncateCache(void)
     for(stat_cache_t::iterator iter = stat_cache.begin(); iter != stat_cache.end(); ){
       stat_cache_entry* entry = iter->second;
       if(!entry || (0L < entry->notruncate && IsExpireStatCacheTime(entry->cache_date, ExpireTime))){
-        stat_cache.erase(iter++);
-      }else{
-        ++iter;
+        if(entry){
+            delete entry;
+        }
+        stat_cache.erase(iter);
       }
+      ++iter;
     }
   }
 
@@ -532,6 +534,9 @@ bool StatCache::TruncateCache(void)
     stat_cache_t::iterator siter = *iiter;
 
     S3FS_PRN_DBG("truncate stat cache[path=%s]", siter->first.c_str());
+    if(siter->second){
+        delete siter->second;
+    }
     stat_cache.erase(siter);
   }
   S3FS_MALLOCTRIM(0);

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -499,9 +499,10 @@ bool StatCache::TruncateCache(void)
         if(entry){
             delete entry;
         }
-        stat_cache.erase(iter);
+        stat_cache.erase(iter++);
+      }else{
+        ++iter;
       }
-      ++iter;
     }
   }
 


### PR DESCRIPTION
As discussed in #340 - I've run this for a few days in production, and under an intense test load and it has resolved valgrind reported leaks, allocated from AddStat.