### PR TITLE
Accept paths with : in them

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4310,7 +4310,7 @@ static int set_bucket(const char* arg)
       return -1;
     }
     bucket = strtok(bucket_name, ":");
-    char* pmount_prefix = strtok(NULL, ":");
+    char* pmount_prefix = strtok(NULL, "");
     if(pmount_prefix){
       if(0 == strlen(pmount_prefix) || '/' != pmount_prefix[0]){
         S3FS_PRN_EXIT("path(%s) must be prefix \"/\".", pmount_prefix);


### PR DESCRIPTION
### Details
Paths with `:` in them (e.g., `/foo:123`) should be valid. The second call to `strtok` truncates anything after the second `:` in the bucket argument in the current version, so:

```
s3fs bucket:'/foo:123' '/tmp/foo:123'
```

ends up trying to mount `bucket:/foo` instead which isn't correct.