### PR TITLE
Added an error message when HTTP 301 status

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2082,8 +2082,12 @@ int S3fsCurl::RequestPerform(void)
           break; 
         }
 
-        // Service response codes which are >= 400 && < 500
+        // Service response codes which are >= 300 && < 500
         switch(LastResponseCode){
+          case 301:
+            S3FS_PRN_ERR("HTTP response code 301(Moved Permanently: also happens when bucket's region is incorrect), returning EIO. Body Text: %s", (bodydata ? bodydata->str() : ""));
+            return -EIO;
+
           case 400:
             S3FS_PRN_ERR("HTTP response code %ld, returning EIO. Body Text: %s", LastResponseCode, (bodydata ? bodydata->str() : ""));
             return -EIO;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#899 ( #693 )

### Details
Added message for HTTP 301 status code error.
Since it is one of the reasons that the region of the bucket is mainly different, it displays its contents in case of this error.
