### PR TITLE
Changed .travis.yml for fixing not found gpg2 on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ matrix:
     - os: osx
       osx_image: xcode8.3
       before_install:
-        - curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
-        - rvm get head
         - brew update
         - brew install truncate
         - brew tap caskroom/cask


### PR DESCRIPTION
#### Relevant Issue (if applicable)
#667

#### Details
Removed lines about before_install(gpg2 and rvm commands)
