### PR TITLE
FdManager::Rename

### DIFF
--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -153,6 +153,7 @@ class FdEntity
     void SetPath(const std::string &newpath) { path = newpath; }
     int GetFd(void) const { return fd; }
 
+    const char* GetCachePath(void) const { return cachepath.c_str(); }
     bool GetStats(struct stat& st);
     int SetMtime(time_t time);
     bool UpdateMtime(void);


### PR DESCRIPTION
1.use_cache not rename cachefile, rename_object has delete rename source cachefile
2.not use_cache don't find FdEntity,because eky have perfix NOCACHE_PATH_PREFIX_FORM.

Signed-off-by: zhong.li <lz_bruce@126.com>
Signed-off-by: puchun.shen <spcjv5@gmail.com>

### Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

### Details
_Please describe the details of PullRequest._
