### PR TITLE
Fixed code for latest cppcheck error on OSX

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,7 @@ cppcheck:
 	cppcheck --quiet --error-exitcode=1 \
             --inline-suppr \
             --std=c++03 \
+            --xml \
             -D HAVE_ATTR_XATTR_H \
             -D HAVE_SYS_EXTATTR_H \
             -D HAVE_MALLOC_TRIM \
@@ -40,4 +41,5 @@ cppcheck:
             -U ENOATTR \
             --enable=warning,style,information,missingInclude \
             --suppress=missingIncludeSystem \
+            --suppress=unmatchedSuppression \
             src/ test/

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -659,9 +659,8 @@ string S3fsCurl::LookupMimeType(const string& name)
     return result;
   }
   // extract the last extension
-  if(last_pos != string::npos){
-    ext = name.substr(1+last_pos, string::npos);
-  }
+  ext = name.substr(1+last_pos, string::npos);
+
   if (last_pos != string::npos) {
      // one dot was found, now look for another
      if (first_pos != string::npos && first_pos < last_pos) {

--- a/src/gnutls_auth.cpp
+++ b/src/gnutls_auth.cpp
@@ -371,6 +371,7 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
 bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char** digest, unsigned int* digestlen)
 {
   (*digestlen) = static_cast<unsigned int>(get_sha256_digest_length());
+                                                                                    // cppcheck-suppress constArgument
   if(NULL == ((*digest) = reinterpret_cast<unsigned char*>(malloc(*digestlen)))){
     return false;
   }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -883,7 +883,7 @@ static int s3fs_getattr(const char* path, struct stat* stbuf)
 
 static int s3fs_readlink(const char* path, char* buf, size_t size)
 {
-  if(!path || !buf || 0 >= size){
+  if(!path || !buf || 0 == size){
     return 0;
   }
   // Open
@@ -2161,7 +2161,7 @@ static int s3fs_read(const char* path, char* buf, size_t size, off_t offset, str
 
   // check real file size
   size_t realsize = 0;
-  if(!ent->GetSize(realsize) || realsize <= 0){
+  if(!ent->GetSize(realsize) || 0 == realsize){
     S3FS_PRN_DBG("file size is 0, so break to read.");
     FdManager::get()->Close(ent);
     return 0;
@@ -3255,7 +3255,7 @@ static int s3fs_listxattr(const char* path, char* list, size_t size)
   }
 
   // check parameters
-  if(size <= 0){
+  if(0 == size){
     free_xattrs(xattrs);
     return total;
   }

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -152,7 +152,9 @@ bool S3ObjList::insert_normalized(const char* name, const char* normalized, bool
     // found name --> over write
     (*iter).second.orgname.erase();
     (*iter).second.etag.erase();
+                                                // cppcheck-suppress unreadVariable
     (*iter).second.normalname = normalized;
+                                                // cppcheck-suppress unreadVariable
     (*iter).second.is_dir     = is_dir;
   }else{
     // not found --> add new object

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -369,7 +369,7 @@ char* s3fs_base64(const unsigned char* input, size_t length)
   static const char* base = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
   char* result;
 
-  if(!input || 0 >= length){
+  if(!input || 0 == length){
     return NULL;
   }
   if(NULL == (result = reinterpret_cast<char*>(malloc((((length / 3) + 1) * 4 + 1) * sizeof(char))))){


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
With the upgrade of cppcheck used by OSX on TravisCI, cppcheck error appeared.
I corrected these errors.
Since the version of cppcheck depends on the build OS, the code for handling it complicates.
Therefore, inline cppcheck-suppress prevented it(Even if it is unnecessary code, I want to keep it).
Added --suppress=unmatchedSuppression and --xml(to show error id) in cppcheck options.
