### PR TITLE
switch S3fsMultiCurl to use foreground threads

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -441,7 +441,6 @@ class S3fsMultiCurl
   private:
     static int    max_multireq;
 
-    CURLM*        hMulti;
     s3fscurlmap_t cMap_all;  // all of curl requests
     s3fscurlmap_t cMap_req;  // curl requests are sent
 
@@ -452,6 +451,8 @@ class S3fsMultiCurl
     bool ClearEx(bool is_all);
     int MultiPerform(void);
     int MultiRead(void);
+
+    static void* RequestPerformWrapper(void* arg);
 
   public:
     S3fsMultiCurl();


### PR DESCRIPTION
#### Details
Currently, s3fs uses a multicurl handle to use parallel connections to s3.
The connections are indeed parallel, but are handled by a single CPU thread.
This creates a CPU bottleneck when reaching high throughput with TLS (HTTPS) connections.
To solve this issue, I propose a change to the S3fsMultiCurl class to use foreground pthreads instead of a multicurl handle.