### PR TITLE
fix condition for parallel download

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1155,7 +1155,7 @@ int FdEntity::Load(off_t start, size_t size)
       size_t over_size = (*iter)->bytes - need_load_size;
 
       // download
-      if(static_cast<size_t>(2 * S3fsCurl::GetMultipartSize()) < need_load_size && !nomultipart){ // default 20MB
+      if(static_cast<size_t>(2 * S3fsCurl::GetMultipartSize()) <= need_load_size && !nomultipart){ // default 20MB
         // parallel request
         // Additional time is needed for large files
         time_t backup = 0;


### PR DESCRIPTION
### Details
The parallel download request condition needs a small fix.
The parallel upload request condition is correct
(see: https://github.com/s3fs-fuse/s3fs-fuse/blob/566961c7a5db78066bdceefd385acbb964feb1c4/src/fdcache.cpp#L1505)
