### PR TITLE
Added reset curl handle when returning to handle pool

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -304,6 +304,7 @@ void CurlHandlerPool::ReturnHandler(CURL* h)
   pthread_mutex_lock(&mLock);
   if (mIndex < mMaxHandlers - 1) {
     mHandlers[++mIndex] = h;
+    curl_easy_reset(h);
     needCleanup = false;
     S3FS_PRN_DBG("Return handler to pool: %d", mIndex);
   }


### PR DESCRIPTION
### Relevant Issue (if applicable)
#748

### Details
This is a fix as a precautionary measure for resetting curl handle, it does not change something.
