### PR TITLE
Instructions for SUSE and openSUSE prebuilt packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,22 @@ Some systems provide pre-built packages:
 
 * On Debian 9 and Ubuntu 16.04 or newer:
 
-```
-sudo apt-get install s3fs
-```
+  ```
+  sudo apt-get install s3fs
+  ```
+
+* On SUSE 12 or newer and openSUSE 42.1 or newer:
+
+  ```
+  sudo zypper in s3fs
+  ```
 
 * On Mac OS X, install via [Homebrew](http://brew.sh/):
 
-```ShellSession
-$ brew cask install osxfuse
-$ brew install s3fs
-```
+  ```ShellSession
+  $ brew cask install osxfuse
+  $ brew install s3fs
+  ```
 
 Compilation
 -----------


### PR DESCRIPTION
### Relevant Issue (if applicable)

Request from @gaul at #785.

### Details

Add the instructions to install both official packages at SUSE and openSUSE. Advanced instructions are now also available at the [Wiki](https://github.com/s3fs-fuse/s3fs-fuse/wiki/Installation-Notes#suse-and-opensuse).

Since I am adding a new distribution, I also adjusted tabulation to make the file more readable (see the ```README.md``` file on [view mode](https://github.com/juliogonzalez/s3fs-fuse/blob/96779eb2ebda9d6773bffa4c80e62e19b955d3e0/README.md).