### PR TITLE
Add mirror file logic for removing cache file

### DIFF
--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -117,6 +117,7 @@ class FdEntity
     std::string     path;           // object path
     std::string     cachepath;      // local cache file path
                                     // (if this is empty, does not load/save pagelist.)
+    std::string     mirrorpath;     // mirror file path to local cache file path
     int             fd;             // file descriptor(tmp file or cache file)
     FILE*           pfile;          // file pointer(tmp file or cache file)
     bool            is_modify;      // if file is changed, this flag is true
@@ -132,6 +133,7 @@ class FdEntity
     static int FillFile(int fd, unsigned char byte, size_t size, off_t start);
 
     void Clear(void);
+    int OpenMirrorFile(void);
     bool SetAllStatus(bool is_loaded);                          // [NOTE] not locking
     //bool SetAllStatusLoaded(void) { return SetAllStatus(true); }
     bool SetAllStatusUnloaded(void) { return SetAllStatus(false); }
@@ -202,7 +204,7 @@ class FdManager
     static bool SetCacheDir(const char* dir);
     static bool IsCacheDir(void) { return (0 < FdManager::cache_dir.size()); }
     static const char* GetCacheDir(void) { return FdManager::cache_dir.c_str(); }
-    static bool MakeCachePath(const char* path, std::string& cache_path, bool is_create_dir = true);
+    static bool MakeCachePath(const char* path, std::string& cache_path, bool is_create_dir = true, bool is_mirror_path = false);
     static bool CheckCacheTopDir(void);
     static bool MakeRandomTempPath(const char* path, std::string& tmppath);
 

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -545,6 +545,14 @@ int is_uid_inculde_group(uid_t uid, gid_t gid)
 //-------------------------------------------------------------------
 // safe variant of dirname
 // dirname clobbers path so let it operate on a tmp copy
+string mydirname(const char* path)
+{
+  if(!path || '\0' == path[0]){
+    return string("");
+  }
+  return mydirname(string(path));
+}
+
 string mydirname(string path)
 {
   return string(dirname((char*)path.c_str()));
@@ -552,6 +560,14 @@ string mydirname(string path)
 
 // safe variant of basename
 // basename clobbers path so let it operate on a tmp copy
+string mybasename(const char* path)
+{
+  if(!path || '\0' == path[0]){
+    return string("");
+  }
+  return mybasename(string(path));
+}
+
 string mybasename(string path)
 {
   return string(basename((char*)path.c_str()));

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -106,7 +106,9 @@ void free_mvnodes(MVNODE *head);
 std::string get_username(uid_t uid);
 int is_uid_inculde_group(uid_t uid, gid_t gid);
 
+std::string mydirname(const char* path);
 std::string mydirname(std::string path);
+std::string mybasename(const char* path);
 std::string mybasename(std::string path);
 int mkdirp(const std::string& path, mode_t mode);
 bool check_exist_dir_permission(const char* dirpath);


### PR DESCRIPTION
This PR is for #428.

If the cache file is removed during upload/download a object, s3fs uploads/downloads the object which has some null bytes.
This patch changes a logic about upload/download when using cache files.
This new logic uses mirror file which is (hard) linked the cache file, then if the cache file is removed, s3fs can continue to upload/download a object without wrong data. 
