### PR TITLE
Fixed a bug about could not copy file mode from org file

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1561,6 +1561,17 @@ static int s3fs_chmod(const char* path, mode_t mode)
       return -EIO;
     }
     StatCache::getStatCacheData()->DelStat(nowcache);
+
+    // check opened file handle.
+    //
+    // If we have already opened file handle, should set mode to it.
+    // And new mode is set when the file handle is closed.
+    //
+    FdEntity* ent;
+    if(NULL != (ent = FdManager::get()->ExistOpen(path))){
+      ent->SetMode(mode);      // Set new mode to opened fd.
+      FdManager::get()->Close(ent);
+    }
   }
   S3FS_MALLOCTRIM(0);
 

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -207,7 +207,7 @@ function test_chown {
     # if they're the same, we have a problem.
     if [ $(stat --format=%u:%g $TEST_TEXT_FILE) == $ORIGINAL_PERMISSIONS ]
     then
-      echo "Could not modify $TEST_TEXT_FILE ownership"
+      echo "Could not modify $TEST_TEXT_FILE ownership($ORIGINAL_PERMISSIONS to 1000:1000)"
       return 1
     fi
 

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -208,11 +208,12 @@ function test_chown {
     if [ $(stat --format=%u:%g $TEST_TEXT_FILE) == $ORIGINAL_PERMISSIONS ]
     then
       if [ $ORIGINAL_PERMISSIONS == "1000:1000" ]
+      then
         echo "Could not be strict check because original file permission 1000:1000"
       else
         echo "Could not modify $TEST_TEXT_FILE ownership($ORIGINAL_PERMISSIONS to 1000:1000)"
         return 1
-      then
+      fi
     fi
 
     # clean up

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -207,8 +207,12 @@ function test_chown {
     # if they're the same, we have a problem.
     if [ $(stat --format=%u:%g $TEST_TEXT_FILE) == $ORIGINAL_PERMISSIONS ]
     then
-      echo "Could not modify $TEST_TEXT_FILE ownership($ORIGINAL_PERMISSIONS to 1000:1000)"
-      return 1
+      if [ $ORIGINAL_PERMISSIONS == "1000:1000" ]
+        echo "Could not be strict check because original file permission 1000:1000"
+      else
+        echo "Could not modify $TEST_TEXT_FILE ownership($ORIGINAL_PERMISSIONS to 1000:1000)"
+        return 1
+      then
     fi
 
     # clean up


### PR DESCRIPTION
This is a bug fix related to the #460.
If s3fs did not support xattrs, s3fs cound not copy file mode from original file when using "cp -p".
Thus this patch fixed this problem.
But now s3fs supports xattrs, then this patch does not effect to solve issue #460.