### PR TITLE
Fixed a bug about uploading NULL to some part of the file contents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: apt
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq cppcheck libfuse-dev openjdk-7-jdk
- - sudo update-alternatives --auto java
+ - sudo update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
 script:
  - ./autogen.sh
  - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq cppcheck libfuse-dev
  - sudo apt-get install openjdk-7-jdk
+ - sudo update-alternatives --config java
 script:
  - ./autogen.sh
  - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ dist: trusty
 cache: apt
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq cppcheck libfuse-dev
- - sudo apt-get install openjdk-7-jdk
- - sudo update-alternatives --config java
+ - sudo apt-get install -qq cppcheck libfuse-dev openjdk-7-jdk
 script:
  - ./autogen.sh
  - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: apt
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq cppcheck libfuse-dev openjdk-7-jdk
+ - sudo update-alternatives --auto java
 script:
  - ./autogen.sh
  - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ dist: trusty
 cache: apt
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq cppcheck libfuse-dev openjdk-7-jdk
+ - sudo apt-get install -qq cppcheck libfuse-dev
+ - sudo apt-get install openjdk-7-jdk
 script:
  - ./autogen.sh
  - ./configure

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1963,8 +1963,23 @@ FdEntity* FdManager::Open(const char* path, headers_t* pmeta, ssize_t size, time
   }
   AutoLock auto_lock(&FdManager::fd_manager_lock);
 
+  // search in mapping by key(path)
   fdent_map_t::iterator iter = fent.find(string(path));
-  FdEntity*             ent;
+
+  if(fent.end() == iter && !FdManager::IsCacheDir()){
+    // If the cache directory is not specified, s3fs opens a temporary file
+    // when the file is opened.
+    // Then if it could not find a entity in map for the file, s3fs should
+    // search a entity in all which opened the temporary file.
+    //
+    for(iter = fent.begin(); iter != fent.end(); ++iter){
+      if((*iter).second && (*iter).second->IsOpen()){
+        break;      // found opened fd in mapping
+      }
+    }
+  }
+
+  FdEntity* ent;
   if(fent.end() != iter){
     // found
     ent = (*iter).second;

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1966,7 +1966,7 @@ FdEntity* FdManager::Open(const char* path, headers_t* pmeta, ssize_t size, time
   // search in mapping by key(path)
   fdent_map_t::iterator iter = fent.find(string(path));
 
-  if(fent.end() == iter && !FdManager::IsCacheDir()){
+  if(fent.end() == iter && !force_tmpfile && !FdManager::IsCacheDir()){
     // If the cache directory is not specified, s3fs opens a temporary file
     // when the file is opened.
     // Then if it could not find a entity in map for the file, s3fs should

--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -99,6 +99,15 @@ function start_s3proxy {
     else
         S3PROXY_CONFIG="s3proxy.conf"
     fi
+    JAVA_BIN=`which java`
+    if [ $? -ne 0 ]; then
+        if [ -f /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java ]; then
+            JAVA_BIN=/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
+        else
+            # not found java command, so probabry gets error by stdbuf command line.
+            JAVA_BIN=java
+        fi
+    fi
 
     if [ -n "${S3PROXY_BINARY}" ]
     then
@@ -108,7 +117,7 @@ function start_s3proxy {
             chmod +x "${S3PROXY_BINARY}"
         fi
 
-        stdbuf -oL -eL java -jar "$S3PROXY_BINARY" --properties $S3PROXY_CONFIG | stdbuf -oL -eL sed -u "s/^/s3proxy: /" &
+        stdbuf -oL -eL ${JAVA_BIN} -jar "$S3PROXY_BINARY" --properties $S3PROXY_CONFIG | stdbuf -oL -eL sed -u "s/^/s3proxy: /" &
 
         # wait for S3Proxy to start
         for i in $(seq 30);

--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -99,15 +99,6 @@ function start_s3proxy {
     else
         S3PROXY_CONFIG="s3proxy.conf"
     fi
-    JAVA_BIN=`which java`
-    if [ $? -ne 0 ]; then
-        if [ -f /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java ]; then
-            JAVA_BIN=/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
-        else
-            # not found java command, so probabry gets error by stdbuf command line.
-            JAVA_BIN=java
-        fi
-    fi
 
     if [ -n "${S3PROXY_BINARY}" ]
     then
@@ -117,7 +108,7 @@ function start_s3proxy {
             chmod +x "${S3PROXY_BINARY}"
         fi
 
-        stdbuf -oL -eL ${JAVA_BIN} -jar "$S3PROXY_BINARY" --properties $S3PROXY_CONFIG | stdbuf -oL -eL sed -u "s/^/s3proxy: /" &
+        stdbuf -oL -eL java -jar "$S3PROXY_BINARY" --properties $S3PROXY_CONFIG | stdbuf -oL -eL sed -u "s/^/s3proxy: /" &
 
         # wait for S3Proxy to start
         for i in $(seq 30);


### PR DESCRIPTION
When s3fs performs continuous upload, part of the file can not be uploaded normally and some part of the file was written as a NULL code.
(See the issue of #435, and there are other issues related to this bug.)
After fixing this bug to another branch, it seems to be stable, so I try to merge it into the master branch.