### PR TITLE
Fix comparison in s3fs_strtoofft

### DIFF
--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -75,7 +75,7 @@ off_t s3fs_strtoofft(const char* str, bool is_base_16)
     }
     // check like isalnum and set data
     result *= (is_base_16 ? 16 : 10);
-    if('0' <= *str || '9' < *str){
+    if('0' <= *str && '9' >= *str){
       result += static_cast<off_t>(*str - '0');
     }else if(is_base_16){
       if('A' <= *str && *str <= 'F'){

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -35,6 +35,7 @@ static inline int STR2NCMP(const char *str1, const char *str2) { return strncmp(
 
 template <class T> std::string str(T value);
 
+// Convert string to off_t.  Does not signal invalid input.
 off_t s3fs_strtoofft(const char* str, bool is_base_16 = false);
 
 std::string trim_left(const std::string &s, const std::string &t = SPACES);

--- a/src/test_string_util.cpp
+++ b/src/test_string_util.cpp
@@ -75,9 +75,22 @@ void test_base64()
   // TODO: invalid input
 }
 
+void test_strtoofft()
+{
+  ASSERT_EQUALS(s3fs_strtoofft("0"), static_cast<off_t>(0L));
+  ASSERT_EQUALS(s3fs_strtoofft("9"), static_cast<off_t>(9L));
+  ASSERT_EQUALS(s3fs_strtoofft("A"), static_cast<off_t>(0L));
+  ASSERT_EQUALS(s3fs_strtoofft("A", /*is_base_16=*/ true), static_cast<off_t>(10L));
+  ASSERT_EQUALS(s3fs_strtoofft("F", /*is_base_16=*/ true), static_cast<off_t>(15L));
+  ASSERT_EQUALS(s3fs_strtoofft("a", /*is_base_16=*/ true), static_cast<off_t>(10L));
+  ASSERT_EQUALS(s3fs_strtoofft("f", /*is_base_16=*/ true), static_cast<off_t>(15L));
+  ASSERT_EQUALS(s3fs_strtoofft("deadbeef", /*is_base_16=*/ true), static_cast<off_t>(3735928559L));
+}
+
 int main(int argc, char *argv[])
 {
   test_trim();
   test_base64();
+  test_strtoofft();
   return 0;
 }


### PR DESCRIPTION
Also backfill unit tests.  Document limitations.  Found via
clang-tidy.