### PR TITLE
Enhanced bucket/path parameter check

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4222,6 +4222,10 @@ static int set_bucket(const char* arg)
 {
   char *bucket_name = (char*)arg;
   if(strstr(arg, ":")){
+    if(strstr(arg, "://")){
+      S3FS_PRN_EXIT("bucket name and path(\"%s\") is wrong, it must be \"bucket[:/path]\".", arg);
+      return -1;
+    }
     bucket = strtok(bucket_name, ":");
     char* pmount_prefix = strtok(NULL, ":");
     if(pmount_prefix){


### PR DESCRIPTION
#### Relevant Issue (if applicable)
#475

#### Details
Enhanced bucket/path parameter check, if the parameter has "://" string, it will be error and not start to run s3fs.
If user specify "s3://" prefix for bucket name and it matches "bucketname:/path" format, user can not know the reason that is wrong bucket name, because s3fs reports "do not access your bucket".
So, s3fs checks bucket name and path for finding wrong prefix at first.
