### PR TITLE
Remove unneeded void parameter

### DIFF
--- a/src/addhead.cpp
+++ b/src/addhead.cpp
@@ -164,7 +164,7 @@ bool AdditionalHeader::Load(const char* file)
   return true;
 }
 
-void AdditionalHeader::Unload(void)
+void AdditionalHeader::Unload()
 {
   is_enable = false;
 
@@ -239,7 +239,7 @@ struct curl_slist* AdditionalHeader::AddHeader(struct curl_slist* list, const ch
   return list;
 }
 
-bool AdditionalHeader::Dump(void) const
+bool AdditionalHeader::Dump() const
 {
   if(!IS_S3FS_LOG_DBG()){
     return true;

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -167,7 +167,7 @@ StatCache::~StatCache()
 //-------------------------------------------------------------------
 // Methods
 //-------------------------------------------------------------------
-unsigned long StatCache::GetCacheSize(void) const
+unsigned long StatCache::GetCacheSize() const
 {
   return CacheSize;
 }
@@ -179,7 +179,7 @@ unsigned long StatCache::SetCacheSize(unsigned long size)
   return old;
 }
 
-time_t StatCache::GetExpireTime(void) const
+time_t StatCache::GetExpireTime() const
 {
   return (IsExpireTime ? ExpireTime : (-1));
 }
@@ -193,7 +193,7 @@ time_t StatCache::SetExpireTime(time_t expire, bool is_interval)
   return old;
 }
 
-time_t StatCache::UnsetExpireTime(void)
+time_t StatCache::UnsetExpireTime()
 {
   time_t old           = IsExpireTime ? ExpireTime : (-1);
   ExpireTime           = 0;
@@ -209,7 +209,7 @@ bool StatCache::SetCacheNoObject(bool flag)
   return old;
 }
 
-void StatCache::Clear(void)
+void StatCache::Clear()
 {
   AutoLock lock(&StatCache::stat_cache_lock);
 
@@ -478,7 +478,7 @@ void StatCache::ChangeNoTruncateFlag(const std::string& key, bool no_truncate)
   }
 }
 
-bool StatCache::TruncateCache(void)
+bool StatCache::TruncateCache()
 {
   AutoLock lock(&StatCache::stat_cache_lock);
 

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -198,7 +198,7 @@ bool BodyData::Resize(size_t addbytes)
   return true;
 }
 
