### PR TITLE
reduce lock contention on file open

### DIFF
--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -146,7 +146,7 @@ class FdEntity
     bool IsOpen(void) const { return (-1 != fd); }
     int Open(headers_t* pmeta = NULL, ssize_t size = -1, time_t time = -1, bool no_fd_lock_wait = false);
     bool OpenAndLoadAll(headers_t* pmeta = NULL, size_t* size = NULL, bool force_load = false);
-    int Dup(bool no_fd_lock_wait = false);
+    int Dup();
 
     const char* GetPath(void) const { return path.c_str(); }
     void SetPath(const std::string &newpath) { path = newpath; }


### PR DESCRIPTION
### Details
I found that when using use_cache and opening multiple files in parallel, you get a lock bottleneck on fd_manager_lock.

To improve the performance, I made two changes:
1. Change OpenMirrorFile to use urandom instead of time(), in order to avoid parallel threads creating mirror files of the same name. Additionally, instead of calling time() in a for loop (time changes only every 1 second), just increment the seed.
2. In FdManager::Open, release fd_manager_lock after fdent is found/created.

Prior to this PR, parallel open requests were served sequentially, with a 1s delay between each (because of the mirror file creation loop being stuck).
With this PR, this delays were gone, and parallel open are returning immediately.
