### PR TITLE
Add umount instruction for unplivileged user.

### DIFF
--- a/doc/man/s3fs.1
+++ b/doc/man/s3fs.1
@@ -10,6 +10,10 @@ S3FS \- FUSE-based file system backed by Amazon S3
 .SS unmounting
 .TP
 \fBumount mountpoint
+For root.
+.TP
+\fBfusermount -u mountpoint
+For unprivileged user.
 .SS utility mode ( remove interrupted multipart uploading objects )
 .TP
 \fBs3fs \-u bucket


### PR DESCRIPTION
#### Details
Ordinary user has no permissions to use umount command, so it is good to add fuse unmount instruction in man file.
