### PR TITLE
Refixed s3fs_init message(ref #652)

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -100,6 +100,14 @@ enum s3fs_log_level{
          syslog(S3FS_LOG_LEVEL_TO_SYSLOG(S3FS_LOG_CRIT), "s3fs: " fmt "%s", __VA_ARGS__); \
        }
 
+// Special macro for init message
+#define S3FS_PRN_INIT_INFO(fmt, ...) \
+       if(foreground){ \
+         fprintf(stdout, "%s%s%s:%s(%d): " fmt "%s\n", S3FS_LOG_LEVEL_STRING(S3FS_LOG_INFO), S3FS_LOG_NEST(0), __FILE__, __func__, __LINE__, __VA_ARGS__, ""); \
+       }else{ \
+         syslog(S3FS_LOG_LEVEL_TO_SYSLOG(S3FS_LOG_INFO), "%s" fmt "%s", S3FS_LOG_NEST(0), __VA_ARGS__, ""); \
+       }
+
 // [NOTE]
 // small trick for VA_ARGS
 //

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3364,7 +3364,7 @@ static void s3fs_exit_fuseloop(int exit_status) {
 
 static void* s3fs_init(struct fuse_conn_info* conn)
 {
-  S3FS_PRN_INFO("init v%s(commit:%s) with %s", VERSION, COMMIT_HASH_VAL, s3fs_crypt_lib_name());
+  S3FS_PRN_INIT_INFO("init v%s(commit:%s) with %s", VERSION, COMMIT_HASH_VAL, s3fs_crypt_lib_name());
 
   // cache(remove cache dirs at first)
   if(is_remove_cache && (!CacheFileStat::DeleteCacheFileStatDirectory() || !FdManager::DeleteCacheDirectory())){


### PR DESCRIPTION
#### Relevant Issue (if applicable)
#652

#### Details
I noticed that there was a problem with fixing #652.
s3fs init message was always output when CRIT level.
However, if we changed to the INFO level for this message, it will not be output unless the s3fs log output level specification is less than INFO.
The init message level should be INFO, but it should be outputted independently of the log output level of s3fs.
I fixed this again.
