### PR TITLE
Upgrade to S3Proxy 1.5.1

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3441,7 +3441,8 @@ int S3fsCurl::CopyMultipartPostRequest(const char* from, const char* to, int par
   if(!CreateCurlHandle(true)){
     return -1;
   }
-  string urlargs  = "?partNumber=" + str(part_num) + "&uploadId=" + upload_id;
+  string request_uri = "partNumber=" + str(part_num) + "&uploadId=" + upload_id;
+  string urlargs     = "?" + request_uri;
   string resource;
   string turl;
   MakeUrlResource(get_realpath(to).c_str(), resource, turl);
@@ -3481,7 +3482,7 @@ int S3fsCurl::CopyMultipartPostRequest(const char* from, const char* to, int par
     }
 
   }else{
-    insertV4Headers("PUT", path, "", "");
+    insertV4Headers("PUT", path, request_uri, "");
   }
 
   // setopt

--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -50,7 +50,7 @@ export S3_URL
 export TEST_SCRIPT_DIR=`pwd`
 export TEST_BUCKET_MOUNT_POINT_1=${TEST_BUCKET_1}
 
-S3PROXY_VERSION="1.4.0"
+S3PROXY_VERSION="1.5.1"
 S3PROXY_BINARY=${S3PROXY_BINARY-"s3proxy-${S3PROXY_VERSION}"}
 
 if [ ! -f "$S3FS_CREDENTIALS_FILE" ]
@@ -157,8 +157,6 @@ function start_s3fs {
     #
     # TODO: Allow all these options to be overriden with env variables
     #
-    # sigv2
-    #     Historically because S3Proxy only supports sigv2.  
     # use_path_request_style
     #     The test env doesn't have virtual hosts
     # createbucket
@@ -181,7 +179,6 @@ function start_s3fs {
             ${VALGRIND_EXEC} ${S3FS} \
             $TEST_BUCKET_1 \
             $TEST_BUCKET_MOUNT_POINT_1 \
-            -o sigv2 \
             -o use_path_request_style \
             -o url=${S3_URL} \
             -o createbucket \

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -412,8 +412,7 @@ function add_all_tests {
     # TODO: broken: https://github.com/s3fs-fuse/s3fs-fuse/issues/145
     #add_tests test_rename_before_close
     add_tests test_multipart_upload
-    # TODO: test disabled until S3Proxy 1.5.0 is released
-    #add_tests test_multipart_copy
+    add_tests test_multipart_copy
     add_tests test_special_characters
     add_tests test_symlink
     add_tests test_extended_attributes

--- a/test/s3proxy.conf
+++ b/test/s3proxy.conf
@@ -1,5 +1,5 @@
 s3proxy.endpoint=http://127.0.0.1:8080
-s3proxy.authorization=aws-v2
+s3proxy.authorization=aws-v4
 s3proxy.identity=local-identity
 s3proxy.credential=local-credential
 


### PR DESCRIPTION
Enabled previously broken tests and test with default v4 signer.
Release notes:

https://github.com/andrewgaul/s3proxy/releases/tag/s3proxy-1.5.0
https://github.com/andrewgaul/s3proxy/releases/tag/s3proxy-1.5.1