### PR TITLE
Tighten up HTTP response code check

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2072,7 +2072,7 @@ int S3fsCurl::RequestPerform(void)
           S3FS_PRN_ERR("curl_easy_getinfo failed while trying to retrieve HTTP response code");
           return -EIO;
         }
-        if(400 > LastResponseCode){
+        if(LastResponseCode >= 200 && LastResponseCode < 300){
           S3FS_PRN_INFO3("HTTP response code %ld", LastResponseCode);
           return 0;
         }


### PR DESCRIPTION
Previously s3fs considered 3xx codes as successful.  When writing an
object to a misconfigured region, s3fs did not propagate the 301 as a
write error to the client.  References #693.