### PR TITLE
Group permission checks sometimes fail with large number of groups

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1705,15 +1705,6 @@ static int s3fs_chown(const char* path, uid_t uid, gid_t gid)
     return result;
   }
 
-  struct passwd* pwdata= getpwuid(uid);
-  struct group* grdata = getgrgid(gid);
-  if(pwdata){
-    uid = pwdata->pw_uid;
-  }
-  if(grdata){
-    gid = grdata->gr_gid;
-  }
-
   if(S_ISDIR(stbuf.st_mode) && IS_REPLACEDIR(nDirType)){
     // Should rebuild directory object(except new type)
     // Need to remove old dir("dir" etc) and make new dir("dir/")
@@ -1769,6 +1760,13 @@ static int s3fs_chown_nocopy(const char* path, uid_t uid, gid_t gid)
     return result;
   }
 
+  if((uid_t)(-1) == uid){
+    uid = stbuf.st_uid;
+  }
+  if((gid_t)(-1) == gid){
+    gid = stbuf.st_gid;
+  }
+
   // Get attributes
   if(S_ISDIR(stbuf.st_mode)){
     result = chk_dir_object_type(path, newpath, strpath, nowcache, NULL, &nDirType);
@@ -1779,15 +1777,6 @@ static int s3fs_chown_nocopy(const char* path, uid_t uid, gid_t gid)
   }
   if(0 != result){
     return result;
-  }
-
-  struct passwd* pwdata= getpwuid(uid);
-  struct group* grdata = getgrgid(gid);
-  if(pwdata){
-    uid = pwdata->pw_uid;
-  }
-  if(grdata){
-    gid = grdata->gr_gid;
   }
 
   if(S_ISDIR(stbuf.st_mode)){

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -510,8 +510,17 @@ int is_uid_include_group(uid_t uid, gid_t gid)
     return -ENOMEM;
   }
   // get group information
-  if(0 != (result = getgrgid_r(gid, &ginfo, pbuf, maxlen, &pginfo))){
-    S3FS_PRN_ERR("could not get group information.");
+  while(ERANGE == (result = getgrgid_r(gid, &ginfo, pbuf, maxlen, &pginfo))){
+    free(pbuf);
+    maxlen *= 2;
+    if(NULL == (pbuf = (char*)malloc(sizeof(char) * maxlen))){
+      S3FS_PRN_CRIT("failed to allocate memory.");
+      return -ENOMEM;
+    }
+  }
+
+  if(0 != result){
+    S3FS_PRN_ERR("could not get group information(%d).", result);
     free(pbuf);
     return -result;
   }


### PR DESCRIPTION
On some of my systems users cannot access directories, which they have group membership to access.
One if the groups in particular is quite large, with about 50 members, but I've also got ~150 groups and users in total.

I've traced the issue back to the getgrgid_r call within is_uid_include_group failing with ERANGE, indicating the buffer is too small.
The patch in this pull request solves the problem by expanding the buffer and trying again until it works, but there might be a better way.