### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Installation
 On Ubuntu 14.04:
 
 ```
-sudo apt-get install automake fuse autotools-dev g++ git libcurl4-gnutls-dev libfuse-dev libssl-dev libxml2-dev make pkg-config
+sudo apt-get install automake autotools-dev fuse g++ git libcurl4-gnutls-dev libfuse-dev libssl-dev libxml2-dev make pkg-config
 ```
 
 On CentOS 7:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Installation
 On Ubuntu 14.04:
 
 ```
-sudo apt-get install automake autotools-dev g++ git libcurl4-gnutls-dev libfuse-dev libssl-dev libxml2-dev make pkg-config
+sudo apt-get install automake fuse autotools-dev g++ git libcurl4-gnutls-dev libfuse-dev libssl-dev libxml2-dev make pkg-config
 ```
 
 On CentOS 7:


### PR DESCRIPTION
Add fuse as a dependency!

#### Relevant Issue (if applicable)
Fails to work with fuse as dependency

#### Details
Fuse is not listed as a dependency and it caused mounting to fault even when follwoing instructions to the letter.
