### PR TITLE
Simplify hex conversion

### DIFF
--- a/src/common_auth.cpp
+++ b/src/common_auth.cpp
@@ -71,7 +71,6 @@ string s3fs_sha256sum(int fd, off_t start, ssize_t size)
 {
   size_t digestlen = get_sha256_digest_length();
   char sha256[2 * digestlen + 1];
-  char hexbuf[3];
   unsigned char* sha256hex;
 
   if(NULL == (sha256hex = s3fs_sha256hexsum(fd, start, size))){
@@ -80,8 +79,7 @@ string s3fs_sha256sum(int fd, off_t start, ssize_t size)
 
   memset(sha256, 0, 2 * digestlen + 1);
   for(size_t pos = 0; pos < digestlen; pos++){
-    snprintf(hexbuf, 3, "%02x", sha256hex[pos]);
-    strncat(sha256, hexbuf, 2);
+    snprintf(sha256 + 2 * pos, 3, "%02x", sha256hex[pos]);
   }
   free(sha256hex);
 


### PR DESCRIPTION
Addresses GCC 8 warning:

```
common_auth.cpp: In function ‘std::__cxx11::string s3fs_sha256sum(int, off_t, ssize_t)’:
common_auth.cpp:84:12: warning: ‘char* strncat(char*, const char*, size_t)’ output may be truncated copying 2 bytes from a string of length 2 [-Wstringop-truncation]
    strncat(sha256, hexbuf, 2);
```