### PR TITLE
Fixing race condition in FdEntity::GetStats

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1001,10 +1001,10 @@ bool FdEntity::OpenAndLoadAll(headers_t* pmeta, size_t* size, bool force_load)
 
 bool FdEntity::GetStats(struct stat& st)
 {
+  AutoLock auto_lock(&fdent_lock);
   if(-1 == fd){
     return false;
   }
-  AutoLock auto_lock(&fdent_lock);
 
   memset(&st, 0, sizeof(struct stat)); 
   if(-1 == fstat(fd, &st)){

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -2116,6 +2116,7 @@ FdEntity* FdManager::ExistOpen(const char* path, int existfd, bool ignore_existf
 
 void FdManager::Rename(const std::string &from, const std::string &to)
 {
+  AutoLock auto_lock(&FdManager::fd_manager_lock);
   fdent_map_t::iterator iter = fent.find(from);
   if(fent.end() != iter){
     // found


### PR DESCRIPTION
### Relevant Issue (if applicable)
After few hours of intensive use I got a crash. See backtrace below. This is due to the fact that the file descriptor can change between the sanity check and the real use of it.

### Details

#0  0x00000035f0c325e5 in raise () from /lib64/libc.so.6
#1  0x00000035f0c33dc5 in abort () from /lib64/libc.so.6
#2  0x00000035f0c704f7 in __libc_message () from /lib64/libc.so.6
#3  0x00000035f0c75f3e in malloc_printerr () from /lib64/libc.so.6
#4  0x00000035f0c78d8d in _int_free () from /lib64/libc.so.6
#5  0x00000035f409d565 in std::basic_string<char, std::char_traits<char>, std::allocator<char> >::assign(std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) () from /usr/lib64/libstdc++.so.6
#6  0x000000000046328f in operator= (this=0x7f2ce8035030) at /opt/rh/devtoolset-3/root/usr/include/c++/4.9.1/bits/basic_string.h:555
#7  FdEntity::UpdateMtime (this=0x7f2ce8035030) at fdcache.cpp:1053
#8  0x000000000041249d in s3fs_flush (path=0x7f2cfc008420 "**Removed for security reason**", fi=0x7f2d0d7fdd60) at s3fs.cpp:2203
#9  0x0000003dbb00d24c in ?? () from /lib64/libfuse.so.2
#10 0x0000003dbb00d3cf in ?? () from /lib64/libfuse.so.2
#11 0x0000003dbb014de6 in ?? () from /lib64/libfuse.so.2
#12 0x0000003dbb0120ef in ?? () from /lib64/libfuse.so.2
#13 0x00000035f1007aa1 in start_thread () from /lib64/libpthread.so.0
#14 0x00000035f0ce8aad in clone () from /lib64/libc.so.6

