### PR TITLE
For RPM distributions fuse-libs is enough

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sudo apt-get install automake autotools-dev fuse g++ git libcurl4-openssl-dev li
 On CentOS 7:
 
 ```
-sudo yum install automake fuse fuse-devel gcc-c++ git libcurl-devel libxml2-devel make openssl-devel
+sudo yum install automake fuse-libs fuse-devel gcc-c++ git libcurl-devel libxml2-devel make openssl-devel
 ```
 
 Then compile from master via the following commands:


### PR DESCRIPTION
### Relevant Issue (if applicable)
- #785
- https://bugzilla.redhat.com/show_bug.cgi?id=1631988#c4

### Details
For RPM distributions such as SUSE, openSUSE, CentOS, Red Hat or Fedora, fuse-libs is enough and fuse package is not required neither for building or running.

References:

- Local test for CentOS6 and CentOS7
- https://build.opensuse.org/package/view_file/filesystems/s3fs/s3fs.spec?expand=1
- Dependency checking at my laptop (openSUSE 15.0): 
  ```$ rpm -q -R s3fs                                                                                                                                                                                                                   
  libc.so.6()(64bit)                                                                                                                                                                                                                                                             
  libc.so.6(GLIBC_2.14)(64bit)                                                                                                                                                                                                                                                   
  libc.so.6(GLIBC_2.17)(64bit)                                                                                                                                                                                                                                                   
  libc.so.6(GLIBC_2.2.5)(64bit)                                                                                                                                                                                                                                                  
  libc.so.6(GLIBC_2.3)(64bit)                                                                                                                                                                                                                                                    
  libc.so.6(GLIBC_2.3.4)(64bit)                                                                                                                                                                                                                                                  
  libc.so.6(GLIBC_2.4)(64bit)                                                                                                                                                                                                                                                    
  libcrypto.so.1.1()(64bit)                                                                                                                                                                                                                                                      
  libcrypto.so.1.1(OPENSSL_1_1_0)(64bit)                                                                                                                                                                                                                                         
  libcurl.so.4()(64bit)                                                                                                                                                                                                                                                          
  libfuse.so.2()(64bit)
  libfuse.so.2(FUSE_2.2)(64bit)
  libfuse.so.2(FUSE_2.5)(64bit)
  libfuse.so.2(FUSE_2.6)(64bit)
  libfuse.so.2(FUSE_2.8)(64bit)
  libgcc_s.so.1()(64bit)
  libgcc_s.so.1(GCC_3.0)(64bit)
  libpthread.so.0()(64bit)
  libpthread.so.0(GLIBC_2.2.5)(64bit)
  libstdc++.so.6()(64bit)
  libstdc++.so.6(CXXABI_1.3)(64bit)
  libstdc++.so.6(CXXABI_1.3.8)(64bit)
  libstdc++.so.6(CXXABI_1.3.9)(64bit)
  libstdc++.so.6(GLIBCXX_3.4)(64bit)
  libstdc++.so.6(GLIBCXX_3.4.11)(64bit)
  libstdc++.so.6(GLIBCXX_3.4.15)(64bit)
  libstdc++.so.6(GLIBCXX_3.4.20)(64bit)
  libstdc++.so.6(GLIBCXX_3.4.21)(64bit)
  libstdc++.so.6(GLIBCXX_3.4.9)(64bit)
  libxml2.so.2()(64bit)
  libxml2.so.2(LIBXML2_2.4.30)(64bit)
  libxml2.so.2(LIBXML2_2.6.0)(64bit)
  rpmlib(CompressedFileNames) <= 3.0.4-1
  rpmlib(FileDigests) <= 4.6.0-1
  rpmlib(PayloadFilesHavePrefix) <= 4.0-1
  rpmlib(PayloadIsXz) <= 5.2-1
  ```

