### PR TITLE
fix issue with aws session token provided inside ~/.aws/credentials file

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1205,6 +1205,7 @@ bool S3fsCurl::SetAccessKeyWithSessionToken(const char* AccessKeyId, const char*
   AWSAccessKeyId     = AccessKeyId;
   AWSSecretAccessKey = SecretAccessKey;
   AWSAccessToken     = SessionToken;
+  S3fsCurl::is_use_session_token = true;
   return true;
 }
 
@@ -1222,13 +1223,6 @@ bool S3fsCurl::SetIsIBMIAMAuth(bool flag)
 {
   bool old = S3fsCurl::is_ibm_iam_auth;
   S3fsCurl::is_ibm_iam_auth = flag;
-  return old;
-}
-
-bool S3fsCurl::SetIsUseSessionToken(bool flag)
-{
-  bool old = S3fsCurl::is_use_session_token;
-  S3fsCurl::is_use_session_token = flag;
   return old;
 }
 

--- a/src/curl.h
+++ b/src/curl.h
@@ -445,7 +445,6 @@ class S3fsCurl
     static int SetMaxMultiRequest(int max);
     static int GetMaxMultiRequest(void) { return S3fsCurl::max_multireq; }
     static bool SetIsECS(bool flag);
-    static bool SetIsUseSessionToken(bool flag);
     static bool SetIsIBMIAMAuth(bool flag);
     static size_t SetIAMFieldCount(size_t field_count);
     static std::string SetIAMCredentialsURL(const char* url);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4132,6 +4132,10 @@ static int read_aws_credentials_file(const std::string &filename)
     return EXIT_FAILURE;
   }
   if (session_token.empty()) {
+    if (is_use_session_token) {
+      S3FS_PRN_EXIT("AWS session token was expected but wasn't provided in aws/credentials file for profile: %s.", aws_profile.c_str());
+      return EXIT_FAILURE;
+    }
     if(!S3fsCurl::SetAccessKey(accesskey.c_str(), secret.c_str())){
       S3FS_PRN_EXIT("failed to set internal data for access key/secret key from aws credential file.");
       return EXIT_FAILURE;
@@ -4280,8 +4284,6 @@ static int get_access_keys()
     S3FS_PRN_INFO2("access key from env variables");
     if (AWSSESSIONTOKEN != NULL) {
       S3FS_PRN_INFO2("session token is available");
-      is_use_session_token = true;
-      S3fsCurl::SetIsUseSessionToken(true);
       if (!S3fsCurl::SetAccessKeyWithSessionToken(AWSACCESSKEYID, AWSSECRETACCESSKEY, AWSSESSIONTOKEN)) {
          S3FS_PRN_EXIT("session token is invalid.");
          return EXIT_FAILURE;
@@ -4719,7 +4721,6 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 0;
     }
     if (0 == STR2NCMP(arg, "use_session_token")) {
-      S3fsCurl::SetIsUseSessionToken(true);
       is_use_session_token = true;
     }
     if(0 == STR2NCMP(arg, "ibm_iam_endpoint=")){


### PR DESCRIPTION
### Details
I fixed one issue that I discovered recently related to AWS session token support: when credentials are provided by ~/.aws/credentials file and session token is present, session token is not to request. I decided to remove set_is_session_token_use function from public interface of curl.cpp file. Instead of this I set the flag to true inside method SetAccessKeyWithSessionToken.

I hope code is cleaner right now and works fine. Sorry for introducing a bug in last PR.
