### PR TITLE
Fixed clock_gettime build failure on macOS 10.12 Sierra - #600

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -59,7 +59,7 @@ using namespace std;
 #ifdef HAVE_CLOCK_GETTIME
 static int s3fs_clock_gettime(int clk_id, struct timespec* ts)
 {
-  return clock_gettime(clk_id, ts);
+  return clock_gettime(static_cast<clockid_t>(clk_id), ts);
 }
 #else
 static int s3fs_clock_gettime(int clk_id, struct timespec* ts)


### PR DESCRIPTION
#### Relevant Issue (if applicable)
#600

#### Details
Sierra has clock_gettime function, but s3fs code does not convert first argument(cast).
Then it is an error as wrong variable type .
So it is cast to clockid_t.
