### PR TITLE
Fixed Travis CI error about cppcheck - #713

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,11 +32,12 @@ cppcheck:
 	cppcheck --quiet --error-exitcode=1 \
             --inline-suppr \
             --std=c++03 \
+            -D HAVE_ATTR_XATTR_H \
+            -D HAVE_SYS_EXTATTR_H \
+            -D HAVE_MALLOC_TRIM \
             -U CURLE_PEER_FAILED_VERIFICATION \
             -U P_tmpdir \
             -U ENOATTR \
-            --enable=all \
+            --enable=warning,style,information,missingInclude \
             --suppress=missingIncludeSystem \
-            --suppress=unusedFunction \
-            --suppress=variableScope \
             src/ test/

--- a/src/addhead.cpp
+++ b/src/addhead.cpp
@@ -130,8 +130,8 @@ bool AdditionalHeader::Load(const char* file)
       // compile
       regex_t*  preg = new regex_t;
       int       result;
-      char      errbuf[256];
       if(0 != (result = regcomp(preg, key.c_str(), REG_EXTENDED | REG_NOSUB))){ // we do not need matching info
+        char    errbuf[256];
         regerror(result, preg, errbuf, sizeof(errbuf));
         S3FS_PRN_ERR("failed to compile regex from %s key by %s.", key.c_str(), errbuf);
         delete preg;

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -226,8 +226,8 @@ bool BodyData::Append(void* ptr, size_t bytes)
 
 const char* BodyData::str(void) const
 {
-  static const char* strnull = "";
   if(!text){
+    static const char* strnull = "";
     return strnull;
   }
   return text;
@@ -697,10 +697,8 @@ bool S3fsCurl::LocateBundle(void)
   // See if environment variable CURL_CA_BUNDLE is set
   // if so, check it, if it is a good path, then set the
   // curl_ca_bundle variable to it
-  char *CURL_CA_BUNDLE; 
-
   if(0 == S3fsCurl::curl_ca_bundle.size()){
-    CURL_CA_BUNDLE = getenv("CURL_CA_BUNDLE");
+    char* CURL_CA_BUNDLE = getenv("CURL_CA_BUNDLE");
     if(CURL_CA_BUNDLE != NULL)  {
       // check for existence and readability of the file
       ifstream BF(CURL_CA_BUNDLE);
@@ -1620,16 +1618,12 @@ int S3fsCurl::CurlDebugFunc(CURL* hcurl, curl_infotype type, char* data, size_t 
       break;
     case CURLINFO_HEADER_IN:
     case CURLINFO_HEADER_OUT:
-      size_t length, remaining;
-      int newline;
-      char* p;
-
       // Print each line individually for tidy output
-      remaining = size;
-      p = data;
+      size_t remaining = size;
+      char*  p         = data;
       do {
-        char* eol = (char*)memchr(p, '\n', remaining);
-        newline = 0;
+        char* eol     = (char*)memchr(p, '\n', remaining);
+        int   newline = 0;
         if (eol == NULL) {
           eol = (char*)memchr(p, '\r', remaining);
         } else if (eol > p && *(eol - 1) == '\r') {
@@ -1639,7 +1633,7 @@ int S3fsCurl::CurlDebugFunc(CURL* hcurl, curl_infotype type, char* data, size_t 
           newline++;
           eol++;
         }
-        length = eol - p;
+        size_t length = eol - p;
         S3FS_PRN_CURL("%c %.*s", CURLINFO_HEADER_IN == type ? '<' : '>', (int)length - newline, p);
         remaining -= length;
         p = eol;
@@ -2867,7 +2861,6 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
 {
   struct stat st;
   FILE*       file = NULL;
-  int         fd2;
 
   S3FS_PRN_INFO3("[tpath=%s]", SAFESTRPTR(tpath));
 
@@ -2876,6 +2869,7 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
   }
   if(-1 != fd){
     // duplicate fd
+    int fd2;
     if(-1 == (fd2 = dup(fd)) || -1 == fstat(fd2, &st) || 0 != lseek(fd2, 0, SEEK_SET) || NULL == (file = fdopen(fd2, "rb"))){
       S3FS_PRN_ERR("Could not duplicate file descriptor(errno=%d)", errno);
       if(-1 != fd2){
@@ -3994,8 +3988,6 @@ int S3fsMultiCurl::MultiRead(void)
 
 int S3fsMultiCurl::Request(void)
 {
-  int result;
-
   S3FS_PRN_INFO3("[count=%zu]", cMap_all.size());
 
   // Make request list.
@@ -4005,6 +3997,7 @@ int S3fsMultiCurl::Request(void)
   //
   while(!cMap_all.empty()){
     // set curl handle to multi handle
+    int                     result;
     int                     cnt;
     s3fscurlmap_t::iterator iter;
     for(cnt = 0, iter = cMap_all.begin(); cnt < S3fsMultiCurl::max_multireq && iter != cMap_all.end(); cMap_all.erase(iter++), cnt++){

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -4071,7 +4071,7 @@ struct curl_slist* curl_slist_sort_insert(struct curl_slist* list, const char* k
   if(!key){
     return list;
   }
-  if(NULL == (new_item = (struct curl_slist*)malloc(sizeof(struct curl_slist)))){
+  if(NULL == (new_item = reinterpret_cast<struct curl_slist*>(malloc(sizeof(struct curl_slist))))){
     return list;
   }
 

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2980,7 +2980,7 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
 
 int S3fsCurl::PreGetObjectRequest(const char* tpath, int fd, off_t start, ssize_t size, sse_type_t ssetype, string& ssevalue)
 {
-  S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%zd]", SAFESTRPTR(tpath), (intmax_t)start, size);
+  S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%jd]", SAFESTRPTR(tpath), (intmax_t)start, (intmax_t)size);
 
   if(!tpath || -1 == fd || 0 > start || 0 > size){
     return -1;
@@ -3040,7 +3040,7 @@ int S3fsCurl::GetObjectRequest(const char* tpath, int fd, off_t start, ssize_t s
 {
   int result;
 
-  S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%zd]", SAFESTRPTR(tpath), (intmax_t)start, size);
+  S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%jd]", SAFESTRPTR(tpath), (intmax_t)start, (intmax_t)size);
 
   if(!tpath){
     return -1;
@@ -3418,7 +3418,7 @@ int S3fsCurl::AbortMultipartUpload(const char* tpath, string& upload_id)
 
 int S3fsCurl::UploadMultipartPostSetup(const char* tpath, int part_num, const string& upload_id)
 {
-  S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%zd][part=%d]", SAFESTRPTR(tpath), (intmax_t)(partdata.startpos), partdata.size, part_num);
+  S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%jd][part=%d]", SAFESTRPTR(tpath), (intmax_t)(partdata.startpos), (intmax_t)(partdata.size), part_num);
 
   if(-1 == partdata.fd || -1 == partdata.startpos || -1 == partdata.size){
     return -1;
@@ -3492,7 +3492,7 @@ int S3fsCurl::UploadMultipartPostRequest(const char* tpath, int part_num, const 
 {
   int result;
 
-  S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%zd][part=%d]", SAFESTRPTR(tpath), (intmax_t)(partdata.startpos), partdata.size, part_num);
+  S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%jd][part=%d]", SAFESTRPTR(tpath), (intmax_t)(partdata.startpos), (intmax_t)(partdata.size), part_num);
 
   // setup
   if(0 != (result = S3fsCurl::UploadMultipartPostSetup(tpath, part_num, upload_id))){

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1618,12 +1618,15 @@ int S3fsCurl::CurlDebugFunc(CURL* hcurl, curl_infotype type, char* data, size_t 
       break;
     case CURLINFO_HEADER_IN:
     case CURLINFO_HEADER_OUT:
+      size_t remaining;
+      char* p;
+
       // Print each line individually for tidy output
-      size_t remaining = size;
-      char*  p         = data;
+      remaining = size;
+      p = data;
       do {
-        char* eol     = (char*)memchr(p, '\n', remaining);
-        int   newline = 0;
+        char* eol = (char*)memchr(p, '\n', remaining);
+        int newline = 0;
         if (eol == NULL) {
           eol = (char*)memchr(p, '\r', remaining);
         } else if (eol > p && *(eol - 1) == '\r') {

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1571,7 +1571,6 @@ ssize_t FdEntity::Read(char* bytes, off_t start, size_t size, bool force_load)
     pagelist.SetPageLoadedStatus(start, size, false);
   }
 
-  int     result;
   ssize_t rsize;
 
   // check disk space
@@ -1605,6 +1604,7 @@ ssize_t FdEntity::Read(char* bytes, off_t start, size_t size, bool force_load)
       }
     }
     // Loading
+    int result;
     if(0 < size && 0 != (result = Load(start, load_size))){
       S3FS_PRN_ERR("could not download. start(%jd), size(%zu), errno(%d)", (intmax_t)start, size, result);
       return -EIO;

--- a/src/gnutls_auth.cpp
+++ b/src/gnutls_auth.cpp
@@ -107,7 +107,7 @@ bool s3fs_HMAC(const void* key, size_t keylen, const unsigned char* data, size_t
     return false;
   }
 
-  if(NULL == (*digest = (unsigned char*)malloc(SHA1_DIGEST_SIZE))){
+  if(NULL == (*digest = reinterpret_cast<unsigned char*>(malloc(SHA1_DIGEST_SIZE)))){
     return false;
   }
 
@@ -126,7 +126,7 @@ bool s3fs_HMAC256(const void* key, size_t keylen, const unsigned char* data, siz
     return false;
   }
 
-  if(NULL == (*digest = (unsigned char*)malloc(SHA256_DIGEST_SIZE))){
+  if(NULL == (*digest = reinterpret_cast<unsigned char*>(malloc(SHA256_DIGEST_SIZE)))){
     return false;
   }
 
@@ -150,7 +150,7 @@ bool s3fs_HMAC(const void* key, size_t keylen, const unsigned char* data, size_t
   if(0 == (*digestlen = gnutls_hmac_get_len(GNUTLS_MAC_SHA1))){
     return false;
   }
-  if(NULL == (*digest = (unsigned char*)malloc(*digestlen + 1))){
+  if(NULL == (*digest = reinterpret_cast<unsigned char*>(malloc(*digestlen + 1)))){
     return false;
   }
   if(0 > gnutls_hmac_fast(GNUTLS_MAC_SHA1, key, keylen, data, datalen, *digest)){
@@ -170,7 +170,7 @@ bool s3fs_HMAC256(const void* key, size_t keylen, const unsigned char* data, siz
   if(0 == (*digestlen = gnutls_hmac_get_len(GNUTLS_MAC_SHA256))){
     return false;
   }
-  if(NULL == (*digest = (unsigned char*)malloc(*digestlen + 1))){
+  if(NULL == (*digest = reinterpret_cast<unsigned char*>(malloc(*digestlen + 1)))){
     return false;
   }
   if(0 > gnutls_hmac_fast(GNUTLS_MAC_SHA256, key, keylen, data, datalen, *digest)){
@@ -221,7 +221,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
     md5_update(&ctx_md5, bytes, buf);
     memset(buf, 0, 512);
   }
-  if(NULL == (result = (unsigned char*)malloc(get_md5_digest_length()))){
+  if(NULL == (result = reinterpret_cast<unsigned char*>(malloc(get_md5_digest_length())))){
     return NULL;
   }
   md5_digest(&ctx_md5, get_md5_digest_length(), result);
@@ -277,7 +277,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
     gcry_md_write(ctx_md5, buf, bytes);
     memset(buf, 0, 512);
   }
-  if(NULL == (result = (unsigned char*)malloc(get_md5_digest_length()))){
+  if(NULL == (result = reinterpret_cast<unsigned char*>(malloc(get_md5_digest_length())))){
     return NULL;
   }
   memcpy(result, gcry_md_read(ctx_md5, 0), get_md5_digest_length());
@@ -346,7 +346,7 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
     sha256_update(&ctx_sha256, bytes, buf);
     memset(buf, 0, 512);
   }
-  if(NULL == (result = (unsigned char*)malloc(get_sha256_digest_length()))){
+  if(NULL == (result = reinterpret_cast<unsigned char*>(malloc(get_sha256_digest_length())))){
     return NULL;
   }
   sha256_digest(&ctx_sha256, get_sha256_digest_length(), result);
@@ -423,7 +423,7 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
     gcry_md_write(ctx_sha256, buf, bytes);
     memset(buf, 0, 512);
   }
-  if(NULL == (result = (unsigned char*)malloc(get_sha256_digest_length()))){
+  if(NULL == (result = reinterpret_cast<unsigned char*>(malloc(get_sha256_digest_length())))){
     return NULL;
   }
   memcpy(result, gcry_md_read(ctx_sha256, 0), get_sha256_digest_length());

--- a/src/nss_auth.cpp
+++ b/src/nss_auth.cpp
@@ -124,7 +124,7 @@ static bool s3fs_HMAC_RAW(const void* key, size_t keylen, const unsigned char* d
   PK11_FreeSymKey(pKey);
   PK11_FreeSlot(Slot);
 
-  if(NULL == (*digest = (unsigned char*)malloc(*digestlen))){
+  if(NULL == (*digest = reinterpret_cast<unsigned char*>(malloc(*digestlen)))){
     return false;
   }
   memcpy(*digest, tmpdigest, *digestlen);
@@ -188,7 +188,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
     PK11_DigestOp(md5ctx, buf, bytes);
     memset(buf, 0, 512);
   }
-  if(NULL == (result = (unsigned char*)malloc(get_md5_digest_length()))){
+  if(NULL == (result = reinterpret_cast<unsigned char*>(malloc(get_md5_digest_length())))){
     PK11_DestroyContext(md5ctx, PR_TRUE);
     return NULL;
   }
@@ -269,7 +269,7 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
     PK11_DigestOp(sha256ctx, buf, bytes);
     memset(buf, 0, 512);
   }
-  if(NULL == (result = (unsigned char*)malloc(get_sha256_digest_length()))){
+  if(NULL == (result = reinterpret_cast<unsigned char*>(malloc(get_sha256_digest_length())))){
     PK11_DestroyContext(sha256ctx, PR_TRUE);
     return NULL;
   }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2463,7 +2463,6 @@ static int s3fs_readdir(const char* path, void* buf, fuse_fill_dir_t filler, off
 
 static int list_bucket(const char* path, S3ObjList& head, const char* delimiter, bool check_content_only)
 {
-  int       result; 
   string    s3_realpath;
   string    query_delimiter;;
   string    query_prefix;;
@@ -2472,7 +2471,6 @@ static int list_bucket(const char* path, S3ObjList& head, const char* delimiter,
   bool      truncated = true;
   S3fsCurl  s3fscurl;
   xmlDocPtr doc;
-  BodyData* body;
 
   S3FS_PRN_INFO1("[path=%s]", path);
 
@@ -2508,11 +2506,12 @@ static int list_bucket(const char* path, S3ObjList& head, const char* delimiter,
     each_query += query_prefix;
 
     // request
+    int result; 
     if(0 != (result = s3fscurl.ListBucketRequest(path, each_query.c_str()))){
       S3FS_PRN_ERR("ListBucketRequest returns with error.");
       return result;
     }
-    body = s3fscurl.GetBodyData();
+    BodyData* body = s3fscurl.GetBodyData();
 
     // xmlDocPtr
     if(NULL == (doc = xmlReadMemory(body->str(), static_cast<int>(body->size()), "", NULL, 0))){
@@ -3847,7 +3846,6 @@ static int parse_passwd_file(bucketkvmap_t& resmap)
 {
   string line;
   size_t first_pos;
-  size_t last_pos;
   readline_t linelist;
   readline_t::iterator iter;
 
@@ -3902,8 +3900,8 @@ static int parse_passwd_file(bucketkvmap_t& resmap)
 
   // read ':' type
   for(iter = linelist.begin(); iter != linelist.end(); ++iter){
-    first_pos = iter->find_first_of(":");
-    last_pos  = iter->find_last_of(":");
+    first_pos       = iter->find_first_of(":");
+    size_t last_pos = iter->find_last_of(":");
     if(first_pos == string::npos){
       continue;
     }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -892,7 +892,7 @@ static int s3fs_readlink(const char* path, char* buf, size_t size)
   // Read
   ssize_t ressize;
   if(0 > (ressize = ent->Read(buf, 0, readsize))){
-    S3FS_PRN_ERR("could not read file(file=%s, errno=%zd)", path, ressize);
+    S3FS_PRN_ERR("could not read file(file=%s, ressize=%jd)", path, (intmax_t)ressize);
     FdManager::get()->Close(ent);
     return static_cast<int>(ressize);
   }
@@ -2138,7 +2138,7 @@ static int s3fs_read(const char* path, char* buf, size_t size, off_t offset, str
   }
 
   if(0 > (res = ent->Read(buf, offset, size, false))){
-    S3FS_PRN_WARN("failed to read file(%s). result=%zd", path, res);
+    S3FS_PRN_WARN("failed to read file(%s). result=%jd", path, (intmax_t)res);
   }
   FdManager::get()->Close(ent);
 
@@ -2160,7 +2160,7 @@ static int s3fs_write(const char* path, const char* buf, size_t size, off_t offs
     S3FS_PRN_WARN("different fd(%d - %llu)", ent->GetFd(), (unsigned long long)(fi->fh));
   }
   if(0 > (res = ent->Write(buf, offset, size))){
-    S3FS_PRN_WARN("failed to write file(%s). result=%zd", path, res);
+    S3FS_PRN_WARN("failed to write file(%s). result=%jd", path, (intmax_t)res);
   }
   FdManager::get()->Close(ent);
 
@@ -4860,9 +4860,8 @@ int main(int argc, char* argv[])
   LIBXML_TEST_VERSION
 
   // get program name - emulate basename
-  size_t found = string::npos;
   program_name.assign(argv[0]);
-  found = program_name.find_last_of("/");
+  size_t found = program_name.find_last_of("/");
   if(found != string::npos){
     program_name.replace(0, found+1, "");
   }

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -303,7 +303,7 @@ char* s3fs_base64(const unsigned char* input, size_t length)
   if(!input || 0 >= length){
     return NULL;
   }
-  if(NULL == (result = (char*)malloc((((length / 3) + 1) * 4 + 1) * sizeof(char)))){
+  if(NULL == (result = reinterpret_cast<char*>(malloc((((length / 3) + 1) * 4 + 1) * sizeof(char))))){
     return NULL; // ENOMEM
   }
 
@@ -353,7 +353,7 @@ unsigned char* s3fs_decode64(const char* input, size_t* plength)
   if(!input || 0 == strlen(input) || !plength){
     return NULL;
   }
-  if(NULL == (result = (unsigned char*)malloc((strlen(input) + 1)))){
+  if(NULL == (result = reinterpret_cast<unsigned char*>(malloc((strlen(input) + 1))))){
     return NULL; // ENOMEM
   }
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#713

### Details
The version of cppcheck prepared by TravisCI differs between OSX and ubuntu.
OSX was 1.82, and the behavior of unusedFunction was different from 1.63.
On OSX, exitcode = 0 does not become 0 even if suppressing unusedFunction error using suppress option.
Since it can not be helped, I adjust the option so as not to check unusedFunction.
In addition, we modified the code for the variableScope error and deleted it from the suppress option.