### PR TITLE
don't sign empty headers (as they are discarded by libcurl)

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -4136,6 +4136,10 @@ string get_sorted_header_keys(const struct curl_slist* list)
     string strkey = list->data;
     size_t pos;
     if(string::npos != (pos = strkey.find(':', 0))){
+      if (trim(strkey.substr(pos + 1)).empty()) {
+        // skip empty-value headers (as they are discarded by libcurl)
+        continue;
+      }
       strkey = strkey.substr(0, pos);
     }
     if(0 < sorted_headers.length()){
@@ -4162,6 +4166,10 @@ string get_canonical_headers(const struct curl_slist* list)
     if(string::npos != (pos = strhead.find(':', 0))){
       string strkey = trim(lower(strhead.substr(0, pos)));
       string strval = trim(strhead.substr(pos + 1));
+      if (strval.empty()) {
+        // skip empty-value headers (as they are discarded by libcurl)
+        continue;
+      }
       strhead       = strkey + string(":") + strval;
     }else{
       strhead       = trim(lower(strhead));
@@ -4187,6 +4195,10 @@ string get_canonical_headers(const struct curl_slist* list, bool only_amz)
     if(string::npos != (pos = strhead.find(':', 0))){
       string strkey = trim(lower(strhead.substr(0, pos)));
       string strval = trim(strhead.substr(pos + 1));
+      if (strval.empty()) {
+        // skip empty-value headers (as they are discarded by libcurl)
+        continue;
+      }
       strhead       = strkey + string(":") + strval;
     }else{
       strhead       = trim(lower(strhead));


### PR DESCRIPTION
#### Details
The AWSv4 signature function signs all request headers, including those with an empty string value.
Those headers with empty value are later discarded by libcurl (i.e. they are not sent to the s3 server).
This lead to a situation of a bad signature.

For example, this invalid request was generated:
POST /ozeri/rand10m5?uploads= HTTP/1.1
host: <...>
User-Agent: s3fs/1.80 (commit hash unknown; OpenSSL)
Authorization: AWS4-HMAC-SHA256 Credential=<...>, SignedHeaders=accept;content-length;content-type;host;x-amz-acl;x-amz-content-sha256;x-amz-date;x-amz-meta-gid;x-amz-meta-mode;x-amz-meta-mtime;x-amz-meta-uid, Signature=<...>
Content-Type: application/octet-stream
x-amz-acl: private
x-amz-content-sha256: <...>
x-amz-date: <...>
x-amz-meta-gid: 0
x-amz-meta-mode: 33188
x-amz-meta-mtime: <...>
x-amz-meta-uid: 0

Note that the Authorization string contains accept;content-length in the signedheaders list, but this headers don't actually appear in the request.