### PR TITLE
Remove redundant string initializations

### DIFF
--- a/src/addhead.cpp
+++ b/src/addhead.cpp
@@ -94,7 +94,7 @@ bool AdditionalHeader::Load(const char* file)
     }
     // load a line
     stringstream ss(line);
-    string       key("");       // suffix(key)
+    string       key;           // suffix(key)
     string       head;          // additional HTTP header
     string       value;         // header value
     if(0 == isblank(line[0])){

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -352,7 +352,7 @@ bool             S3fsCurl::is_public_bucket    = false;
 string           S3fsCurl::default_acl         = "private";
 storage_class_t  S3fsCurl::storage_class       = STANDARD;
 sseckeylist_t    S3fsCurl::sseckeys;
-std::string      S3fsCurl::ssekmsid            = "";
+std::string      S3fsCurl::ssekmsid;
 sse_type_t       S3fsCurl::ssetype             = SSE_DISABLE;
 bool             S3fsCurl::is_content_md5      = false;
 bool             S3fsCurl::is_verbose          = false;
@@ -2713,7 +2713,7 @@ bool S3fsCurl::PreHeadRequest(const char* tpath, const char* bpath, const char* 
 
   // requestHeaders
   if(0 <= ssekey_pos){
-    string md5("");
+    string md5;
     if(!S3fsCurl::GetSseKeyMd5(ssekey_pos, md5) || !AddSseRequestHead(SSE_C, md5, true, false)){
       S3FS_PRN_ERR("Failed to set SSE-C headers for sse-c key pos(%d)(=md5(%s)).", ssekey_pos, md5.c_str());
       return false;
@@ -2850,7 +2850,7 @@ int S3fsCurl::PutHeadRequest(const char* tpath, headers_t& meta, bool is_copy)
   }
   // SSE
   if(!is_copy){
-    string ssevalue("");
+    string ssevalue;
     if(!AddSseRequestHead(S3fsCurl::GetSseType(), ssevalue, false, false)){
       S3FS_PRN_WARN("Failed to set SSE header, but continue...");
     }
@@ -2980,7 +2980,7 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
     requestHeaders = curl_slist_sort_insert(requestHeaders, "x-amz-storage-class", "ONEZONE_IA");
   }
   // SSE
-  string ssevalue("");
+  string ssevalue;
   if(!AddSseRequestHead(S3fsCurl::GetSseType(), ssevalue, false, false)){
     S3FS_PRN_WARN("Failed to set SSE header, but continue...");
   }
@@ -3250,7 +3250,7 @@ int S3fsCurl::PreMultipartPostRequest(const char* tpath, headers_t& meta, string
   }
   // SSE
   if(!is_copy){
-    string ssevalue("");
+    string ssevalue;
     if(!AddSseRequestHead(S3fsCurl::GetSseType(), ssevalue, false, false)){
       S3FS_PRN_WARN("Failed to set SSE header, but continue...");
     }
@@ -3504,7 +3504,7 @@ int S3fsCurl::UploadMultipartPostSetup(const char* tpath, int part_num, const st
 
   // SSE
   if(SSE_C == S3fsCurl::GetSseType()){
-    string ssevalue("");
+    string ssevalue;
     if(!AddSseRequestHead(S3fsCurl::GetSseType(), ssevalue, false, false)){
       S3FS_PRN_WARN("Failed to set SSE header, but continue...");
     }
@@ -4117,7 +4117,7 @@ struct curl_slist* curl_slist_sort_insert(struct curl_slist* list, const char* d
     return list;
   }
   string strkey = data;
-  string strval = "";
+  string strval;
 
   string::size_type pos = strkey.find(':', 0);
   if(string::npos != pos){

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1798,7 +1798,7 @@ pthread_mutex_t FdManager::fd_manager_lock;
 pthread_mutex_t FdManager::cache_cleanup_lock;
 pthread_mutex_t FdManager::reserved_diskspace_lock;
 bool            FdManager::is_lock_init(false);
-string          FdManager::cache_dir("");
+string          FdManager::cache_dir;
 bool            FdManager::check_cache_dir_exist(false);
 size_t          FdManager::free_disk_space = 0;
 
@@ -1837,7 +1837,7 @@ int FdManager::DeleteCacheFile(const char* path)
   if(0 == FdManager::cache_dir.size()){
     return 0;
   }
-  string cache_path = "";
+  string cache_path;
   if(!FdManager::MakeCachePath(path, cache_path, false)){
     return 0;
   }
@@ -2090,7 +2090,7 @@ FdEntity* FdManager::Open(const char* path, headers_t* pmeta, ssize_t size, time
 
     }else if(is_create){
       // not found
-      string cache_path = "";
+      string cache_path;
       if(!force_tmpfile && !FdManager::MakeCachePath(path, cache_path, true)){
         S3FS_PRN_ERR("failed to make cache path for object(%s).", path);
         return NULL;
@@ -2109,7 +2109,7 @@ FdEntity* FdManager::Open(const char* path, headers_t* pmeta, ssize_t size, time
         // The reason why this process here, please look at the definition of the
         // comments of NOCACHE_PATH_PREFIX_FORM symbol.
         //
-        string tmppath("");
+        string tmppath;
         FdManager::MakeRandomTempPath(path, tmppath);
         fent[tmppath] = ent;
       }
@@ -2208,7 +2208,7 @@ bool FdManager::ChangeEntityToTempPath(FdEntity* ent, const char* path)
     if((*iter).second == ent){
       fent.erase(iter++);
 
-      string tmppath("");
+      string tmppath;
       FdManager::MakeRandomTempPath(path, tmppath);
       fent[tmppath] = ent;
     }else{

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -97,10 +97,10 @@ bool complement_stat              = false;
 std::string program_name;
 std::string service_path          = "/";
 std::string host                  = "https://s3.amazonaws.com";
-std::string bucket                = "";
+std::string bucket;
 std::string endpoint              = "us-east-1";
-std::string cipher_suites         = "";
-std::string instance_name         = "";
+std::string cipher_suites;
+std::string instance_name;
 s3fs_log_level debug_level        = S3FS_LOG_CRIT;
 const char*    s3fs_log_nest[S3FS_LOG_NEST_MAX] = {"", "  ", "    ", "      "};
 std::string aws_profile           = "default";
@@ -114,7 +114,7 @@ static mode_t mp_mode             = 0;    // mode of mount point
 static mode_t mp_umask            = 0;    // umask for mount point
 static bool is_mp_umask           = false;// default does not set.
 static std::string mountpoint;
-static std::string passwd_file    = "";
+static std::string passwd_file;
 static bool utility_mode          = false;
 static bool noxmlns               = false;
 static bool nocopyapi             = false;
@@ -138,7 +138,7 @@ static int s3fs_init_deferred_exit_status = 0;
 static bool support_compat_dir    = true;// default supports compatibility directory type
 static int max_keys_list_object   = 1000;// default is 1000
 
-static const std::string allbucket_fields_type = "";         // special key for mapping(This name is absolutely not used as a bucket name)
+static const std::string allbucket_fields_type;              // special key for mapping(This name is absolutely not used as a bucket name)
 static const std::string keyval_fields_type    = "\t";       // special key for mapping(This name is absolutely not used as a bucket name)
 static const std::string aws_accesskeyid       = "AWSAccessKeyId";
 static const std::string aws_secretkey         = "AWSSecretKey";
@@ -2481,7 +2481,7 @@ static int list_bucket(const char* path, S3ObjList& head, const char* delimiter,
   string    query_delimiter;;
   string    query_prefix;;
   string    query_maxkey;;
-  string    next_marker = "";
+  string    next_marker;
   bool      truncated = true;
   S3fsCurl  s3fscurl;
   xmlDocPtr doc;
@@ -2657,7 +2657,7 @@ static int append_objects_from_xml_ex(const char* path, xmlDocPtr doc, xmlXPathC
 static bool GetXmlNsUrl(xmlDocPtr doc, string& nsurl)
 {
   static time_t tmLast = 0;  // cache for 60 sec.
-  static string strNs("");
+  static string strNs;
   bool result = false;
 
   if(!doc){
@@ -2689,10 +2689,10 @@ static int append_objects_from_xml(const char* path, xmlDocPtr doc, S3ObjList& h
 {
   string xmlnsurl;
   string ex_contents = "//";
-  string ex_key      = "";
+  string ex_key;
   string ex_cprefix  = "//";
-  string ex_prefix   = "";
-  string ex_etag     = "";
+  string ex_prefix;
+  string ex_etag;
 
   if(!doc){
     return -1;
@@ -2849,7 +2849,7 @@ static char* get_object_name(xmlDocPtr doc, xmlNodePtr node, const char* path)
         // OK
         return strdup(mybname);
       }else if(basepath && 0 < strlen(basepath) && '/' == basepath[strlen(basepath) - 1] && 0 == strncmp(dirpath, basepath, strlen(basepath) - 1)){
-        string withdirname = "";
+        string withdirname;
         if(strlen(dirpath) > strlen(basepath)){
           withdirname = &dirpath[strlen(basepath)];
         }
@@ -2940,7 +2940,7 @@ static size_t parse_xattrs(const std::string& strxattrs, xattrs_t& xattrs)
   // parse each key:val
   for(size_t pair_nextpos = restxattrs.find_first_of(','); 0 < restxattrs.length(); restxattrs = (pair_nextpos != string::npos ? restxattrs.substr(pair_nextpos + 1) : string("")), pair_nextpos = restxattrs.find_first_of(',')){
     string pair = pair_nextpos != string::npos ? restxattrs.substr(0, pair_nextpos) : restxattrs;
-    string    key  = "";
+    string    key;
     PXATTRVAL pval = NULL;
     if(!parse_xattr_keyval(pair, key, pval)){
       // something format error, so skip this.
@@ -3571,9 +3571,9 @@ static bool get_uncomp_mp_list(xmlDocPtr doc, uncomp_mp_list_t& list)
 
   string xmlnsurl;
   string ex_upload = "//";
-  string ex_key    = "";
-  string ex_id     = "";
-  string ex_date   = "";
+  string ex_key;
+  string ex_id;
+  string ex_date;
 
   if(!noxmlns && GetXmlNsUrl(doc, xmlnsurl)){
     xmlXPathRegisterNs(ctx, (xmlChar*)"s3", (xmlChar*)xmlnsurl.c_str());
@@ -4614,7 +4614,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 0;
     }
     if(0 == STR2NCMP(arg, "ibm_iam_endpoint=")){
-      std::string endpoint_url = "";
+      std::string endpoint_url;
       std::string iam_endpoint = strchr(arg, '=') + sizeof(char);
       // Check url for http / https protocol string
       if((iam_endpoint.compare(0, 8, "https://") != 0) && (iam_endpoint.compare(0, 7, "http://") != 0)) {

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -48,7 +48,7 @@ using namespace std;
 //-------------------------------------------------------------------
 // Global variables
 //-------------------------------------------------------------------
-std::string mount_prefix   = "";
+std::string mount_prefix;
 
 //-------------------------------------------------------------------
 // Utility
@@ -756,7 +756,7 @@ time_t get_mtime(const char *str)
   // truncating the floating point or less (in seconds or less) to
   // correspond to this.
   //
-  string strmtime("");
+  string strmtime;
   if(str && '\0' != *str){
     strmtime = str;
     string::size_type pos = strmtime.find('.', 0);


### PR DESCRIPTION
Found and fixed via clang-tidy.