### PR TITLE
Check errors returned in 200 OK responses for put header request

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2656,6 +2656,26 @@ int S3fsCurl::PutHeadRequest(const char* tpath, headers_t& meta, bool is_copy)
   S3FS_PRN_INFO3("copying... [path=%s]", tpath);
 
   int result = RequestPerform();
+  if(0 == result){
+    // PUT returns 200 status code with something error, thus
+    // we need to check body.
+    //
+    // example error body:
+    //     <?xml version="1.0" encoding="UTF-8"?>
+    //     <Error>
+    //       <Code>AccessDenied</Code>
+    //       <Message>Access Denied</Message>
+    //       <RequestId>E4CA6F6767D6685C</RequestId>
+    //       <HostId>BHzLOATeDuvN8Es1wI8IcERq4kl4dc2A9tOB8Yqr39Ys6fl7N4EJ8sjGiVvu6wLP</HostId>
+    //     </Error>
+    //
+    const char* pstrbody = bodydata->str();
+    if(!pstrbody || NULL != strcasestr(pstrbody, "<Error>")){
+      S3FS_PRN_ERR("PutHeadRequest get 200 status response, but it included error body(or NULL). The request failed during copying the object in S3.");
+      S3FS_PRN_DBG("PutHeadRequest Response Body : %s", (pstrbody ? pstrbody : "(null)"));
+      result = -EIO;
+    }
+  }
   delete bodydata;
   bodydata = NULL;
 


### PR DESCRIPTION
#### Relevant Issue (if applicable)
#535

#### Details
Added simple response body check when getting 200 OK status by Put Head Request. 
This check is only single request(except multi head request).
 
