### PR TITLE
Avoid pass-by-value when not necessary

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -472,7 +472,7 @@ bool StatCache::AddNoObjectCache(string& key)
   return true;
 }
 
-void StatCache::ChangeNoTruncateFlag(std::string key, bool no_truncate)
+void StatCache::ChangeNoTruncateFlag(const std::string& key, bool no_truncate)
 {
   pthread_mutex_lock(&StatCache::stat_cache_lock);
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -117,7 +117,7 @@ class StatCache
     bool AddStat(std::string& key, headers_t& meta, bool forcedir = false, bool no_truncate = false);
 
     // Change no truncate flag
-    void ChangeNoTruncateFlag(std::string key, bool no_truncate);
+    void ChangeNoTruncateFlag(const std::string& key, bool no_truncate);
 
     // Delete stat cache
     bool DelStat(const char* key);

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -586,7 +586,7 @@ string mydirname(const char* path)
   return mydirname(string(path));
 }
 
-string mydirname(string path)
+string mydirname(const string& path)
 {
   return string(dirname((char*)path.c_str()));
 }
@@ -601,7 +601,7 @@ string mybasename(const char* path)
   return mybasename(string(path));
 }
 
-string mybasename(string path)
+string mybasename(const string& path)
 {
   return string(basename((char*)path.c_str()));
 }

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -109,9 +109,9 @@ std::string get_username(uid_t uid);
 int is_uid_include_group(uid_t uid, gid_t gid);
 
 std::string mydirname(const char* path);
-std::string mydirname(std::string path);
+std::string mydirname(const std::string& path);
 std::string mybasename(const char* path);
-std::string mybasename(std::string path);
+std::string mybasename(const std::string& path);
 int mkdirp(const std::string& path, mode_t mode);
 std::string get_exist_directory_path(const std::string& path);
 bool check_exist_dir_permission(const char* dirpath);


### PR DESCRIPTION
This requires unnecessary `memcpy`.  Found via clang-tidy.