### PR TITLE
Group permission checks sometimes fail with large number of groups

### DIFF
--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -510,8 +510,17 @@ int is_uid_include_group(uid_t uid, gid_t gid)
     return -ENOMEM;
   }
   // get group information
-  if(0 != (result = getgrgid_r(gid, &ginfo, pbuf, maxlen, &pginfo))){
-    S3FS_PRN_ERR("could not get group information.");
+  while(ERANGE == (result = getgrgid_r(gid, &ginfo, pbuf, maxlen, &pginfo))){
+    free(pbuf);
+    maxlen *= 2;
+    if(NULL == (pbuf = (char*)malloc(sizeof(char) * maxlen))){
+      S3FS_PRN_CRIT("failed to allocate memory.");
+      return -ENOMEM;
+    }
+  }
+
+  if(0 != result){
+    S3FS_PRN_ERR("could not get group information(%d).", result);
     free(pbuf);
     return -result;
   }


### PR DESCRIPTION
(Same as #605 with different branch)
On some of my systems users cannot access directories, which they have group membership to access.
One if the groups in particular is quite large, with about 50 members, but I've also got ~150 groups and users in total.

I've traced the issue back to the getgrgid_r call within is_uid_include_group failing with ERANGE, indicating the buffer is too small.
The patch in this pull request solves the problem by expanding the buffer and trying again until it works, but there might be a better way.