### PR TITLE
Remove unnecessary string copies

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -4261,7 +4261,7 @@ string get_canonical_headers(const struct curl_slist* list)
         // skip empty-value headers (as they are discarded by libcurl)
         continue;
       }
-      strhead       = strkey + string(":") + strval;
+      strhead       = strkey.append(":").append(strval);
     }else{
       strhead       = trim(lower(strhead));
     }
@@ -4290,7 +4290,7 @@ string get_canonical_headers(const struct curl_slist* list, bool only_amz)
         // skip empty-value headers (as they are discarded by libcurl)
         continue;
       }
-      strhead       = strkey + string(":") + strval;
+      strhead       = strkey.append(":").append(strval);
     }else{
       strhead       = trim(lower(strhead));
     }

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -120,8 +120,7 @@ string trim_right(const string &s, const string &t /* = SPACES */)
 
 string trim(const string &s, const string &t /* = SPACES */)
 {
-  string d(s);
-  return trim_left(trim_right(d, t), t);
+  return trim_left(trim_right(s, t), t);
 }
 
 /**


### PR DESCRIPTION
Found via clang-tidy.