### PR TITLE
Log messages for 5xx and 4xx HTTP response code

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2063,6 +2063,7 @@ int S3fsCurl::RequestPerform(void)
           return 0;
         }
         if(500 <= LastResponseCode){
+          S3FS_PRN_ERR("HTTP response code = %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
           S3FS_PRN_INFO3("HTTP response code %ld", LastResponseCode);
           sleep(4);
           break; 
@@ -2071,21 +2072,25 @@ int S3fsCurl::RequestPerform(void)
         // Service response codes which are >= 400 && < 500
         switch(LastResponseCode){
           case 400:
+            S3FS_PRN_ERR("HTTP response code %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
             S3FS_PRN_INFO3("HTTP response code 400 was returned, returning EIO.");
             S3FS_PRN_DBG("Body Text: %s", (bodydata ? bodydata->str() : ""));
             return -EIO;
 
           case 403:
+            S3FS_PRN_ERR("HTTP response code %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
             S3FS_PRN_INFO3("HTTP response code 403 was returned, returning EPERM");
             S3FS_PRN_DBG("Body Text: %s", (bodydata ? bodydata->str() : ""));
             return -EPERM;
 
           case 404:
+            S3FS_PRN_ERR("HTTP response code %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
             S3FS_PRN_INFO3("HTTP response code 404 was returned, returning ENOENT");
             S3FS_PRN_DBG("Body Text: %s", (bodydata ? bodydata->str() : ""));
             return -ENOENT;
 
           default:
+            S3FS_PRN_ERR("HTTP response code %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
             S3FS_PRN_INFO3("HTTP response code = %ld, returning EIO", LastResponseCode);
             S3FS_PRN_DBG("Body Text: %s", (bodydata ? bodydata->str() : ""));
             return -EIO;

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2064,7 +2064,6 @@ int S3fsCurl::RequestPerform(void)
         }
         if(500 <= LastResponseCode){
           S3FS_PRN_ERR("HTTP response code = %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
-          S3FS_PRN_INFO3("HTTP response code %ld", LastResponseCode);
           sleep(4);
           break; 
         }
@@ -2073,26 +2072,19 @@ int S3fsCurl::RequestPerform(void)
         switch(LastResponseCode){
           case 400:
             S3FS_PRN_ERR("HTTP response code %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
-            S3FS_PRN_INFO3("HTTP response code 400 was returned, returning EIO.");
-            S3FS_PRN_DBG("Body Text: %s", (bodydata ? bodydata->str() : ""));
             return -EIO;
 
           case 403:
             S3FS_PRN_ERR("HTTP response code %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
-            S3FS_PRN_INFO3("HTTP response code 403 was returned, returning EPERM");
-            S3FS_PRN_DBG("Body Text: %s", (bodydata ? bodydata->str() : ""));
             return -EPERM;
 
           case 404:
-            S3FS_PRN_ERR("HTTP response code %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
             S3FS_PRN_INFO3("HTTP response code 404 was returned, returning ENOENT");
             S3FS_PRN_DBG("Body Text: %s", (bodydata ? bodydata->str() : ""));
             return -ENOENT;
 
           default:
             S3FS_PRN_ERR("HTTP response code %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
-            S3FS_PRN_INFO3("HTTP response code = %ld, returning EIO", LastResponseCode);
-            S3FS_PRN_DBG("Body Text: %s", (bodydata ? bodydata->str() : ""));
             return -EIO;
         }
         break;

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2071,11 +2071,11 @@ int S3fsCurl::RequestPerform(void)
         // Service response codes which are >= 400 && < 500
         switch(LastResponseCode){
           case 400:
-            S3FS_PRN_ERR("HTTP response code %ld, Returning EIO, Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
+            S3FS_PRN_ERR("HTTP response code %ld, returning EIO. Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
             return -EIO;
 
           case 403:
-            S3FS_PRN_ERR("HTTP response code %ld, Returning EPERM, Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
+            S3FS_PRN_ERR("HTTP response code %ld, returning EPERM. Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
             return -EPERM;
 
           case 404:
@@ -2084,7 +2084,7 @@ int S3fsCurl::RequestPerform(void)
             return -ENOENT;
 
           default:
-            S3FS_PRN_ERR("HTTP response code %ld, Returning EIO, Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
+            S3FS_PRN_ERR("HTTP response code %ld, returning EIO. Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
             return -EIO;
         }
         break;

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2071,11 +2071,11 @@ int S3fsCurl::RequestPerform(void)
         // Service response codes which are >= 400 && < 500
         switch(LastResponseCode){
           case 400:
-            S3FS_PRN_ERR("HTTP response code %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
+            S3FS_PRN_ERR("HTTP response code %ld, Returning EIO, Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
             return -EIO;
 
           case 403:
-            S3FS_PRN_ERR("HTTP response code %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
+            S3FS_PRN_ERR("HTTP response code %ld, Returning EPERM, Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
             return -EPERM;
 
           case 404:
@@ -2084,7 +2084,7 @@ int S3fsCurl::RequestPerform(void)
             return -ENOENT;
 
           default:
-            S3FS_PRN_ERR("HTTP response code %ld Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
+            S3FS_PRN_ERR("HTTP response code %ld, Returning EIO, Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
             return -EIO;
         }
         break;


### PR DESCRIPTION
### Relevant Issue (if applicable)

If there are Issues related to this PullRequest, please list it.

### Details
Currently S3FS fuse is not logging any message for 4xx and 5xx HTTP response codes.  
The code change enable the logging for 4xx and 5xx  codes.