### PR TITLE
Load tail range during overwrite

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1732,6 +1732,15 @@ ssize_t FdEntity::Write(const char* bytes, off_t start, size_t size)
     pagelist.SetPageLoadedStatus(start, static_cast<size_t>(wsize), true);
   }
 
+  // Load uninitialized area which starts from (start + size) to EOF after writing.
+  if(pagelist.Size() > static_cast<size_t>(start) + size){
+    result = Load(static_cast<size_t>(start + size), pagelist.Size());
+    if(0 != result){
+      S3FS_PRN_ERR("failed to load uninitialized area after writing(errno=%d)", result);
+      return static_cast<ssize_t>(result);
+    }
+  }
+
   // check multipart uploading
   if(0 < upload_id.length()){
     mp_size += static_cast<size_t>(wsize);

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -487,6 +487,17 @@ function test_write_after_seek_ahead {
    rm testfile
 }
 
+function test_overwrite_existing_file_range {
+    describe "Test overwrite range succeeds"
+    dd if=<(seq 1000) of=${TEST_TEXT_FILE}
+    dd if=/dev/zero of=${TEST_TEXT_FILE} seek=1 count=1 bs=1024 conv=notrunc
+    cmp ${TEST_TEXT_FILE} <(
+        seq 1000 | head -c 1024
+        dd if=/dev/zero count=1 bs=1024
+        seq 1000 | tail -c +2049
+    )
+    rm -f ${TEST_TEXT_FILE}
+}
 
 function add_all_tests {
     add_tests test_append_file 
@@ -510,6 +521,7 @@ function add_all_tests {
     add_tests test_update_time
     add_tests test_rm_rf_dir
     add_tests test_write_after_seek_ahead
+    add_tests test_overwrite_existing_file_range
 }
 
 init_suite


### PR DESCRIPTION
Previously s3fs experienced data loss when writing to the middle of a
file.  Corrupt files would have the expected data from 0..offset+size
but unexpected NUL bytes from offset+size..EOF.  References #808.