### PR TITLE
cleanup curl handle state on retries

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1762,7 +1762,9 @@ bool S3fsCurl::DestroyCurlHandle(void)
 
   S3fsCurl::curl_times.erase(hCurl);
   S3fsCurl::curl_progress.erase(hCurl);
-  sCurlPool->ReturnHandler(hCurl);
+  if(retry_count == 0){
+    sCurlPool->ReturnHandler(hCurl);
+  }
   hCurl = NULL;
   ClearInternalData();
 
@@ -1872,7 +1874,12 @@ bool S3fsCurl::RemakeHandle(void)
   partdata.size      = b_partdata_size;
 
   // reset handle
+  curl_easy_cleanup(hCurl);
+  hCurl = curl_easy_init();
   ResetHandle();
+  // disable ssl cache, so that a new session will be created
+  curl_easy_setopt(hCurl, CURLOPT_SSL_SESSIONID_CACHE, 0);
+  curl_easy_setopt(hCurl, CURLOPT_SHARE, NULL);
 
   // set options
   switch(type){


### PR DESCRIPTION
### Details

I encountered this re-occurring issue, popping once every few days of running an s3fs mountpoint:
A curl request failed with a readwrite_timeout.
S3fs retries the request -> gets curl error 35 CURLE_SSL_CONNECT_ERROR.
The same request is retried again -> same error CURLE_SSL_CONNECT_ERROR.
While the retries of this request fail, other requests do complete successfully.
This lead me to think that the CURL handle of the retry connection is re-using state (specifically SSL state) from the old (failing) connection.
I made this PR to cleanup the SSL state (or any other state) of the retry handle, by creating a fresh handle, with curl caches disabled (only for the retry request).

I tested with this patch and found that the issue is resolved.
@ggtakec would appreciate your approval.
