### PR TITLE
OS-specific correspondence of the extended attribute header

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,10 @@ AM_INIT_AUTOMAKE([foreign])
 AC_PROG_CXX
 AC_PROG_CC
 
+AC_CHECK_HEADERS([sys/xattr.h])
+AC_CHECK_HEADERS([attr/xattr.h])
+AC_CHECK_HEADERS([sys/extattr.h])
+
 CXXFLAGS="$CXXFLAGS -Wall -D_FILE_OFFSET_BITS=64"
 
 dnl ----------------------------------------------

--- a/src/common.h
+++ b/src/common.h
@@ -24,6 +24,17 @@
 #include "../config.h"
 
 //
+// Extended attribute
+//
+#ifdef HAVE_SYS_EXTATTR_H
+#include <sys/extattr.h>
+#elif HAVE_ATTR_XATTR_H
+#include <attr/xattr.h>
+#elif HAVE_SYS_XATTR_H
+#include <sys/xattr.h>
+#endif
+
+//
 // Macro
 //
 #define SAFESTRPTR(strptr) (strptr ? strptr : "")

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -34,7 +34,6 @@
 #include <pwd.h>
 #include <grp.h>
 #include <getopt.h>
-#include <sys/xattr.h>
 #include <signal.h>
 
 #include <fstream>


### PR DESCRIPTION
Fixed for #476
Supported the header file for extended attributes on each OS(file type) 