### PR TITLE
Fixed an error by cppcheck on OSX

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1633,10 +1633,10 @@ int S3fsCurl::CurlDebugFunc(CURL* hcurl, curl_infotype type, char* data, size_t 
         int newline = 0;
         if (eol == NULL) {
           eol = (char*)memchr(p, '\r', remaining);
-        } else if (eol > p && *(eol - 1) == '\r') {
-          newline++;
-        }
-        if (eol != NULL) {
+        } else {
+          if (eol > p && *(eol - 1) == '\r') {
+            newline++;
+          }
           newline++;
           eol++;
         }


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
On OSX, build is failed by following a error by cppcheck, then it has been fixed.
```
[src/curl.cpp:1639] -> [src/curl.cpp:1643]: (warning) Either the condition 'eol!=NULL' is redundant or there is overflow in pointer subtraction.
```
