### PR TITLE
Fixed about multipart uploading at no free space related to #509

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3432,8 +3432,13 @@ int S3fsCurl::UploadMultipartPostRequest(const char* tpath, int part_num, const 
   // request
   if(0 == (result = RequestPerform())){
     // check etag
-    if(NULL != strstr(headdata->str(), partdata.etag.c_str())){
-      partdata.uploaded = true;
+    headers_t::iterator it = responseHeaders.find("ETag");
+    if (it != responseHeaders.end()) {
+      if(S3fsCurl::is_content_md5 && !etag_equals(it->second, partdata.etag)){
+        result = -1;
+      }else{
+        partdata.uploaded = true;
+      }
     }else{
       result = -1;
     }


### PR DESCRIPTION
#### Relevant Issue (if applicable)
#509 #556 #559

#### Details
This PR is a fix for defects detected during investigation in #559.

There was a mistake in code change of #509, and it will fail multipart uploads if there is insufficient disk space.
This bug was corrected additionally by this PR.

##### NOTE
This correction will be overwritten by #556.
It is a modification that is applied in a short period until #556 merge is completed.