### PR TITLE
Patch 1

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -806,7 +806,7 @@ int FdEntity::Open(headers_t* pmeta, ssize_t size, time_t time, bool no_fd_lock_
     Dup();
 
     // check only file size(do not need to save cfs and time.
-    if(0 <= size && pagelist.Size() != static_cast<size_t>(size) && size_orgmeta != 0 && pagelist.Size() <= size_orgmeta){
+    if(0 <= size && pagelist.Size() != static_cast<size_t>(size) && pagelist.Size() <= size_orgmeta){
       // truncate temporary file size
       if(-1 == ftruncate(fd, static_cast<size_t>(size))){
         S3FS_PRN_ERR("failed to truncate temporary file(%d) by errno(%d).", fd, errno);

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -806,7 +806,7 @@ int FdEntity::Open(headers_t* pmeta, ssize_t size, time_t time, bool no_fd_lock_
     Dup();
 
     // check only file size(do not need to save cfs and time.
-    if(0 <= size && pagelist.Size() != static_cast<size_t>(size)){
+    if(0 <= size && pagelist.Size() != static_cast<size_t>(size) && size_orgmeta != 0 && pagelist.Size() <= size_orgmeta){
       // truncate temporary file size
       if(-1 == ftruncate(fd, static_cast<size_t>(size))){
         S3FS_PRN_ERR("failed to truncate temporary file(%d) by errno(%d).", fd, errno);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1022 

### Details
I use s3fs-fuse to mount object-storage bucket，and share the mounted directory for others by NFS. For example nfs-ganesha or nfs-utils, when I write a big file (For exmple 100M) to NFS, then the file will be uplouded to S3 ,but the file will be incorrect truncated by s3fs-fuse ,so the datas of file which uplouded to s3 will be wrong.
