### PR TITLE
Prefer abort over assert(false)

### DIFF
--- a/src/addhead.cpp
+++ b/src/addhead.cpp
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
-#include <assert.h>
 #include <curl/curl.h>
 #include <sstream>
 #include <fstream>
@@ -56,7 +55,7 @@ AdditionalHeader::AdditionalHeader()
   if(this == AdditionalHeader::get()){
     is_enable = false;
   }else{
-    assert(false);
+    abort();
   }
 }
 
@@ -65,7 +64,7 @@ AdditionalHeader::~AdditionalHeader()
   if(this == AdditionalHeader::get()){
     Unload();
   }else{
-    assert(false);
+    abort();
   }
 }
 

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -28,7 +28,6 @@
 #include <stdint.h>
 #include <pthread.h>
 #include <string.h>
-#include <assert.h>
 #include <syslog.h>
 #include <string>
 #include <map>
@@ -148,7 +147,7 @@ StatCache::StatCache() : IsExpireTime(false), IsExpireIntervalType(false), Expir
     stat_cache.clear();
     pthread_mutex_init(&(StatCache::stat_cache_lock), NULL);
   }else{
-    assert(false);
+    abort();
   }
 }
 
@@ -158,7 +157,7 @@ StatCache::~StatCache()
     Clear();
     pthread_mutex_destroy(&(StatCache::stat_cache_lock));
   }else{
-    assert(false);
+    abort();
   }
 }
 

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -110,7 +110,8 @@ static string url_to_host(const std::string &url)
   } else if (url.compare(0, https.size(), https) == 0) {
     hostname = url.substr(https.size());
   } else {
-    assert(!"url does not begin with http:// or https://");
+    S3FS_PRN_EXIT("url does not begin with http:// or https://");
+    abort();
   }
 
   size_t idx;

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -30,7 +30,6 @@
 #include <syslog.h>
 #include <errno.h>
 #include <string.h>
-#include <assert.h>
 #include <dirent.h>
 #include <curl/curl.h>
 #include <string>
@@ -2000,7 +1999,7 @@ FdManager::FdManager()
       S3FS_PRN_CRIT("failed to init mutex");
     }
   }else{
-    assert(false);
+    abort();
   }
 }
 
@@ -2024,7 +2023,7 @@ FdManager::~FdManager()
       FdManager::is_lock_init = false;
     }
   }else{
-    assert(false);
+    abort();
   }
 }
 


### PR DESCRIPTION
The compiler can remove the latter when compiled with `NDEBUG` which may
cause unintended control flow.