### PR TITLE
Fixed a bug in logic about truncating stat cache

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -505,7 +505,7 @@ bool StatCache::TruncateCache(void)
   if(IsExpireTime){
     for(stat_cache_t::iterator iter = stat_cache.begin(); iter != stat_cache.end(); ){
       stat_cache_entry* entry = iter->second;
-      if(!entry || (0L < entry->notruncate && IsExpireStatCacheTime(entry->cache_date, ExpireTime))){
+      if(!entry || (0L == entry->notruncate && IsExpireStatCacheTime(entry->cache_date, ExpireTime))){
         if(entry){
             delete entry;
         }


### PR DESCRIPTION
#### Relevant Issue (if applicable)
#549

#### Details
There was a problem with the cache out logic of the stat cache.
This may possibly be the cause of # 549
