### PR TITLE
don't fail mkdir when directory exists

### DIFF
--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -621,7 +621,7 @@ int mkdirp(const string& path, mode_t mode)
         return EPERM;
       }
     }else{
-      if(0 != mkdir(base.c_str(), mode)){
+      if(0 != mkdir(base.c_str(), mode) && errno != EEXIST){
         return errno;
      }
     }


### PR DESCRIPTION
### Details

I came across the following error:

s3fs[11960]: [/mys3fsmount]fdcache.cpp:MakeCachePath(1876): failed to create dir((null)) by errno(17).
s3fs[11960]: [/mys3fsmount]fdcache.cpp:OpenMirrorFile(752): could not make bup cache directory path or create it.
s3fs[11960]: [/mys3fsmount]fdcache.cpp:Open(890): failed to open mirror file linked cache file(/s3fscache/ozeri/testfile).

I'm guessing it happened because of a race between two threads that tried to create the ".mirror" directory inside the cache.

To fix it, I added a check to ignore the case where the directory already exists.