### PR TITLE
Fixed memory leak

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -405,7 +405,7 @@ class S3fsCurl
 
     // methods
     bool CreateCurlHandle(bool force = false);
-    bool DestroyCurlHandle(void);
+    bool DestroyCurlHandle(bool force = false);
 
     bool LoadIAMRoleFromMetaData(void);
     bool AddSseRequestHead(sse_type_t ssetype, std::string& ssevalue, bool is_only_c, bool is_copy);

--- a/src/gnutls_auth.cpp
+++ b/src/gnutls_auth.cpp
@@ -272,12 +272,14 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
     }else if(-1 == bytes){
       // error
       S3FS_PRN_ERR("file read error(%d)", errno);
+      gcry_md_close(ctx_md5);
       return NULL;
     }
     gcry_md_write(ctx_md5, buf, bytes);
     memset(buf, 0, 512);
   }
   if(NULL == (result = reinterpret_cast<unsigned char*>(malloc(get_md5_digest_length())))){
+    gcry_md_close(ctx_md5);
     return NULL;
   }
   memcpy(result, gcry_md_read(ctx_md5, 0), get_md5_digest_length());
@@ -418,12 +420,14 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
     }else if(-1 == bytes){
       // error
       S3FS_PRN_ERR("file read error(%d)", errno);
+      gcry_md_close(ctx_sha256);
       return NULL;
     }
     gcry_md_write(ctx_sha256, buf, bytes);
     memset(buf, 0, 512);
   }
   if(NULL == (result = reinterpret_cast<unsigned char*>(malloc(get_sha256_digest_length())))){
+    gcry_md_close(ctx_sha256);
     return NULL;
   }
   memcpy(result, gcry_md_read(ctx_sha256, 0), get_sha256_digest_length());

--- a/src/nss_auth.cpp
+++ b/src/nss_auth.cpp
@@ -54,8 +54,12 @@ const char* s3fs_crypt_lib_name(void)
 //-------------------------------------------------------------------
 bool s3fs_init_global_ssl(void)
 {
-  NSS_Init(NULL);
-  NSS_NoDB_Init(NULL);
+  PR_Init(PR_USER_THREAD, PR_PRIORITY_NORMAL, 0);
+
+  if(SECSuccess != NSS_NoDB_Init(NULL)){
+    S3FS_PRN_ERR("Failed NSS_NoDB_Init call.");
+    return false;
+  }
   return true;
 }
 
@@ -183,6 +187,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
     }else if(-1 == bytes){
       // error
       S3FS_PRN_ERR("file read error(%d)", errno);
+      PK11_DestroyContext(md5ctx, PR_TRUE);
       return NULL;
     }
     PK11_DigestOp(md5ctx, buf, bytes);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#748 #340

### Details
Fixed the memory leak about #748(and #340)
- Reviewed the processing such as destruction related to CurlHandlerPool.
- Changed the initialization processing of the NSS library.
- Changed to execute the CURL library initialization and destruction processing mainly.  
There was a call to CURL for bucket check before calling fuse_main, then initialization/destruction of CURL in s3fs_init/s3fs_destroy was inappropriate.

