### PR TITLE
Modified to discard _netdev option etc

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -5000,6 +5000,20 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       use_wtf8 = true;
       return 0;
     }
+
+    // [NOTE]
+    // following option will be discarding, because these are not for fuse.
+    // (Referenced sshfs.c)
+    //
+    if(0 == strcmp(arg, "auto")   ||
+       0 == strcmp(arg, "noauto") ||
+       0 == strcmp(arg, "user")   ||
+       0 == strcmp(arg, "nouser") ||
+       0 == strcmp(arg, "users")  ||
+       0 == strcmp(arg, "_netdev"))
+    {
+      return 0;
+    }
   }
   return 1;
 }


### PR DESCRIPTION
### Relevant Issue (if applicable)
#996 

### Details
This PR is a fix for the #996 Issue.
The _netdev option has been corrected to be ignored by s3fs.
Refer to the code of sshfs(sshfs.c) and ignore auto/noauto/user/nouser/users options as well.
