### PR TITLE
Store and retrieve file creation time

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -620,6 +620,9 @@ bool convert_header_to_stat(const char* path, headers_t& meta, struct stat* pst,
   // mtime
   pst->st_mtime = get_mtime(meta);
 
+  // ctime
+  pst->st_ctime = get_ctime(meta);
+
   // size
   pst->st_size = get_size(meta);
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -963,12 +963,14 @@ static int create_file_object(const char* path, mode_t mode, uid_t uid, gid_t gi
 {
   S3FS_PRN_INFO2("[path=%s][mode=%04o]", path, mode);
 
+  time_t now = time(NULL);
   headers_t meta;
   meta["Content-Type"]     = S3fsCurl::LookupMimeType(string(path));
   meta["x-amz-meta-uid"]   = str(uid);
   meta["x-amz-meta-gid"]   = str(gid);
   meta["x-amz-meta-mode"]  = str(mode);
-  meta["x-amz-meta-mtime"] = str(time(NULL));
+  meta["x-amz-meta-ctime"] = str(now);
+  meta["x-amz-meta-mtime"] = str(now);
 
   S3fsCurl s3fscurl(true);
   return s3fscurl.PutRequest(path, meta, -1);    // fd=-1 means for creating zero byte object.
@@ -1055,6 +1057,7 @@ static int create_directory_object(const char* path, mode_t mode, time_t time, u
   meta["x-amz-meta-uid"]   = str(uid);
   meta["x-amz-meta-gid"]   = str(gid);
   meta["x-amz-meta-mode"]  = str(mode);
+  meta["x-amz-meta-ctime"] = str(time);
   meta["x-amz-meta-mtime"] = str(time);
 
   S3fsCurl s3fscurl;
@@ -1199,10 +1202,12 @@ static int s3fs_symlink(const char* from, const char* to)
     return result;
   }
 
+  time_t now = time(NULL);
   headers_t headers;
   headers["Content-Type"]     = string("application/octet-stream"); // Static
   headers["x-amz-meta-mode"]  = str(S_IFLNK | S_IRWXU | S_IRWXG | S_IRWXO);
-  headers["x-amz-meta-mtime"] = str(time(NULL));
+  headers["x-amz-meta-ctime"] = str(now);
+  headers["x-amz-meta-mtime"] = str(now);
   headers["x-amz-meta-uid"]   = str(pcxt->uid);
   headers["x-amz-meta-gid"]   = str(pcxt->gid);
 
@@ -2032,9 +2037,11 @@ static int s3fs_truncate(const char* path, off_t size)
     if(NULL == (pcxt = fuse_get_context())){
       return -EIO;
     }
+    time_t now = time(NULL);
     meta["Content-Type"]     = string("application/octet-stream"); // Static
     meta["x-amz-meta-mode"]  = str(S_IFLNK | S_IRWXU | S_IRWXG | S_IRWXO);
-    meta["x-amz-meta-mtime"] = str(time(NULL));
+    meta["x-amz-meta-ctime"] = str(now);
+    meta["x-amz-meta-mtime"] = str(now);
     meta["x-amz-meta-uid"]   = str(pcxt->uid);
     meta["x-amz-meta-gid"]   = str(pcxt->gid);
 

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -753,16 +753,26 @@ time_t get_mtime(const char *s)
   return static_cast<time_t>(s3fs_strtoofft(s));
 }
 
-time_t get_mtime(headers_t& meta, bool overcheck)
+static time_t get_time(headers_t& meta, bool overcheck, const char *header)
 {
   headers_t::const_iterator iter;
-  if(meta.end() == (iter = meta.find("x-amz-meta-mtime"))){
+  if(meta.end() == (iter = meta.find(header))){
     if(overcheck){
       return get_lastmodified(meta);
     }
     return 0;
   }
   return get_mtime((*iter).second.c_str());
+}
+
+time_t get_mtime(headers_t& meta, bool overcheck)
+{
+  return get_time(meta, overcheck, "x-amz-meta-mtime");
+}
+
+time_t get_ctime(headers_t& meta)
+{
+  return get_time(meta, false, "x-amz-meta-ctime");
 }
 
 off_t get_size(const char *s)

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -119,6 +119,7 @@ bool delete_files_in_dir(const char* dir, bool is_remove_own);
 
 time_t get_mtime(const char *s);
 time_t get_mtime(headers_t& meta, bool overcheck = true);
+time_t get_ctime(headers_t& meta);
 off_t get_size(const char *s);
 off_t get_size(headers_t& meta);
 mode_t get_mode(const char *s);


### PR DESCRIPTION
This introduces a new header with the creation date; existing object
will report creation dates in 1969.  Fixes #771.