### PR TITLE
Trim symbolic link original path in file.

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -868,7 +868,7 @@ static int s3fs_readlink(const char* path, char* buf, size_t size)
 
   // check buf if it has space words.
   string strTmp = trim(string(buf));
-  ressize       = strTmp.length();
+  ressize       = static_cast<ssize_t>(strTmp.length());
   strcpy(buf, strTmp.c_str());
 
   FdManager::get()->Close(ent);
@@ -1179,7 +1179,7 @@ static int s3fs_symlink(const char* from, const char* to)
   }
   // write(without space words)
   string  strFrom   = trim(string(from));
-  ssize_t from_size = strFrom.size();
+  ssize_t from_size = static_cast<ssize_t>(strFrom.length());
   if(from_size != ent->Write(strFrom.c_str(), 0, from_size)){
     S3FS_PRN_ERR("could not write tmpfile(errno=%d)", errno);
     FdManager::get()->Close(ent);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -868,7 +868,6 @@ static int s3fs_readlink(const char* path, char* buf, size_t size)
 
   // check buf if it has space words.
   string strTmp = trim(string(buf));
-  ressize       = static_cast<ssize_t>(strTmp.length());
   strcpy(buf, strTmp.c_str());
 
   FdManager::get()->Close(ent);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -866,6 +866,11 @@ static int s3fs_readlink(const char* path, char* buf, size_t size)
   }
   buf[ressize] = '\0';
 
+  // check buf if it has space words.
+  string strTmp = trim(string(buf));
+  ressize       = strTmp.length();
+  strcpy(buf, strTmp.c_str());
+
   FdManager::get()->Close(ent);
   S3FS_MALLOCTRIM(0);
 
@@ -1172,9 +1177,10 @@ static int s3fs_symlink(const char* from, const char* to)
     S3FS_PRN_ERR("could not open tmpfile(errno=%d)", errno);
     return -errno;
   }
-  // write
-  ssize_t from_size = strlen(from);
-  if(from_size != ent->Write(from, 0, from_size)){
+  // write(without space words)
+  string  strFrom   = trim(string(from));
+  ssize_t from_size = strFrom.size();
+  if(from_size != ent->Write(strFrom.c_str(), 0, from_size)){
     S3FS_PRN_ERR("could not write tmpfile(errno=%d)", errno);
     FdManager::get()->Close(ent);
     return -errno;


### PR DESCRIPTION
If the original file path has white characters in symbolic link file, s3fs fails read link.
So that, trim original file path at reading/writing from link file. 