### PR TITLE
fix multipart upload handling without cache

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -319,6 +319,7 @@ class S3fsCurl
 
     int UploadMultipartPostSetup(const char* tpath, int part_num, const std::string& upload_id);
     int CopyMultipartPostRequest(const char* from, const char* to, int part_num, std::string& upload_id, headers_t& meta);
+    bool UploadMultipartPostComplete();
 
   public:
     // class methods


### PR DESCRIPTION
#### Details
The multipart upload function which is called when running out of disk space is broken.
The etag for the parts are not stored as necessary to complete the upload.
I refactored the multipart upload success callback to be called on this case as well.