### PR TITLE
add disk space reservation

### DIFF
--- a/doc/man/s3fs.1
+++ b/doc/man/s3fs.1
@@ -183,7 +183,7 @@ number of one part size in multipart uploading request.
 The default size is 10MB(10485760byte), minimum value is 5MB(5242880byte).
 Specify number of MB and over 5(MB).
 .TP
-\fB\-o\fR ensure_diskfree(default the same as multipart_size value)
+\fB\-o\fR ensure_diskfree(default 0)
 sets MB to ensure disk free space. This option means the threshold of free space size on disk which is used for the cache file by s3fs.
 s3fs makes file for downloading, and uploading and caching files.
 If the disk free space is smaller than this value, s3fs do not use diskspace as possible in exchange for the performance.

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -144,6 +144,7 @@ class FdEntity
 
     void Close(void);
     bool IsOpen(void) const { return (-1 != fd); }
+    bool IsMultiOpened(void) const { return refcnt > 1; }
     int Open(headers_t* pmeta = NULL, ssize_t size = -1, time_t time = -1, bool no_fd_lock_wait = false);
     bool OpenAndLoadAll(headers_t* pmeta = NULL, size_t* size = NULL, bool force_load = false);
     int Dup(bool no_fd_lock_wait = false);
@@ -173,6 +174,7 @@ class FdEntity
     ssize_t Read(char* bytes, off_t start, size_t size, bool force_load = false);
     ssize_t Write(const char* bytes, off_t start, size_t size);
 
+    bool ReserveDiskSpace(size_t size);
     void CleanupCache();
 };
 typedef std::map<std::string, class FdEntity*> fdent_map_t;   // key=path, value=FdEntity*
@@ -186,6 +188,7 @@ class FdManager
     static FdManager       singleton;
     static pthread_mutex_t fd_manager_lock;
     static pthread_mutex_t cache_cleanup_lock;
+    static pthread_mutex_t reserved_diskspace_lock;
     static bool            is_lock_init;
     static std::string     cache_dir;
     static bool            check_cache_dir_exist;
@@ -217,8 +220,9 @@ class FdManager
 
     static size_t GetEnsureFreeDiskSpace(void) { return FdManager::free_disk_space; }
     static size_t SetEnsureFreeDiskSpace(size_t size);
-    static size_t InitEnsureFreeDiskSpace(void) { return SetEnsureFreeDiskSpace(0); }
     static bool IsSafeDiskSpace(const char* path, size_t size);
+    static void FreeReservedDiskSpace(size_t size);
+    bool ReserveDiskSpace(size_t size);
 
     FdEntity* GetFdEntity(const char* path, int existfd = -1);
     FdEntity* Open(const char* path, headers_t* pmeta = NULL, ssize_t size = -1, time_t time = -1, bool force_tmpfile = false, bool is_create = true, bool no_fd_lock_wait = false);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4671,8 +4671,6 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
         S3FS_PRN_EXIT("multipart_size option must be at least 5 MB.");
         return -1;
       }
-      // update ensure free disk space if it is not set.
-      FdManager::InitEnsureFreeDiskSpace();
       return 0;
     }
     if(0 == STR2NCMP(arg, "ensure_diskfree=")){
@@ -5034,8 +5032,7 @@ int main(int argc, char* argv[])
   }
 
   // check free disk space
-  FdManager::InitEnsureFreeDiskSpace();
-  if(!FdManager::IsSafeDiskSpace(NULL, S3fsCurl::GetMultipartSize())){
+  if(!FdManager::IsSafeDiskSpace(NULL, S3fsCurl::GetMultipartSize() * S3fsCurl::GetMaxParallelCount())){
     S3FS_PRN_EXIT("There is no enough disk space for used as cache(or temporary) directory by s3fs.");
     exit(EXIT_FAILURE);
   }

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -1125,7 +1125,7 @@ void show_help (void)
     "   multipart_size (default=\"10\")\n"
     "      - part size, in MB, for each multipart request.\n"
     "\n"
-    "   ensure_diskfree (default same multipart_size value)\n"
+    "   ensure_diskfree (default 0)\n"
     "      - sets MB to ensure disk free space. s3fs makes file for\n"
     "        downloading, uploading and caching files. If the disk free\n"
     "        space is smaller than this value, s3fs do not use diskspace\n"


### PR DESCRIPTION
### Details
This PR includes the following changes:

- Atomically reserving disk space instead of calling IsSafeDiskSpace before Load, and freeing reserved disk-space when Load completes. This is to avoid a race where two or more threads think they have enough disk space to download, but they don't account for each other. If not enough space exists on disk to reserve, then two methods are tried to free up disk space: freeing disk space from the current fd, followed by trying other fd's (when using -o use_cache).
- Changed EnsureDiskFree setting to be 0 for default (since we have the disk space reservation, we no longer need to default it to MaxParallelCount * MultipartSize).
- Added some debug printings to cache cleanup methods.
- Changed cache cleanup method to skip opened fd's (i.e. to clean from the cache only files which are not currently opened).

@ggtakec @gaul would appreciate your review.