### PR TITLE
Validate the URL format for http/https

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4740,7 +4740,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
          length = host.length();
       }
       // Check url for http / https protocol string
-      if((host.find("https://") != 0) && (host.find("http://") != 0)) {
+      if((host.compare(0, 8, "https://") != 0) && (host.compare(0, 7, "http://") != 0)) {
          S3FS_PRN_EXIT("option url has invalid format, missing http / https protocol");
          return -1;
       }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4739,6 +4739,11 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
          found  = host.find_last_of('/');
          length = host.length();
       }
+      // Check url for http / https protocol string
+      if((host.find("https://") != 0) && (host.find("http://") != 0)) {
+         S3FS_PRN_EXIT("option url has invalid format, missing http / https protocol");
+         return -1;
+      }
       return 0;
     }
     if(0 == strcmp(arg, "sigv2")){


### PR DESCRIPTION
### Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

### Details
_Please describe the details of PullRequest._
When the URL is specified without protocol detail like `s3-api.us-geo.objectstorage.softlayer.net`,
the `s3fs` process is silently terminating with exit code zero.
The code change validate the URL and throws error message if `http` / `https` is missing.