### PR TITLE
Prefer simple over compound statements in macros

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -76,38 +76,46 @@ enum s3fs_log_level{
 #define S3FS_LOG_NEST(nest)  (nest < S3FS_LOG_NEST_MAX ? s3fs_log_nest[nest] : s3fs_log_nest[S3FS_LOG_NEST_MAX - 1])
 
 #define S3FS_LOW_LOGPRN(level, fmt, ...) \
+     do{ \
        if(S3FS_LOG_CRIT == level || (S3FS_LOG_CRIT != debug_level && level == (debug_level & level))){ \
          if(foreground){ \
            fprintf(stdout, "%s%s:%s(%d): " fmt "%s\n", S3FS_LOG_LEVEL_STRING(level), __FILE__, __func__, __LINE__, __VA_ARGS__); \
          }else{ \
            syslog(S3FS_LOG_LEVEL_TO_SYSLOG(level), "%s%s:%s(%d): " fmt "%s", instance_name.c_str(), __FILE__, __func__, __LINE__, __VA_ARGS__); \
          } \
-       }
+       } \
+     }while(0)
 
 #define S3FS_LOW_LOGPRN2(level, nest, fmt, ...) \
+     do{ \
        if(S3FS_LOG_CRIT == level || (S3FS_LOG_CRIT != debug_level && level == (debug_level & level))){ \
          if(foreground){ \
            fprintf(stdout, "%s%s%s:%s(%d): " fmt "%s\n", S3FS_LOG_LEVEL_STRING(level), S3FS_LOG_NEST(nest), __FILE__, __func__, __LINE__, __VA_ARGS__); \
          }else{ \
            syslog(S3FS_LOG_LEVEL_TO_SYSLOG(level), "%s%s" fmt "%s", instance_name.c_str(), S3FS_LOG_NEST(nest), __VA_ARGS__); \
          } \
-       }
+       } \
+     }while(0)
 
 #define S3FS_LOW_LOGPRN_EXIT(fmt, ...) \
+     do{ \
        if(foreground){ \
          fprintf(stderr, "s3fs: " fmt "%s\n", __VA_ARGS__); \
        }else{ \
          fprintf(stderr, "s3fs: " fmt "%s\n", __VA_ARGS__); \
          syslog(S3FS_LOG_LEVEL_TO_SYSLOG(S3FS_LOG_CRIT), "%ss3fs: " fmt "%s", instance_name.c_str(), __VA_ARGS__); \
-       }
+       } \
+     }while(0)
 
 // Special macro for init message
 #define S3FS_PRN_INIT_INFO(fmt, ...) \
+     do{ \
        if(foreground){ \
          fprintf(stdout, "%s%s%s:%s(%d): " fmt "%s\n", S3FS_LOG_LEVEL_STRING(S3FS_LOG_INFO), S3FS_LOG_NEST(0), __FILE__, __func__, __LINE__, __VA_ARGS__, ""); \
        }else{ \
          syslog(S3FS_LOG_LEVEL_TO_SYSLOG(S3FS_LOG_INFO), "%s%s" fmt "%s", instance_name.c_str(), S3FS_LOG_NEST(0), __VA_ARGS__, ""); \
-       }
+       } \
+     }while(0)
 
 // [NOTE]
 // small trick for VA_ARGS

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1892,8 +1892,8 @@ bool S3fsCurl::ResetHandle()
     curl_easy_setopt(hCurl, CURLOPT_SHARE, S3fsCurl::hCurlShare);
   }
   if(!S3fsCurl::is_cert_check) {
-    S3FS_PRN_DBG("'no_check_certificate' option in effect.")
-    S3FS_PRN_DBG("The server certificate won't be checked against the available certificate authorities.")
+    S3FS_PRN_DBG("'no_check_certificate' option in effect.");
+    S3FS_PRN_DBG("The server certificate won't be checked against the available certificate authorities.");
     curl_easy_setopt(hCurl, CURLOPT_SSL_VERIFYPEER, false);
   }
   if(S3fsCurl::is_verbose){

--- a/src/s3fs.h
+++ b/src/s3fs.h
@@ -26,12 +26,13 @@ static const int64_t FIVE_GB = 5LL * 1024LL * 1024LL * 1024LL;
 
 #include <fuse.h>
 
-#define S3FS_FUSE_EXIT() { \
+#define S3FS_FUSE_EXIT() \
+do{ \
   struct fuse_context* pcxt = fuse_get_context(); \
   if(pcxt){ \
     fuse_exit(pcxt->fuse); \
   } \
-}
+}while(0)
 
 // [NOTE]
 // s3fs use many small allocated chunk in heap area for stats
@@ -60,25 +61,25 @@ static const int64_t FIVE_GB = 5LL * 1024LL * 1024LL * 1024LL;
 #endif  // S3FS_MALLOC_TRIM
 
 #define S3FS_XMLFREEDOC(doc) \
-        { \
+        do{ \
           xmlFreeDoc(doc); \
           S3FS_MALLOCTRIM(0); \
-        }
+        }while(0)
 #define S3FS_XMLFREE(ptr) \
-        { \
+        do{ \
           xmlFree(ptr); \
           S3FS_MALLOCTRIM(0); \
-        }
+        }while(0)
 #define S3FS_XMLXPATHFREECONTEXT(ctx) \
-        { \
+        do{ \
           xmlXPathFreeContext(ctx); \
           S3FS_MALLOCTRIM(0); \
-        }
+        }while(0)
 #define S3FS_XMLXPATHFREEOBJECT(obj) \
-        { \
+        do{ \
           xmlXPathFreeObject(obj); \
           S3FS_MALLOCTRIM(0); \
-        }
+        }while(0)
 
 #endif // S3FS_S3_H_
 


### PR DESCRIPTION
This prohibits missing semicolons.