### PR TITLE
Support undefined CURLoption in libcurl library used in build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,51 @@ AC_COMPILE_IFELSE(
 )
 
 dnl ----------------------------------------------
+dnl check CURLoption
+dnl ----------------------------------------------
+dnl CURLOPT_TCP_KEEPALIVE (is supported by 7.25.0 and later)
+AC_MSG_CHECKING([checking CURLOPT_TCP_KEEPALIVE])
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM([[#include <curl/curl.h>]],
+                   [[CURLoption opt = CURLOPT_TCP_KEEPALIVE;]])
+  ],
+  [AC_DEFINE(HAVE_CURLOPT_TCP_KEEPALIVE, 1, [Define to 1 if libcurl has CURLOPT_TCP_KEEPALIVE CURLoption])
+   AC_MSG_RESULT(yes)
+  ],
+  [AC_DEFINE(HAVE_CURLOPT_TCP_KEEPALIVE, 0, [Define to 1 if libcurl has CURLOPT_TCP_KEEPALIVE CURLoption])
+   AC_MSG_RESULT(no)
+  ]
+)
+
+dnl CURLOPT_SSL_ENABLE_ALPN (is supported by 7.36.0 and later)
+AC_MSG_CHECKING([checking CURLOPT_SSL_ENABLE_ALPN])
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM([[#include <curl/curl.h>]],
+                   [[CURLoption opt = CURLOPT_SSL_ENABLE_ALPN;]])
+  ],
+  [AC_DEFINE(HAVE_CURLOPT_SSL_ENABLE_ALPN, 1, [Define to 1 if libcurl has CURLOPT_SSL_ENABLE_ALPN CURLoption])
+   AC_MSG_RESULT(yes)
+  ],
+  [AC_DEFINE(HAVE_CURLOPT_SSL_ENABLE_ALPN, 0, [Define to 1 if libcurl has CURLOPT_SSL_ENABLE_ALPN CURLoption])
+   AC_MSG_RESULT(no)
+  ]
+)
+
+dnl CURLOPT_KEEP_SENDING_ON_ERROR (is supported by 7.51.0 and later)
+AC_MSG_CHECKING([checking CURLOPT_KEEP_SENDING_ON_ERROR])
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM([[#include <curl/curl.h>]],
+                   [[CURLoption opt = CURLOPT_KEEP_SENDING_ON_ERROR;]])
+  ],
+  [AC_DEFINE(HAVE_CURLOPT_KEEP_SENDING_ON_ERROR, 1, [Define to 1 if libcurl has CURLOPT_KEEP_SENDING_ON_ERROR CURLoption])
+   AC_MSG_RESULT(yes)
+  ],
+  [AC_DEFINE(HAVE_CURLOPT_KEEP_SENDING_ON_ERROR, 0, [Define to 1 if libcurl has CURLOPT_KEEP_SENDING_ON_ERROR CURLoption])
+   AC_MSG_RESULT(no)
+  ]
+)
+
+dnl ----------------------------------------------
 dnl output files
 dnl ----------------------------------------------
 AC_CONFIG_FILES(Makefile src/Makefile test/Makefile doc/Makefile)

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1848,9 +1848,15 @@ bool S3fsCurl::ResetHandle()
   curl_easy_setopt(hCurl, CURLOPT_PROGRESSFUNCTION, S3fsCurl::CurlProgress);
   curl_easy_setopt(hCurl, CURLOPT_PROGRESSDATA, hCurl);
   // curl_easy_setopt(hCurl, CURLOPT_FORBID_REUSE, 1);
