### PR TITLE
Added option for complementing lack of stat mode

### DIFF
--- a/doc/man/s3fs.1
+++ b/doc/man/s3fs.1
@@ -248,6 +248,10 @@ Customize TLS cipher suite list. Expects a colon separated list of cipher suite 
 A list of available cipher suites, depending on your TLS engine, can be found on the CURL library documentation:
 https://curl.haxx.se/docs/ssl-ciphers.html
 .TP
+\fB\-o\fR complement_stat (complement lack of file/directory mode)
+s3fs complements lack of information about file/directory mode if a file or a directory object does not have x-amz-meta-mode header.
+As default, s3fs does not complements stat information for a object, then the object will not be able to be allowed to list/modify.
+.TP
 \fB\-o\fR dbglevel (default="crit")
 Set the debug message level. set value as crit(critical), err(error), warn(warning), info(information) to debug level. default debug level is critical.
 If s3fs run with "-d" option, the debug level is set information.

--- a/src/common.h
+++ b/src/common.h
@@ -152,6 +152,7 @@ typedef std::map<std::string, PXATTRVAL> xattrs_t;
 extern bool           foreground;
 extern bool           nomultipart;
 extern bool           pathrequeststyle;
+extern bool           complement_stat;
 extern std::string    program_name;
 extern std::string    service_path;
 extern std::string    host;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -88,6 +88,7 @@ typedef std::list<UNCOMP_MP_INFO> uncomp_mp_list_t;
 bool foreground                   = false;
 bool nomultipart                  = false;
 bool pathrequeststyle             = false;
+bool complement_stat              = false;
 std::string program_name;
 std::string service_path          = "/";
 std::string host                  = "http://s3.amazonaws.com";
@@ -4667,6 +4668,10 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
     }
     if(0 == strcmp(arg, "norenameapi")){
       norenameapi = true;
+      return 0;
+    }
+    if(0 == strcmp(arg, "complement_stat")){
+      complement_stat = true;
       return 0;
     }
     if(0 == strcmp(arg, "enable_content_md5")){


### PR DESCRIPTION
#### Relevant Issue (if applicable)
n/a
(This is a request by direct mail.)

#### Details
If the object in S3 bucket was uploaded directly from the AWS S3 console or another tool incompatible with s3fs, it may not have the x-amz-meta-mode header required by s3fs or it's content type is not application/x-directory.
In this case, the object(file or directory) permission mode is 0, and even reading it can not.
In other words, if the object does not have the minimum necessary header, s3fs makes a strict judgment and the object is not authorized to operate.

However, with many users this mode=0 is confusing, and in the case of directories it is a problem that it can not be judged as a directory in particular.

Even if the x-amz-meta-mode does not exist or it can not be judged strictly as a directory, s3fs can predict that it is a directory and grants that it has the minimum permission (owner can read only for a file or read/excute for directory) by adding new option "complement_stat".

Thanks to Steven Marcus for giving the request!
