### PR TITLE
New installation instructions for Fedora >= 27 and CentOS7

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Some systems provide pre-built packages:
   sudo zypper in s3fs
   ```
 
+* On Fedora 27 and newer:
+  ```
+  sudo yum install s3fs-fuse
+  ```
+
+* On RHEL 7 and CentOS 7 trough EPEL 7 repositories:
+  ```
+  sudo yum install epel-release
+  sudo yum install s3fs-fuse
+  ```
+
 * On Mac OS X, install via [Homebrew](http://brew.sh/):
 
   ```ShellSession
@@ -52,12 +63,6 @@ On Ubuntu 14.04:
 
 ```
 sudo apt-get install automake autotools-dev fuse g++ git libcurl4-openssl-dev libfuse-dev libssl-dev libxml2-dev make pkg-config
-```
-
-On CentOS 7:
-
-```
-sudo yum install automake fuse fuse-devel gcc-c++ git libcurl-devel libxml2-devel make openssl-devel
 ```
 
 Then compile from master via the following commands:


### PR DESCRIPTION
### Relevant Issue

#785 

### Details
Since I submitted s3fs-fuse for Fedora 27, Fedora 28, Fedora 29 and EPEL7, I am adding the instructions about how to install, and removing the compilation details for CentOS7.

Compilation details for Fedora and CentOS are still available at https://github.com/s3fs-fuse/s3fs-fuse/wiki/Installation-Notes#fedora--centos
