### PR TITLE
don't fail multirequest on single thread error

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3920,8 +3920,7 @@ int S3fsMultiCurl::MultiPerform(void)
     } else {
       int int_retval = (int)(intptr_t)(retval);
       if (int_retval) {
-        S3FS_PRN_ERR("thread failed - rc(%d)", int_retval);
-        success = false;
+        S3FS_PRN_WARN("thread failed - rc(%d)", int_retval);
       }
     }
   }


### PR DESCRIPTION
### Details
We don't need to return -EIO on MultiRequest when one or more curl threads returns an error.
The error path is handled by MultiRead which uses retries.