### PR TITLE
gnutls_auth: initialize libgcrypt

### DIFF
--- a/src/gnutls_auth.cpp
+++ b/src/gnutls_auth.cpp
@@ -74,6 +74,11 @@ bool s3fs_init_global_ssl(void)
   if(GNUTLS_E_SUCCESS != gnutls_global_init()){
     return false;
   }
+#ifndef USE_GNUTLS_NETTLE
+  if(NULL == gcry_check_version(NULL)){
+    return false;
+  }
+#endif	// USE_GNUTLS_NETTLE
   return true;
 }
 


### PR DESCRIPTION
Without this change, the following warning appears in the syslog/journal
during startup:

  Libgcrypt warning: missing initialization - please fix the application

From the [documentation][0]:

> The function `gcry_check_version` initializes some subsystems used by
> Libgcrypt and must be invoked before any other function in the
> library.

Fixes #524, which says:

> gnutls is initialized by gnutls_global_init() function and
> gcry_check_version() function for initializing libgcry is called from
> this gnutls_global_init().

I checked the gnutls source and it hasn't contained a call to
gcry_check_version() since the libgcrypt backend was removed in 2011
(commit 8116cdc8f131edd586dad3128ae35dd744cfc32f). In any case, the
gcry_check_version() documentation continues:

> It is important that these initialization steps are not done by a
> library but by the actual application.

so it would be incorrect for a library used by s3fs to initialize
libgcrypt.

[0]: https://www.gnupg.org/documentation/manuals/gcrypt/Initializing-the-library.html