-  curl_easy_setopt(hCurl, CURLOPT_TCP_KEEPALIVE, 1);
-  // curl_easy_setopt(hCurl, CURLOPT_KEEP_SENDING_ON_ERROR, 1);    // after 7.51.0
-  // curl_easy_setopt(hCurl, CURLOPT_SSL_ENABLE_ALPN, 0);          // after 7.36.0 for disable ALPN for s3 server
+  if(CURLE_OK != curl_easy_setopt(hCurl, S3FS_CURLOPT_TCP_KEEPALIVE, 1)){
+    S3FS_PRN_WARN("The CURLOPT_TCP_KEEPALIVE option could not be set. For maximize performance you need to enable this option and you should use libcurl 7.25.0 or later.");
+  }
+  if(CURLE_OK != curl_easy_setopt(hCurl, S3FS_CURLOPT_SSL_ENABLE_ALPN, 0)){
+    S3FS_PRN_WARN("The CURLOPT_SSL_ENABLE_ALPN option could not be unset. S3 server does not support ALPN, then this option should be disabled to maximize performance. you need to use libcurl 7.36.0 or later.");
+  }
+  if(CURLE_OK != curl_easy_setopt(hCurl, S3FS_CURLOPT_KEEP_SENDING_ON_ERROR, 1)){
+    S3FS_PRN_WARN("The S3FS_CURLOPT_KEEP_SENDING_ON_ERROR option could not be set. For maximize performance you need to enable this option and you should use libcurl 7.51.0 or later.");
+  }
 
   if(type != REQTYPE_IAMCRED && type != REQTYPE_IAMROLE){
     // REQTYPE_IAMCRED and REQTYPE_IAMROLE are always HTTP

--- a/src/curl.h
+++ b/src/curl.h
@@ -26,6 +26,39 @@
 #include "psemaphore.h"
 
 //----------------------------------------------
+// Avoid dependency on libcurl version
+//----------------------------------------------
+// [NOTE]
+// The following symbols (enum) depend on the version of libcurl.
+//  CURLOPT_TCP_KEEPALIVE           7.25.0 and later
+//  CURLOPT_SSL_ENABLE_ALPN         7.36.0 and later
+//  CURLOPT_KEEP_SENDING_ON_ERROR   7.51.0 and later
+//
+// s3fs uses these, if you build s3fs with the old libcurl, 
+// substitute the following symbols to avoid errors.
+// If the version of libcurl linked at runtime is old,
+// curl_easy_setopt results in an error(CURLE_UNKNOWN_OPTION) and
+// a message is output.
+//
+#if defined(HAVE_CURLOPT_TCP_KEEPALIVE) && (HAVE_CURLOPT_TCP_KEEPALIVE == 1)
+  #define   S3FS_CURLOPT_TCP_KEEPALIVE          CURLOPT_TCP_KEEPALIVE
+#else
+  #define   S3FS_CURLOPT_TCP_KEEPALIVE          static_cast<CURLoption>(213)
+#endif
+
+#if defined(HAVE_CURLOPT_SSL_ENABLE_ALPN) && (HAVE_CURLOPT_SSL_ENABLE_ALPN == 1)
+  #define   S3FS_CURLOPT_SSL_ENABLE_ALPN        CURLOPT_SSL_ENABLE_ALPN
+#else
+  #define   S3FS_CURLOPT_SSL_ENABLE_ALPN        static_cast<CURLoption>(226)
+#endif
+
+#if defined(HAVE_CURLOPT_KEEP_SENDING_ON_ERROR) && (HAVE_CURLOPT_KEEP_SENDING_ON_ERROR == 1)
+  #define   S3FS_CURLOPT_KEEP_SENDING_ON_ERROR  CURLOPT_KEEP_SENDING_ON_ERROR
+#else
+  #define   S3FS_CURLOPT_KEEP_SENDING_ON_ERROR  static_cast<CURLoption>(245)
+#endif
+
+//----------------------------------------------
 // Symbols
 //----------------------------------------------
 static const int MIN_MULTIPART_SIZE = 5 * 1024 * 1024;


### PR DESCRIPTION
## Relevant Issue (if applicable)
#976 #935 

## Details
Maintaining an SSL session with CURL will improve performance, and s3fs should use the CURLOPT_TCP_KEEPALIVE, CURLOPT_KEEP_SENDING_ON_ERROR and CURLOPT_SSL_ENABLE_ALPN CURLoptions for curl_easy_setopt().

However, the version of libcurl you use when building may not support these options.

This PR can create s3fs regardless of the version of libcurl used in the build.
That is, if these options are not defined in curl.h, these options will be defined in the s3fs header file and used.
Certainly, defining option values ​​in curl.h to be present in s3fs may not be good, but we expect that libcurl will not change the defined values ​​and assign a fixed value.
So far, this PR allows you to build s3fs without reliance on the libcurl version.

### More details
#### configure output
When you start configure, the following message is output.
It will output "no" if the target option is undefined.
```
checking checking CURLOPT_TCP_KEEPALIVE... (yes or no)
checking checking CURLOPT_SSL_ENABLE_ALPN... (yes or no)
checking checking CURLOPT_KEEP_SENDING_ON_ERROR... (yes or no)
```
#### common.h
In this header file, CURLOPT_TCP_KEEPALIVE, CURLOPT_KEEP_SENDING_ON_ERROR and CURLOPT_SSL_ENABLE_ALPN CURLoptions are defined with S3FS prefix.
And s3fs calls curl_easy_setopt () using the S3FS prefix symbol.