### PR TITLE
Optimize defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Installation
 On Ubuntu 14.04:
 
 ```
-sudo apt-get install automake autotools-dev fuse g++ git libcurl4-gnutls-dev libfuse-dev libssl-dev libxml2-dev make pkg-config
+sudo apt-get install automake autotools-dev fuse g++ git libcurl4-openssl-dev libfuse-dev libssl-dev libxml2-dev make pkg-config
 ```
 
 On CentOS 7:

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -142,7 +142,7 @@ pthread_mutex_t StatCache::stat_cache_lock;
 //-------------------------------------------------------------------
 // Constructor/Destructor
 //-------------------------------------------------------------------
-StatCache::StatCache() : IsExpireTime(false), IsExpireIntervalType(false), ExpireTime(0), CacheSize(1000), IsCacheNoObject(false)
+StatCache::StatCache() : IsExpireTime(false), IsExpireIntervalType(false), ExpireTime(0), CacheSize(100000), IsCacheNoObject(false)
 {
   if(this == StatCache::getStatCacheData()){
     stat_cache.clear();

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -120,6 +120,7 @@ static bool nocopyapi             = false;
 static bool norenameapi           = false;
 static bool nonempty              = false;
 static bool allow_other           = false;
+static bool fuse_read_mode_set    = false;
 static bool load_iamrole          = false;
 static uid_t s3fs_uid             = 0;
 static gid_t s3fs_gid             = 0;
@@ -4355,6 +4356,10 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       allow_other = true;
       return 1; // continue for fuse option
     }
+    if(0 == strcmp(arg, "sync_read") || 0 == strcmp(arg, "async_read")){
+      fuse_read_mode_set = true;
+      return 1; // continue for fuse option
+    }
     if(0 == STR2NCMP(arg, "mp_umask=")){
       mp_umask = strtol(strchr(arg, '=') + sizeof(char), NULL, 0);
       mp_umask &= (S_IRWXU | S_IRWXG | S_IRWXO);
@@ -4922,6 +4927,15 @@ int main(int argc, char* argv[])
   // should have been set
   struct fuse_args custom_args = FUSE_ARGS_INIT(argc, argv);
   if(0 != fuse_opt_parse(&custom_args, NULL, NULL, my_fuse_opt_proc)){
+    exit(EXIT_FAILURE);
+  }
+
+  // s3fs read is sync (fdent_lock is locked while reading)
+  // FUSE is async read by default
+  // switch FUSE to sync read to avoid hitting FUSE's max_background limit
+  // as well as to make sure that big read requests that are splitted by the kernel
+  // are always read in-order
+  if (!fuse_read_mode_set && 0 != fuse_opt_add_arg(&custom_args, "-osync_read")){
     exit(EXIT_FAILURE);
   }
 


### PR DESCRIPTION
### Details

This PR includes 3 changes to default s3fs configuration, in order to boost performance:

1. Change readme to recommened OpenSSL instead of gnuTLS (I tested openssl to be much faster)
2. Increase the stat cache size from 1000 to 100000. This greatly reduces the number of HEAD requests made by s3fs, as many use-cases list buckets of more than 1000 objects.
Each entry in the cache takes upto 0.5KB, so a full cache will take upto 0.5KB*100000 = 50MB of memory.
3. set FUSE sync_read by default (instead of the default async_read).
   This can increase performance as async_read causes the creation of background threads that can create a bottleneck when reaching FUSE's max_background. On the other hand, you don't get the benefit when using async_read since s3fs allows only a single thread to read from a file at a time.
I verified that this patch increases the performance in the case of multiple threads reading different files at the same time.

@gaul @ggtakec Thanks in advance!