### PR TITLE
Added Cygwin build options

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,11 @@ dnl ----------------------------------------------
 dnl For OSX
 dnl ----------------------------------------------
 case "$target" in
+   *-cygwin* )
+      # Do something specific for windows using winfsp
+      CXXFLAGS="$CXXFLAGS -D_GNU_SOURCE=1"
+      min_fuse_version=2.8
+      ;;
    *-darwin* )
       # Do something specific for mac
       min_fuse_version=2.7.3


### PR DESCRIPTION
### Relevant Issue (if applicable)
Doesn't build on Cygwin

### Details
`libfuse` is not available on Windows.
When you try to compile `libfuse` on Windows the result is:
```
Error encountered: libfuse does not support Windows.
Take a look at http://www.secfs.net/winfsp/ instead
```

WinFSP provides an compatibility layer to FUSE using version number `2.8`, this is why I added a specific target configuration for Cygwin to `configure.ac`. Also, to use the non-standard calls used in the `s3fs` code, the `_GNU_SOURCE` flag is required.

Last change is the addition of a `.gitattributes` file. Indeed, `autogen.sh` must be in Unix format to be executed and when using Windows the file is changed to Windows line endings. hence the addition.

Next step is to have a working example for it. I wasn't able to mount a S3 bucket.
I started a discussion here: https://groups.google.com/forum/#!topic/winfsp/xXe6M_MoW8w

I someone care to help :)
Thanks!
