### PR TITLE
Ignore after period character of floating point in x-amz-meta-mtime

### DIFF
--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -748,9 +748,23 @@ bool delete_files_in_dir(const char* dir, bool is_remove_own)
 //-------------------------------------------------------------------
 // Utility functions for convert
 //-------------------------------------------------------------------
-time_t get_mtime(const char *s)
+time_t get_mtime(const char *str)
 {
-  return static_cast<time_t>(s3fs_strtoofft(s));
+  // [NOTE]
+  // In rclone, there are cases where ns is set to x-amz-meta-mtime
+  // with floating point number. s3fs uses x-amz-meta-mtime by
+  // truncating the floating point or less (in seconds or less) to
+  // correspond to this.
+  //
+  string strmtime("");
+  if(str && '\0' != *str){
+    strmtime = str;
+    string::size_type pos = strmtime.find('.', 0);
+    if(string::npos != pos){
+      strmtime = strmtime.substr(0, pos);
+    }
+  }
+  return static_cast<time_t>(s3fs_strtoofft(strmtime.c_str()));
 }
 
 static time_t get_time(headers_t& meta, bool overcheck, const char *header)


### PR DESCRIPTION
### Relevant Issue (if applicable)
#897 

### Details
rcloud sets ns(or 10ns) of unixtime using floating point in x-amz-meta-mtime, depending on the conditions such as OS.
Thus, there is a possibility that a numerical value with a decimal point is set in the S3 object's x-amz-meta-mtime.
Therefore, in s3fs, if the value of x-amz-meta-mtime contains a decimal point, s3fs ignore number after the decimal point.
