### PR TITLE
Remove unnecessary calls to std::string::c_str

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -231,11 +231,11 @@ bool StatCache::GetStat(string& key, struct stat* pst, headers_t* meta, bool ove
   stat_cache_t::iterator iter = stat_cache.end();
   if(overcheck && '/' != strpath[strpath.length() - 1]){
     strpath += "/";
-    iter = stat_cache.find(strpath.c_str());
+    iter = stat_cache.find(strpath);
   }
   if(iter == stat_cache.end()){
     strpath = key;
-    iter = stat_cache.find(strpath.c_str());
+    iter = stat_cache.find(strpath);
   }
 
   if(iter != stat_cache.end() && (*iter).second){
@@ -320,11 +320,11 @@ bool StatCache::IsNoObjectCache(string& key, bool overcheck)
   stat_cache_t::iterator iter = stat_cache.end();
   if(overcheck && '/' != strpath[strpath.length() - 1]){
     strpath += "/";
-    iter = stat_cache.find(strpath.c_str());
+    iter = stat_cache.find(strpath);
   }
   if(iter == stat_cache.end()){
     strpath = key;
-    iter = stat_cache.find(strpath.c_str());
+    iter = stat_cache.find(strpath);
   }
 
   if(iter != stat_cache.end() && (*iter).second) {
@@ -582,7 +582,7 @@ bool StatCache::DelStat(const char* key)
       // If there is "path/" cache, delete it.
       strpath += "/";
     }
-    if(stat_cache.end() != (iter = stat_cache.find(strpath.c_str()))){
+    if(stat_cache.end() != (iter = stat_cache.find(strpath))){
       if((*iter).second){
         delete (*iter).second;
       }

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -4341,10 +4341,10 @@ string prepare_url(const char* url)
   uri  = url_str.substr(0, uri_length);
 
   if(!pathrequeststyle){
-    hostname = bucket + "." + url_str.substr(uri_length, bucket_pos - uri_length).c_str();
+    hostname = bucket + "." + url_str.substr(uri_length, bucket_pos - uri_length);
     path = url_str.substr((bucket_pos + bucket_length));
   }else{
-    hostname = url_str.substr(uri_length, bucket_pos - uri_length).c_str();
+    hostname = url_str.substr(uri_length, bucket_pos - uri_length);
     string part = url_str.substr((bucket_pos + bucket_length));
     if('/' != part[0]){
       part = "/" + part;


### PR DESCRIPTION
Found via clang-tidy.