### PR TITLE
Reduce use of preprocessor

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -37,7 +37,7 @@
 //
 // Macro
 //
-#define SAFESTRPTR(strptr) (strptr ? strptr : "")
+static inline const char *SAFESTRPTR(const char *strptr) { return strptr ? strptr : ""; }
 
 //
 // Debug level

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -159,10 +159,11 @@ static string tolower_header_name(const char* head)
 //-------------------------------------------------------------------
 // Class BodyData
 //-------------------------------------------------------------------
-#define BODYDATA_RESIZE_APPEND_MIN  (1 * 1024)         // 1KB
-#define BODYDATA_RESIZE_APPEND_MID  (1 * 1024 * 1024)  // 1MB
-#define BODYDATA_RESIZE_APPEND_MAX  (10 * 1024 * 1024) // 10MB
-#define	AJUST_BLOCK(bytes, block)   (((bytes / block) + ((bytes % block) ? 1 : 0)) * block)
+static const int BODYDATA_RESIZE_APPEND_MIN = 1024;
+static const int BODYDATA_RESIZE_APPEND_MID = 1024 * 1024;
+static const int BODYDATA_RESIZE_APPEND_MAX = 10 * 1024 * 1024;
+
+static size_t adjust_block(size_t bytes, size_t block) { return ((bytes / block) + ((bytes % block) ? 1 : 0)) * block; }
 
 bool BodyData::Resize(size_t addbytes)
 {
@@ -171,7 +172,7 @@ bool BodyData::Resize(size_t addbytes)
   }
 
   // New size