-void BodyData::Clear(void)
+void BodyData::Clear()
 {
   if(text){
     free(text);
@@ -226,7 +226,7 @@ bool BodyData::Append(void* ptr, size_t bytes)
   return true;
 }
 
-const char* BodyData::str(void) const
+const char* BodyData::str() const
 {
   if(!text){
     static const char* strnull = "";
@@ -414,7 +414,7 @@ bool S3fsCurl::InitS3fsCurl(const char* MimeFile)
   return true;
 }
 
-bool S3fsCurl::DestroyS3fsCurl(void)
+bool S3fsCurl::DestroyS3fsCurl()
 {
   int result = true;
 
@@ -444,7 +444,7 @@ bool S3fsCurl::DestroyS3fsCurl(void)
   return result;
 }
 
-bool S3fsCurl::InitGlobalCurl(void)
+bool S3fsCurl::InitGlobalCurl()
 {
   if(S3fsCurl::is_initglobal_done){
     return false;
@@ -457,7 +457,7 @@ bool S3fsCurl::InitGlobalCurl(void)
   return true;
 }
 
-bool S3fsCurl::DestroyGlobalCurl(void)
+bool S3fsCurl::DestroyGlobalCurl()
 {
   if(!S3fsCurl::is_initglobal_done){
     return false;
@@ -467,7 +467,7 @@ bool S3fsCurl::DestroyGlobalCurl(void)
   return true;
 }
 
-bool S3fsCurl::InitShareCurl(void)
+bool S3fsCurl::InitShareCurl()
 {
   CURLSHcode nSHCode;
 
@@ -516,7 +516,7 @@ bool S3fsCurl::InitShareCurl(void)
   return true;
 }
 
-bool S3fsCurl::DestroyShareCurl(void)
+bool S3fsCurl::DestroyShareCurl()
 {
   if(!S3fsCurl::hCurlShare){
     if(!S3fsCurl::is_dns_cache && !S3fsCurl::is_ssl_session_cache){
@@ -558,12 +558,12 @@ void S3fsCurl::UnlockCurlShare(CURL* handle, curl_lock_data nLockData, void* use
   }
 }
 
-bool S3fsCurl::InitCryptMutex(void)
+bool S3fsCurl::InitCryptMutex()
 {
   return s3fs_init_crypt_mutex();
 }
 
-bool S3fsCurl::DestroyCryptMutex(void)
+bool S3fsCurl::DestroyCryptMutex()
 {
   return s3fs_destroy_crypt_mutex();
 }
@@ -627,7 +627,7 @@ bool S3fsCurl::InitMimeType(const char* MimeFile)
   return true;
 }
 
-void S3fsCurl::InitUserAgent(void)
+void S3fsCurl::InitUserAgent()
 {
   if(S3fsCurl::userAgent.empty()){
     S3fsCurl::userAgent =  "s3fs/";
@@ -699,7 +699,7 @@ string S3fsCurl::LookupMimeType(const string& name)
   return result;
 }
 
-bool S3fsCurl::LocateBundle(void)
+bool S3fsCurl::LocateBundle()
 {
   // See if environment variable CURL_CA_BUNDLE is set
   // if so, check it, if it is a good path, then set the
@@ -1063,7 +1063,7 @@ bool S3fsCurl::SetSseKmsid(const char* kmsid)
 // [NOTE]
 // Because SSE is set by some options and environment, 
 // this function check the integrity of the SSE data finally.
-bool S3fsCurl::FinalCheckSse(void)
+bool S3fsCurl::FinalCheckSse()
 {
   if(SSE_DISABLE == S3fsCurl::ssetype){
     S3fsCurl::ssekmsid.erase();
@@ -1091,7 +1091,7 @@ bool S3fsCurl::FinalCheckSse(void)
   return true;
 }
                                                                                                                                                    
-bool S3fsCurl::LoadEnvSseCKeys(void)
+bool S3fsCurl::LoadEnvSseCKeys()
 {
   char* envkeys = getenv("AWSSSECKEYS");
   if(NULL == envkeys){
@@ -1112,7 +1112,7 @@ bool S3fsCurl::LoadEnvSseCKeys(void)
   return true;
 }
 
-bool S3fsCurl::LoadEnvSseKmsid(void)
+bool S3fsCurl::LoadEnvSseKmsid()
 {
   char* envkmsid = getenv("AWSSSEKMSID");
   if(NULL == envkmsid){
@@ -1155,7 +1155,7 @@ bool S3fsCurl::GetSseKeyMd5(int pos, string& md5)
   return false;
 }
 
-int S3fsCurl::GetSseKeyCount(void)
+int S3fsCurl::GetSseKeyCount()
 {
   return S3fsCurl::sseckeys.size();
 }
@@ -1564,7 +1564,7 @@ bool S3fsCurl::SetIAMCredentials(const char* response)
   return true;
 }
 
-bool S3fsCurl::CheckIAMCredentialUpdate(void)
+bool S3fsCurl::CheckIAMCredentialUpdate()
 {
   if(S3fsCurl::IAM_role.empty() && !S3fsCurl::is_ecs && !S3fsCurl::is_ibm_iam_auth){
     return true;
@@ -1698,7 +1698,7 @@ S3fsCurl::~S3fsCurl()
   DestroyCurlHandle();
 }
 
-bool S3fsCurl::ResetHandle(void)
+bool S3fsCurl::ResetHandle()
 {
   curl_easy_reset(hCurl);
   curl_easy_setopt(hCurl, CURLOPT_NOSIGNAL, 1);
@@ -1798,7 +1798,7 @@ bool S3fsCurl::DestroyCurlHandle(bool force)
   return true;
 }
 
-bool S3fsCurl::ClearInternalData(void)
+bool S3fsCurl::ClearInternalData()
 {
   // Always clear internal data
   //
@@ -1861,7 +1861,7 @@ bool S3fsCurl::GetResponseCode(long& responseCode)
 //
 // Reset all options for retrying
 //
-bool S3fsCurl::RemakeHandle(void)
+bool S3fsCurl::RemakeHandle()
 {
   S3FS_PRN_INFO3("Retry request. [type=%d][url=%s][path=%s]", type, url.c_str(), path.c_str());
 
@@ -2056,7 +2056,7 @@ bool S3fsCurl::RemakeHandle(void)
 //
 // returns curl return code
 //
-int S3fsCurl::RequestPerform(void)
+int S3fsCurl::RequestPerform()
 {
   if(IS_S3FS_LOG_DBG()){
     char* ptr_url = NULL;
@@ -2534,7 +2534,7 @@ int S3fsCurl::DeleteRequest(const char* tpath)
 // Get AccessKeyId/SecretAccessKey/AccessToken/Expiration by IAM role,
 // and Set these value to class variable.
 //
-int S3fsCurl::GetIAMCredentials(void)
+int S3fsCurl::GetIAMCredentials()
 {
   if (!S3fsCurl::is_ecs && !S3fsCurl::is_ibm_iam_auth) {
     S3FS_PRN_INFO3("[IAM role=%s]", S3fsCurl::IAM_role.c_str());
@@ -2609,7 +2609,7 @@ int S3fsCurl::GetIAMCredentials(void)
 //
 // Get IAM role name automatically.
 //
-bool S3fsCurl::LoadIAMRoleFromMetaData(void)
+bool S3fsCurl::LoadIAMRoleFromMetaData()
 {
   S3FS_PRN_INFO3("Get IAM Role name");
 
@@ -3100,7 +3100,7 @@ int S3fsCurl::GetObjectRequest(const char* tpath, int fd, off_t start, ssize_t s
   return result;
 }
 
-int S3fsCurl::CheckBucket(void)
+int S3fsCurl::CheckBucket()
 {
   S3FS_PRN_INFO3("check a bucket.");
 
@@ -3915,7 +3915,7 @@ bool S3fsMultiCurl::SetS3fsCurlObject(S3fsCurl* s3fscurl)
   return true;
 }
 
-int S3fsMultiCurl::MultiPerform(void)
+int S3fsMultiCurl::MultiPerform()
 {
   std::vector<pthread_t>   threads;
   bool                     success = true;
@@ -3987,7 +3987,7 @@ int S3fsMultiCurl::MultiPerform(void)
   return success ? 0 : -EIO;
 }
 
-int S3fsMultiCurl::MultiRead(void)
+int S3fsMultiCurl::MultiRead()
 {
   for(s3fscurlmap_t::iterator iter = cMap_req.begin(); iter != cMap_req.end(); cMap_req.erase(iter++)) {
     S3fsCurl* s3fscurl = (*iter).second;
@@ -4053,7 +4053,7 @@ int S3fsMultiCurl::MultiRead(void)
   return 0;
 }
 
-int S3fsMultiCurl::Request(void)
+int S3fsMultiCurl::Request()
 {
   S3FS_PRN_INFO3("[count=%zu]", cMap_all.size());
 

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -88,7 +88,7 @@ bool CacheFileStat::MakeCacheFileStatPath(const char* path, string& sfile_path, 
   return true;
 }
 
-bool CacheFileStat::CheckCacheFileStatTopDir(void)
+bool CacheFileStat::CheckCacheFileStatTopDir()
 {
   if(!FdManager::IsCacheDir()){
     return true;
@@ -128,7 +128,7 @@ bool CacheFileStat::DeleteCacheFileStat(const char* path)
 // If remove stat file directory, it should do before removing
 // file cache directory.
 //
-bool CacheFileStat::DeleteCacheFileStatDirectory(void)
+bool CacheFileStat::DeleteCacheFileStatDirectory()
 {
   string top_path = FdManager::GetCacheDir();
 
@@ -174,7 +174,7 @@ bool CacheFileStat::SetPath(const char* tpath, bool is_open)
   return Open();
 }
 
-bool CacheFileStat::Open(void)
+bool CacheFileStat::Open()
 {
   if(path.empty()){
     return false;
@@ -214,7 +214,7 @@ bool CacheFileStat::Open(void)
   return true;
 }
 
-bool CacheFileStat::Release(void)
+bool CacheFileStat::Release()
 {
   if(-1 == fd){
     // already release
@@ -257,7 +257,7 @@ PageList::~PageList()
   Clear();
 }
 
-void PageList::Clear(void)
+void PageList::Clear()
 {
   PageList::FreeList(pages);
 }
@@ -270,7 +270,7 @@ bool PageList::Init(size_t size, bool is_loaded)
   return true;
 }
 
-size_t PageList::Size(void) const
+size_t PageList::Size() const
 {
   if(pages.empty()){
     return 0;
@@ -279,7 +279,7 @@ size_t PageList::Size(void) const
   return static_cast<size_t>((*riter)->next());
 }
 
-bool PageList::Compress(void)
+bool PageList::Compress()
 {
   bool is_first       = true;
   bool is_last_loaded = false;
@@ -600,7 +600,7 @@ bool PageList::Serialize(CacheFileStat& file, bool is_output)
   return true;
 }
 
-void PageList::Dump(void)
+void PageList::Dump()
 {
   int cnt = 0;
 
@@ -660,7 +660,7 @@ FdEntity::~FdEntity()
   }
 }
 
-void FdEntity::Clear(void)
+void FdEntity::Clear()
 {
   AutoLock auto_lock(&fdent_lock);
 
@@ -691,7 +691,7 @@ void FdEntity::Clear(void)
   is_modify     = false;
 }
 
-void FdEntity::Close(void)
+void FdEntity::Close()
 {
   S3FS_PRN_DBG("[path=%s][fd=%d][refcnt=%d]", path.c_str(), fd, (-1 != fd ? refcnt - 1 : refcnt));
 
@@ -738,7 +738,7 @@ int FdEntity::Dup()
 //
 // Open mirror file which is linked cache file.
 //
-int FdEntity::OpenMirrorFile(void)
+int FdEntity::OpenMirrorFile()
 {
   if(cachepath.empty()){
     S3FS_PRN_ERR("cache path is empty, why come here");
@@ -1055,7 +1055,7 @@ int FdEntity::SetMtime(time_t time)
   return 0;
 }
 
-bool FdEntity::UpdateCtime(void)
+bool FdEntity::UpdateCtime()
 {
   AutoLock auto_lock(&fdent_lock);
   struct stat st;
@@ -1066,7 +1066,7 @@ bool FdEntity::UpdateCtime(void)
   return true;
 }
 
-bool FdEntity::UpdateMtime(void)
+bool FdEntity::UpdateMtime()
 {
   AutoLock auto_lock(&fdent_lock);
   struct stat st;
@@ -1390,7 +1390,7 @@ int FdEntity::NoCacheLoadAndPost(off_t start, size_t size)
 // At no disk space for caching object.
 // This method is starting multipart uploading.
 //
-int FdEntity::NoCachePreMultipartPost(void)
+int FdEntity::NoCachePreMultipartPost()
 {
   // initialize multipart upload values
   upload_id.erase();
@@ -1423,7 +1423,7 @@ int FdEntity::NoCacheMultipartPost(int tgfd, off_t start, size_t size)
 // At no disk space for caching object.
 // This method is finishing multipart uploading.
 //
-int FdEntity::NoCacheCompleteMultipartPost(void)
+int FdEntity::NoCacheCompleteMultipartPost()
 {
   if(upload_id.empty() || etaglist.empty()){
     S3FS_PRN_ERR("There is no upload id or etag list.");
@@ -1824,7 +1824,7 @@ bool FdManager::SetCacheDir(const char* dir)
   return true;
 }
 
-bool FdManager::DeleteCacheDirectory(void)
+bool FdManager::DeleteCacheDirectory()
 {
   if(FdManager::cache_dir.empty()){
     return true;
@@ -1916,7 +1916,7 @@ bool FdManager::MakeCachePath(const char* path, string& cache_path, bool is_crea
   return true;
 }
 
-bool FdManager::CheckCacheTopDir(void)
+bool FdManager::CheckCacheTopDir()
 {
   if(FdManager::cache_dir.empty()){
     return true;
@@ -1943,7 +1943,7 @@ bool FdManager::SetCheckCacheDirExist(bool is_check)
   return old;
 }
 
-bool FdManager::CheckCacheDirExist(void)
+bool FdManager::CheckCacheDirExist()
 {
   if(!FdManager::check_cache_dir_exist){
     return true;

--- a/src/gnutls_auth.cpp
+++ b/src/gnutls_auth.cpp
@@ -57,7 +57,7 @@ const char* s3fs_crypt_lib_name(void)
 
 #else	// USE_GNUTLS_NETTLE
 
-const char* s3fs_crypt_lib_name(void)
+const char* s3fs_crypt_lib_name()
 {
   static const char version[] = "GnuTLS(gcrypt)";
 
@@ -69,7 +69,7 @@ const char* s3fs_crypt_lib_name(void)
 //-------------------------------------------------------------------
 // Utility Function for global init
 //-------------------------------------------------------------------
-bool s3fs_init_global_ssl(void)
+bool s3fs_init_global_ssl()
 {
   if(GNUTLS_E_SUCCESS != gnutls_global_init()){
     return false;
@@ -82,7 +82,7 @@ bool s3fs_init_global_ssl(void)
   return true;
 }
 
-bool s3fs_destroy_global_ssl(void)
+bool s3fs_destroy_global_ssl()
 {
   gnutls_global_deinit();
   return true;
@@ -91,12 +91,12 @@ bool s3fs_destroy_global_ssl(void)
 //-------------------------------------------------------------------
 // Utility Function for crypt lock
 //-------------------------------------------------------------------
-bool s3fs_init_crypt_mutex(void)
+bool s3fs_init_crypt_mutex()
 {
   return true;
 }
 
-bool s3fs_destroy_crypt_mutex(void)
+bool s3fs_destroy_crypt_mutex()
 {
   return true;
 }
@@ -191,7 +191,7 @@ bool s3fs_HMAC256(const void* key, size_t keylen, const unsigned char* data, siz
 //-------------------------------------------------------------------
 // Utility Function for MD5
 //-------------------------------------------------------------------
-size_t get_md5_digest_length(void)
+size_t get_md5_digest_length()
 {
   return 16;
 }
@@ -303,7 +303,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
 //-------------------------------------------------------------------
 // Utility Function for SHA256
 //-------------------------------------------------------------------
-size_t get_sha256_digest_length(void)
+size_t get_sha256_digest_length()
 {
   return 32;
 }

--- a/src/nss_auth.cpp
+++ b/src/nss_auth.cpp
@@ -42,7 +42,7 @@ using namespace std;
 //-------------------------------------------------------------------
 // Utility Function for version
 //-------------------------------------------------------------------
-const char* s3fs_crypt_lib_name(void)
+const char* s3fs_crypt_lib_name()
 {
   static const char version[] = "NSS";
 
@@ -52,7 +52,7 @@ const char* s3fs_crypt_lib_name(void)
 //-------------------------------------------------------------------
 // Utility Function for global init
 //-------------------------------------------------------------------
-bool s3fs_init_global_ssl(void)
+bool s3fs_init_global_ssl()
 {
   PR_Init(PR_USER_THREAD, PR_PRIORITY_NORMAL, 0);
 
@@ -63,7 +63,7 @@ bool s3fs_init_global_ssl(void)
   return true;
 }
 
-bool s3fs_destroy_global_ssl(void)
+bool s3fs_destroy_global_ssl()
 {
   NSS_Shutdown();
   PL_ArenaFinish();
@@ -74,12 +74,12 @@ bool s3fs_destroy_global_ssl(void)
 //-------------------------------------------------------------------
 // Utility Function for crypt lock
 //-------------------------------------------------------------------
-bool s3fs_init_crypt_mutex(void)
+bool s3fs_init_crypt_mutex()
 {
   return true;
 }
 
-bool s3fs_destroy_crypt_mutex(void)
+bool s3fs_destroy_crypt_mutex()
 {
   return true;
 }
@@ -148,7 +148,7 @@ bool s3fs_HMAC256(const void* key, size_t keylen, const unsigned char* data, siz
 //-------------------------------------------------------------------
 // Utility Function for MD5
 //-------------------------------------------------------------------
-size_t get_md5_digest_length(void)
+size_t get_md5_digest_length()
 {
   return MD5_LENGTH;
 }
@@ -210,7 +210,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
 //-------------------------------------------------------------------
 // Utility Function for SHA256
 //-------------------------------------------------------------------
-size_t get_sha256_digest_length(void)
+size_t get_sha256_digest_length()
 {
   return SHA256_LENGTH;
 }

--- a/src/openssl_auth.cpp
+++ b/src/openssl_auth.cpp
@@ -46,7 +46,7 @@ using namespace std;
 //-------------------------------------------------------------------
 // Utility Function for version
 //-------------------------------------------------------------------
-const char* s3fs_crypt_lib_name(void)
+const char* s3fs_crypt_lib_name()
 {
   static const char version[] = "OpenSSL";
 
@@ -56,7 +56,7 @@ const char* s3fs_crypt_lib_name(void)
 //-------------------------------------------------------------------
 // Utility Function for global init
 //-------------------------------------------------------------------
-bool s3fs_init_global_ssl(void)
+bool s3fs_init_global_ssl()
 {
   ERR_load_crypto_strings();
   ERR_load_BIO_strings();
@@ -64,7 +64,7 @@ bool s3fs_init_global_ssl(void)
   return true;
 }
 
-bool s3fs_destroy_global_ssl(void)
+bool s3fs_destroy_global_ssl()
 {
   EVP_cleanup();
   ERR_free_strings();
@@ -93,7 +93,7 @@ static void s3fs_crypt_mutex_lock(int mode, int pos, const char* file, int line)
   }
 }
 
-static unsigned long s3fs_crypt_get_threadid(void)
+static unsigned long s3fs_crypt_get_threadid()
 {
   // For FreeBSD etc, some system's pthread_t is structure pointer.
   // Then we use cast like C style(not C++) instead of ifdef.
@@ -131,7 +131,7 @@ static void s3fs_destroy_dyn_crypt_mutex(struct CRYPTO_dynlock_value* dyndata, c
   }
 }
 
-bool s3fs_init_crypt_mutex(void)
+bool s3fs_init_crypt_mutex()
 {
   if(s3fs_crypt_mutex){
     S3FS_PRN_DBG("s3fs_crypt_mutex is not NULL, destroy it.");
@@ -158,7 +158,7 @@ bool s3fs_init_crypt_mutex(void)
   return true;
 }
 
-bool s3fs_destroy_crypt_mutex(void)
+bool s3fs_destroy_crypt_mutex()
 {
   if(!s3fs_crypt_mutex){
     return true;
@@ -214,7 +214,7 @@ bool s3fs_HMAC256(const void* key, size_t keylen, const unsigned char* data, siz
 //-------------------------------------------------------------------
 // Utility Function for MD5
 //-------------------------------------------------------------------
-size_t get_md5_digest_length(void)
+size_t get_md5_digest_length()
 {
   return MD5_DIGEST_LENGTH;
 }
@@ -273,7 +273,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
 //-------------------------------------------------------------------
 // Utility Function for SHA256
 //-------------------------------------------------------------------
-size_t get_sha256_digest_length(void)
+size_t get_sha256_digest_length()
 {
   return SHA256_DIGEST_LENGTH;
 }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -148,9 +148,9 @@ static const std::string aws_secretkey         = "AWSSecretKey";
 // Static functions : prototype
 //-------------------------------------------------------------------
 static void s3fs_usr2_handler(int sig);
-static bool set_s3fs_usr2_handler(void);
+static bool set_s3fs_usr2_handler();
 static s3fs_log_level set_s3fs_log_level(s3fs_log_level level);
-static s3fs_log_level bumpup_s3fs_log_level(void);
+static s3fs_log_level bumpup_s3fs_log_level();
 static bool is_special_name_folder_object(const char* path);
 static int chk_dir_object_type(const char* path, string& newpath, string& nowpath, string& nowcache, headers_t* pmeta = NULL, dirtype* pDirType = NULL);
 static int remove_old_type_dir(const string& path, dirtype type);
@@ -190,14 +190,14 @@ static void free_xattrs(xattrs_t& xattrs);
 static bool parse_xattr_keyval(const std::string& xattrpair, string& key, PXATTRVAL& pval);
 static size_t parse_xattrs(const std::string& strxattrs, xattrs_t& xattrs);
 static std::string build_xattrs(const xattrs_t& xattrs);
-static int s3fs_utility_mode(void);
-static int s3fs_check_service(void);
+static int s3fs_utility_mode();
+static int s3fs_check_service();
 static int parse_passwd_file(bucketkvmap_t& resmap);
 static int check_for_aws_format(const kvmap_t& kvmap);
-static int check_passwd_file_perms(void);
+static int check_passwd_file_perms();
 static int read_aws_credentials_file(const std::string &filename);
-static int read_passwd_file(void);
-static int get_access_keys(void);
+static int read_passwd_file();
+static int get_access_keys();
 static int set_mountpoint_attribute(struct stat& mpst);
 static int set_bucket(const char* arg);
 static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_args* outargs);
@@ -251,7 +251,7 @@ static void s3fs_usr2_handler(int sig)
     bumpup_s3fs_log_level();
   }
 }
-static bool set_s3fs_usr2_handler(void)
+static bool set_s3fs_usr2_handler()
 {
   struct sigaction sa;
 
@@ -276,7 +276,7 @@ static s3fs_log_level set_s3fs_log_level(s3fs_log_level level)
   return old;
 }
 
-static s3fs_log_level bumpup_s3fs_log_level(void)
+static s3fs_log_level bumpup_s3fs_log_level()
 {
   s3fs_log_level old = debug_level;
   debug_level        = ( S3FS_LOG_CRIT == debug_level ? S3FS_LOG_ERR :
@@ -912,7 +912,7 @@ static int s3fs_readlink(const char* path, char* buf, size_t size)
   return 0;
 }
 
-static int do_create_bucket(void)
+static int do_create_bucket()
 {
   S3FS_PRN_INFO2("/");
 
@@ -3642,7 +3642,7 @@ static bool get_uncomp_mp_list(xmlDocPtr doc, uncomp_mp_list_t& list)
   return true;
 }
 
-static int s3fs_utility_mode(void)
+static int s3fs_utility_mode()
 {
   if(!utility_mode){
     return EXIT_FAILURE;
@@ -3734,7 +3734,7 @@ static bool check_region_error(const char* pbody, const string& currentep, strin
   return true;
 }
 
-static int s3fs_check_service(void)
+static int s3fs_check_service()
 {
   S3FS_PRN_INFO("check services.");
 
@@ -3977,7 +3977,7 @@ static int check_for_aws_format(const kvmap_t& kvmap)
 //
 // only two options: return or error out
 //
-static int check_passwd_file_perms(void)
+static int check_passwd_file_perms()
 {
   struct stat info;
 
@@ -4089,7 +4089,7 @@ static int read_aws_credentials_file(const std::string &filename)
 //
 // only one default key pair is allowed, but not required
 //
-static int read_passwd_file(void)
+static int read_passwd_file()
 {
   bucketkvmap_t bucketmap;
   kvmap_t       keyval;
@@ -4161,7 +4161,7 @@ static int read_passwd_file(void)
 // 4 - from the users ~/.passwd-s3fs
 // 5 - from /etc/passwd-s3fs
 //
-static int get_access_keys(void)
+static int get_access_keys()
 {
   // should be redundant
   if(S3fsCurl::IsPublicBucket()){

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -993,13 +993,13 @@ bool is_need_check_obj_detail(headers_t& meta)
 //-------------------------------------------------------------------
 // Help
 //-------------------------------------------------------------------
-void show_usage (void)
+void show_usage ()
 {
   printf("Usage: %s BUCKET:[PATH] MOUNTPOINT [OPTION]...\n",
     program_name.c_str());
 }
 
-void show_help (void)
+void show_help ()
 {
   show_usage();
   printf(
@@ -1365,7 +1365,7 @@ void show_help (void)
   return;
 }
 
-void show_version(void)
+void show_version()
 {
   printf(
   "Amazon Simple Storage Service File System V%s(commit:%s) with %s\n"


### PR DESCRIPTION
This is implicit in C++.  Found and fixed via clang-tidy.