### PR TITLE
cleanup curl handles before curl share

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -416,10 +416,10 @@ bool S3fsCurl::DestroyS3fsCurl(void)
   if(!S3fsCurl::DestroyCryptMutex()){
     result = false;
   }
-  if(!S3fsCurl::DestroyShareCurl()){
+  if(!sCurlPool->Destroy()){
     result = false;
   }
-  if (!sCurlPool->Destroy()) {
+  if(!S3fsCurl::DestroyShareCurl()){
     result = false;
   }
   if(!S3fsCurl::DestroyGlobalCurl()){


### PR DESCRIPTION
### Details

I noticed the following warning message repeatedly on my logs:

`s3fs.cpp:s3fs_destroy(3438): Could not release curl library`

I debugged it, and found that the reason is a failure in `CURLSHE_OK != curl_share_cleanup(S3fsCurl::hCurlShare)` inside `S3fsCurl::DestroyShareCurl`.

The libcurl [documentation](https://linux.die.net/man/3/libcurl-share) of curl shares says that you need to:
```
When you're done using the share, make sure that no easy handle is still using it, and call curl_share_cleanup(3) on the handle.
```

Currently, s3fs clean up curl handles AFTER the share is destroyed.
This PR fixes this problem, by switching the cleanup of curl handles to be BEFORE the cleanup of the curl share.
I verified that after this fix, the error mentioned above disappears.