### PR TITLE
Do not fail updating directory when removing old-style object

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2325,7 +2325,13 @@ int S3fsCurl::DeleteRequest(const char* tpath)
 
   type = REQTYPE_DELETE;
 
-  return RequestPerform();
+  int result = RequestPerform();
+
+  if (result == -ENOENT && LastResponseCode == 404) {
+    return 0;
+  }
+
+  return result;
 }
 
 //


### PR DESCRIPTION
Fixes #625

When modifying directories, removing the existing object should not cause a failure if the older style directory does not exist.