### PR TITLE
Changed base cached time of stat_cache_expire option - #523

### DIFF
--- a/doc/man/s3fs.1
+++ b/doc/man/s3fs.1
@@ -138,7 +138,11 @@ time to wait between read/write activity before giving up.
 maximum number of entries in the stat cache
 .TP
 \fB\-o\fR stat_cache_expire (default is no expire)
-specify expire time(seconds) for entries in the stat cache
+specify expire time(seconds) for entries in the stat cache. This expire time indicates the time since stat cached.
+.TP
+\fB\-o\fR stat_cache_interval_expire (default is no expire)
+specify expire time(seconds) for entries in the stat cache. This expire time is based on the time from the last access time of the stat cache.
+This option is exclusive with stat_cache_expire, and is left for compatibility with older versions.
 .TP
 \fB\-o\fR enable_noobj_cache (default is disable)
 enable cache entries for the object which does not exist.

--- a/src/cache.h
+++ b/src/cache.h
@@ -55,6 +55,7 @@ class StatCache
     static pthread_mutex_t stat_cache_lock;
     stat_cache_t  stat_cache;
     bool          IsExpireTime;
+    bool          IsExpireIntervalType;         // if this flag is true, cache data is updated at last access time.
     time_t        ExpireTime;
     unsigned long CacheSize;
     bool          IsCacheNoObject;
@@ -78,7 +79,7 @@ class StatCache
     unsigned long GetCacheSize(void) const;
     unsigned long SetCacheSize(unsigned long size);
     time_t GetExpireTime(void) const;
-    time_t SetExpireTime(time_t expire);
+    time_t SetExpireTime(time_t expire, bool is_interval = false);
     time_t UnsetExpireTime(void);
     bool SetCacheNoObject(bool flag);
     bool EnableCacheNoObject(void) {

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4591,6 +4591,13 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       StatCache::getStatCacheData()->SetExpireTime(expr_time);
       return 0;
     }
+    // [NOTE]
+    // This option is for compatibility old version.
+    if(0 == STR2NCMP(arg, "stat_cache_interval_expire=")){
+      time_t expr_time = static_cast<time_t>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char)));
+      StatCache::getStatCacheData()->SetExpireTime(expr_time, true);
+      return 0;
+    }
     if(0 == strcmp(arg, "enable_noobj_cache")){
       StatCache::getStatCacheData()->EnableCacheNoObject();
       return 0;


### PR DESCRIPTION
#### Relevant Issue (if applicable)
#523

#### Details
s3fs updated the cached time of stat information to the time when it was accessed to that cache.
This effectively reduces the number of requests for continuous cache access.
However, if the bucket is mounted with multiple s3fs, it becomes a problem like #523.

In this renovation, the expiration date specified by "stat_cache_expire" shall be the time since stat information was cached.
And I added an option called "**stat_cache_interval_expire**" to update the cached time when accessed stat information for compatibility.
