### PR TITLE
Remove false multihead warnings

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -439,6 +439,7 @@ class S3fsCurl
     std::string GetBasePath(void) const { return base_path; }
     std::string GetSpacialSavedPath(void) const { return saved_path; }
     std::string GetUrl(void) const { return url; }
+    std::string GetOp(void) const { return op; }
     headers_t* GetResponseHeaders(void) { return &responseHeaders; }
     BodyData* GetBodyData(void) const { return bodydata; }
     BodyData* GetHeadData(void) const { return headdata; }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2572,7 +2572,7 @@ static int append_objects_from_xml_ex(const char* path, xmlDocPtr doc, xmlXPathC
     return -1;
   }
   if(xmlXPathNodeSetIsEmpty(contents_xp->nodesetval)){
-    S3FS_PRN_WARN("contents_xp->nodesetval is empty.");
+    S3FS_PRN_DBG("contents_xp->nodesetval is empty.");
     S3FS_XMLXPATHFREEOBJECT(contents_xp);
     return 0;
   }


### PR DESCRIPTION
### Details
I encountered a few false warning messages (when setting dbglevel=warn):

1. `s3fs.cpp:append_objects_from_xml_ex(2575): contents_xp->nodesetval is empty.
this happens whenever the XML listing does not contain either <Contents> or <CommonPrefixes>, which is very very common.

2. `curl.cpp:MultiRead(3956): failed a request(404: ...` and `curl.cpp:MultiPerform(3928): thread failed - rc(-2)`
These warnings appear whenever we get a 404 response on a HEAD request sent as part of `readdir_multi_head`. This can happen if the object is not yet updated in the bucket listing, or if the object is a CommonPrefix.

This PR removes those false warnings.
