### PR TITLE
Replace all mentions to MacOS X to macOS

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Additional Information
 _The following information is very important in order to help us to help you. Omission of the following details may delay your support request or receive no attention at all._
-_Keep in mind that the commands we provide to retrieve information are oriented to GNU/Linux Distributions, so you could need to use others if you use s3fs on MacOS or BSD_
+_Keep in mind that the commands we provide to retrieve information are oriented to GNU/Linux Distributions, so you could need to use others if you use s3fs on macOS or BSD_
 
 #### Version of s3fs being used (s3fs --version)
 _example: 1.00_

--- a/INSTALL
+++ b/INSTALL
@@ -124,7 +124,7 @@ architecture at a time in the source code directory.  After you have
 installed the package for one architecture, use `make distclean' before
 reconfiguring for another architecture.
 
-   On MacOS X 10.5 and later systems, you can create libraries and
+   On macOS 10.5 and later systems, you can create libraries and
 executables that work on multiple system types--known as "fat" or
 "universal" binaries--by specifying multiple `-arch' options to the
 compiler but only a single `-arch' option to the preprocessor.  Like

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 s3fs
 ====
 
-s3fs allows Linux and Mac OS X to mount an S3 bucket via FUSE.
+s3fs allows Linux and macOS to mount an S3 bucket via FUSE.
 s3fs preserves the native object format for files, allowing use of other tools like [s3cmd](http://s3tools.org/s3cmd).  
 [![Build Status](https://travis-ci.org/s3fs-fuse/s3fs-fuse.svg?branch=master)](https://travis-ci.org/s3fs-fuse/s3fs-fuse)
 
@@ -47,7 +47,7 @@ Some systems provide pre-built packages:
   sudo yum install s3fs-fuse
   ```
 
-* On Mac OS X, install via [Homebrew](http://brew.sh/):
+* On macOS, install via [Homebrew](http://brew.sh/):
 
   ```ShellSession
   $ brew cask install osxfuse

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ AC_CHECK_HEADERS([sys/extattr.h])
 CXXFLAGS="$CXXFLAGS -Wall -D_FILE_OFFSET_BITS=64"
 
 dnl ----------------------------------------------
-dnl For OSX
+dnl For macOS
 dnl ----------------------------------------------
 case "$target" in
    *-cygwin* )
@@ -237,7 +237,7 @@ dnl ----------------------------------------------
 dnl malloc_trim function
 AC_CHECK_FUNCS([malloc_trim])
 
-dnl clock_gettime function(osx)
+dnl clock_gettime function(macos)
 AC_SEARCH_LIBS([clock_gettime],[rt posix4]) 
 AC_CHECK_FUNCS([clock_gettime])
 


### PR DESCRIPTION
### Relevant Issue (if applicable)

#835

### Details

Apple changed "Mac OS X" and "OS X" to the new name "macOS" since 10.12 Sierra.

See:
- https://en.wikipedia.org/wiki/MacOS#macOS
- https://www.businessinsider.com/wwdc-2016-os-x-becomes-macos-2016-6?IR=T

So this PR replaces all the mentions to old names with macOS.

Things that were not changed:
- `config.guess` is just a symbolic link to a file belonging to automake package (part of the system).
- `.travis.yml`, as Travis still uses the name `OS X` and similar. See https://docs.travis-ci.com/user/reference/osx/