### PR TITLE
Issue readdir HEAD requests without batching

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -373,6 +373,7 @@ string           S3fsCurl::curl_ca_bundle;
 mimes_t          S3fsCurl::mimeTypes;
 string           S3fsCurl::userAgent;
 int              S3fsCurl::max_parallel_cnt    = 5;              // default
+int              S3fsCurl::max_multireq        = 20;             // default
 off_t            S3fsCurl::multipart_size      = MULTIPART_SIZE; // default
 bool             S3fsCurl::is_sigv4            = true;           // default
 bool             S3fsCurl::is_ua               = true;           // default
@@ -1258,6 +1259,13 @@ int S3fsCurl::SetMaxParallelCount(int value)
   return old;
 }
 
+int S3fsCurl::SetMaxMultiRequest(int max)
+{
+  int old = S3fsCurl::max_multireq;
+  S3fsCurl::max_multireq = max;
+  return old;
+}
+
 bool S3fsCurl::UploadMultipartPostCallback(S3fsCurl* s3fscurl)
 {
   if(!s3fscurl){
@@ -1342,7 +1350,7 @@ int S3fsCurl::ParallelMultipartUploadRequest(const char* tpath, headers_t& meta,
   s3fscurl.DestroyCurlHandle();
 
   // Initialize S3fsMultiCurl
-  S3fsMultiCurl curlmulti;
+  S3fsMultiCurl curlmulti(GetMaxParallelCount());
   curlmulti.SetSuccessCallback(S3fsCurl::UploadMultipartPostCallback);
   curlmulti.SetRetryCallback(S3fsCurl::UploadMultipartPostRetryCallback);
 
@@ -1432,7 +1440,7 @@ int S3fsCurl::ParallelGetObjectRequest(const char* tpath, int fd, off_t start, s
 
   // cycle through open fd, pulling off 10MB chunks at a time
   for(remaining_bytes = size; 0 < remaining_bytes; ){
-    S3fsMultiCurl curlmulti;
+    S3fsMultiCurl curlmulti(GetMaxParallelCount());
     int           para_cnt;
     off_t         chunk;
 
@@ -3847,26 +3855,12 @@ int S3fsCurl::MultipartRenameRequest(const char* from, const char* to, headers_t
 }
 
 //-------------------------------------------------------------------
-// Class S3fsMultiCurl 
-//-------------------------------------------------------------------
-static const int MAX_MULTI_HEADREQ = 20;  // default: max request count in readdir curl_multi.
-
-//-------------------------------------------------------------------
-// Class method for S3fsMultiCurl 
-//-------------------------------------------------------------------
-int S3fsMultiCurl::max_multireq = MAX_MULTI_HEADREQ;
-
-int S3fsMultiCurl::SetMaxMultiRequest(int max)
-{
-  int old = S3fsMultiCurl::max_multireq;
-  S3fsMultiCurl::max_multireq= max;
-  return old;
-}
-
-//-------------------------------------------------------------------
 // method for S3fsMultiCurl 
 //-------------------------------------------------------------------
-S3fsMultiCurl::S3fsMultiCurl() : SuccessCallback(NULL), RetryCallback(NULL)
+S3fsMultiCurl::S3fsMultiCurl(int maxParallelism)
+  : maxParallelism(maxParallelism)
+  , SuccessCallback(NULL)
+  , RetryCallback(NULL)
 {
 }
 
@@ -3929,7 +3923,7 @@ int S3fsMultiCurl::MultiPerform(void)
   std::vector<pthread_t>   threads;
   bool                     success = true;
   bool                     isMultiHead = false;
-  Semaphore                sem(S3fsCurl::max_parallel_cnt);
+  Semaphore                sem(GetMaxParallelism());
   int                      rc;
 
   for(s3fscurlmap_t::iterator iter = cMap_req.begin(); iter != cMap_req.end(); ++iter) {
@@ -3974,16 +3968,9 @@ int S3fsMultiCurl::MultiPerform(void)
     threads.push_back(thread);
   }
 
-  for(int i = 0; i < S3fsCurl::max_parallel_cnt; ++i){
+  for(int i = 0; i < sem.get_value(); ++i){
     sem.wait();
   }
-
-#ifdef __APPLE__
-  // macOS cannot destroy a semaphore with posts less than the initializer
-  for(int i = 0; i < S3fsCurl::max_parallel_cnt; ++i){
-    sem.post();
-  }
-#endif
 
   for (std::vector<pthread_t>::iterator titer = threads.begin(); titer != threads.end(); ++titer) {
     void*   retval;
@@ -4081,9 +4068,8 @@ int S3fsMultiCurl::Request(void)
   while(!cMap_all.empty()){
     // set curl handle to multi handle
     int                     result;
-    int                     cnt;
     s3fscurlmap_t::iterator iter;
-    for(cnt = 0, iter = cMap_all.begin(); cnt < S3fsMultiCurl::max_multireq && iter != cMap_all.end(); cMap_all.erase(iter++), cnt++){
+    for(iter = cMap_all.begin(); iter != cMap_all.end(); cMap_all.erase(iter++)){
       CURL*     hCurl    = (*iter).first;
       S3fsCurl* s3fscurl = (*iter).second;
 

--- a/src/curl.h
+++ b/src/curl.h
@@ -249,6 +249,7 @@ class S3fsCurl
     static mimes_t          mimeTypes;
     static std::string      userAgent;
     static int              max_parallel_cnt;
+    static int              max_multireq;
     static off_t            multipart_size;
     static bool             is_sigv4;
     static bool             is_ua;             // User-Agent
@@ -389,8 +390,12 @@ class S3fsCurl
                 }
     static long SetSslVerifyHostname(long value);
     static long GetSslVerifyHostname(void) { return S3fsCurl::ssl_verify_hostname; }
+    // maximum parallel GET and PUT requests
     static int SetMaxParallelCount(int value);
     static int GetMaxParallelCount(void) { return S3fsCurl::max_parallel_cnt; }
+    // maximum parallel HEAD requests
+    static int SetMaxMultiRequest(int max);
+    static int GetMaxMultiRequest(void) { return S3fsCurl::max_multireq; }
     static bool SetIsECS(bool flag);
     static bool SetIsIBMIAMAuth(bool flag);
     static size_t SetIAMFieldCount(size_t field_count);
@@ -470,7 +475,7 @@ typedef S3fsCurl* (*S3fsMultiRetryCallback)(S3fsCurl* s3fscurl); // callback for
 class S3fsMultiCurl
 {
   private:
-    static int    max_multireq;
+    const int maxParallelism;
 
     s3fscurlmap_t cMap_all;  // all of curl requests
     s3fscurlmap_t cMap_req;  // curl requests are sent
@@ -486,11 +491,10 @@ class S3fsMultiCurl
     static void* RequestPerformWrapper(void* arg);
 
   public:
-    S3fsMultiCurl();
+    explicit S3fsMultiCurl(int maxParallelism);
     ~S3fsMultiCurl();
 
-    static int SetMaxMultiRequest(int max);
-    static int GetMaxMultiRequest(void) { return S3fsMultiCurl::max_multireq; }
+    int GetMaxParallelism() { return maxParallelism; }
 
     S3fsMultiSuccessCallback SetSuccessCallback(S3fsMultiSuccessCallback function);
     S3fsMultiRetryCallback SetRetryCallback(S3fsMultiRetryCallback function);


### PR DESCRIPTION
Previously s3fs would issue a batch of HEAD requests and wait for all
to succeed before issuing the next batch.  Now it issues the first
batch and only waits for a single call to succeed before issuing the
next call.  This can improve performance when one call lags due to
network errors.  I measured 25% improvement with the same level of
parallelism.  This commit also reparents parallelism knobs for
consistency.  Follows on to 88cd8feb053980c808d67771d63a84ca25f6db8a.
Fixes #223.