### PR TITLE
fix xpath selector in bucket listing

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2724,7 +2724,7 @@ static xmlChar* get_base_exp(xmlDocPtr doc, const char* exp)
 {
   xmlXPathObjectPtr  marker_xp;
   string xmlnsurl;
-  string exp_string = "//";
+  string exp_string;
 
   if(!doc){
     return NULL;
@@ -2733,8 +2733,11 @@ static xmlChar* get_base_exp(xmlDocPtr doc, const char* exp)
 
   if(!noxmlns && GetXmlNsUrl(doc, xmlnsurl)){
     xmlXPathRegisterNs(ctx, (xmlChar*)"s3", (xmlChar*)xmlnsurl.c_str());
-    exp_string += "s3:";
+    exp_string = "/s3:ListBucketResult/s3:";
+  } else {
+    exp_string = "/ListBucketResult/";
   }
+  
   exp_string += exp;
 
   if(NULL == (marker_xp = xmlXPathEvalExpression((xmlChar *)exp_string.c_str(), ctx))){


### PR DESCRIPTION
the original implementation in get_base_exp() depends on the order of xml return from the server.
patriotically, when listing a directory with sub directory(s), the xml document response contains more than 2 <Prefix> nodes(some of them are in <CommonPrefixes> node).
the source code arbitrarily select the first one in the documents (nodes->nodeTab[0]->xmlChildrenNode), which is OK for aws.
however, some s3 compatible service return the list-bucket result in different order, leading the s3fs to a wrong behavior