-  size_t need_size = AJUST_BLOCK((lastpos + addbytes + 1) - bufsize, sizeof(off_t));
+  size_t need_size = adjust_block((lastpos + addbytes + 1) - bufsize, sizeof(off_t));
 
   if(BODYDATA_RESIZE_APPEND_MAX < bufsize){
     need_size = (BODYDATA_RESIZE_APPEND_MAX < need_size ? need_size : BODYDATA_RESIZE_APPEND_MAX);
@@ -318,20 +319,20 @@ void CurlHandlerPool::ReturnHandler(CURL* h)
 //-------------------------------------------------------------------
 // Class S3fsCurl
 //-------------------------------------------------------------------
-#define MULTIPART_SIZE              10485760          // 10MB
-#define MAX_MULTI_COPY_SOURCE_SIZE  524288000         // 500MB
+static const int MULTIPART_SIZE = 10 * 1024 * 1024;
+static const int MAX_MULTI_COPY_SOURCE_SIZE = 500 * 1024 * 1024;
 
-#define	IAM_EXPIRE_MERGIN           (20 * 60)         // update timing
-#define IAM_CRED_URL_ECS            "http://169.254.170.2" 
-#define	IAM_CRED_URL                "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
-#define ECS_IAM_ENV_VAR             "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
-#define IAMCRED_ACCESSKEYID         "AccessKeyId"
-#define IAMCRED_SECRETACCESSKEY     "SecretAccessKey"
-#define IAMCRED_ACCESSTOKEN         "Token"
-#define IAMCRED_EXPIRATION          "Expiration"
-#define IAMCRED_ROLEARN             "RoleArn"
-#define IAMCRED_KEYCOUNT            4
-#define IAMCRED_KEYCOUNT_ECS	    5
+static const int IAM_EXPIRE_MERGIN = 20 * 60;  // update timing
+static const std::string IAM_CRED_URL_ECS = "http://169.254.170.2";
+static const std::string IAM_CRED_URL = "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
+static const std::string ECS_IAM_ENV_VAR = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+static const std::string IAMCRED_ACCESSKEYID = "AccessKeyId";
+static const std::string IAMCRED_SECRETACCESSKEY = "SecretAccessKey";
+static const std::string IAMCRED_ACCESSTOKEN = "Token";
+static const std::string IAMCRED_EXPIRATION = "Expiration";
+static const std::string IAMCRED_ROLEARN = "RoleArn";
+static const int IAMCRED_KEYCOUNT = 4;
+static const int IAMCRED_KEYCOUNT_ECS = 5;
 
 // [NOTICE]
 // This symbol is for libcurl under 7.23.0
@@ -2431,7 +2432,7 @@ int S3fsCurl::GetIAMCredentials(void)
 
   // url
   if (is_ecs) {
-    url = string(IAM_CRED_URL_ECS) + std::getenv(ECS_IAM_ENV_VAR);
+    url = string(IAM_CRED_URL_ECS) + std::getenv(ECS_IAM_ENV_VAR.c_str());
   }
   else {
     url = string(IAM_CRED_URL) + S3fsCurl::IAM_role;
@@ -3699,7 +3700,7 @@ int S3fsCurl::MultipartRenameRequest(const char* from, const char* to, headers_t
 //-------------------------------------------------------------------
 // Class S3fsMultiCurl 
 //-------------------------------------------------------------------
-#define MAX_MULTI_HEADREQ   20   // default: max request count in readdir curl_multi.
+static const int MAX_MULTI_HEADREQ = 20;  // default: max request count in readdir curl_multi.
 
 //-------------------------------------------------------------------
 // Class method for S3fsMultiCurl 

--- a/src/curl.h
+++ b/src/curl.h
@@ -26,7 +26,7 @@
 //----------------------------------------------
 // Symbols
 //----------------------------------------------
-#define MIN_MULTIPART_SIZE          5242880           // 5MB
+static const int MIN_MULTIPART_SIZE = 5 * 1024 * 1024;
 
 //----------------------------------------------
 // class BodyData
@@ -175,9 +175,11 @@ enum sse_type_t {
 };
 
 // share
-#define	SHARE_MUTEX_DNS         0
-#define	SHARE_MUTEX_SSL_SESSION 1
-#define	SHARE_MUTEX_MAX         2
+enum {
+  SHARE_MUTEX_DNS = 0,
+  SHARE_MUTEX_SSL_SESSION = 1,
+  SHARE_MUTEX_MAX = 2,
+};
 
 // Class for lapping curl
 //

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -52,7 +52,7 @@ using namespace std;
 //------------------------------------------------
 // Symbols
 //------------------------------------------------
-#define MAX_MULTIPART_CNT   10000                   // S3 multipart max count
+static const int MAX_MULTIPART_CNT = 10 * 1000;  // S3 multipart max count
 
 //
 // For cache directory top path

--- a/src/gnutls_auth.cpp
+++ b/src/gnutls_auth.cpp
@@ -186,11 +186,9 @@ bool s3fs_HMAC256(const void* key, size_t keylen, const unsigned char* data, siz
 //-------------------------------------------------------------------
 // Utility Function for MD5
 //-------------------------------------------------------------------
-#define MD5_DIGEST_LENGTH     16
-
 size_t get_md5_digest_length(void)
 {
-  return MD5_DIGEST_LENGTH;
+  return 16;
 }
 
 #ifdef	USE_GNUTLS_NETTLE
@@ -298,11 +296,9 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
 //-------------------------------------------------------------------
 // Utility Function for SHA256
 //-------------------------------------------------------------------
-#define SHA256_DIGEST_LENGTH     32
-
 size_t get_sha256_digest_length(void)
 {
-  return SHA256_DIGEST_LENGTH;
+  return 32;
 }
 
 #ifdef	USE_GNUTLS_NETTLE

--- a/src/s3fs.h
+++ b/src/s3fs.h
@@ -21,7 +21,8 @@
 #define S3FS_S3_H_
 
 #define FUSE_USE_VERSION      26
-#define FIVE_GB               5368709120LL
+
+static const int64_t FIVE_GB = 5LL * 1024LL * 1024LL * 1024LL;
 
 #include <fuse.h>
 

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -30,8 +30,9 @@
 #include <string>
 #include <sstream>
 
-#define SPACES                " \t\r\n"
-#define STR2NCMP(str1, str2)  strncmp(str1, str2, strlen(str2))
+static const std::string SPACES = " \t\r\n";
+
+static inline int STR2NCMP(const char *str1, const char *str2) { return strncmp(str1, str2, strlen(str2)); }
 
 template<typename T> std::string str(T value) {
   std::stringstream s;


### PR DESCRIPTION
This provides type-safety and avoids token expansion side effects.