### PR TITLE
Individually test multiple s3fs flags

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -983,6 +983,9 @@ static int do_create_bucket()
       // retry to check
       s3fscurl.DestroyCurlHandle();
       res = s3fscurl.PutRequest("/", meta, tmpfd);
+    }else if(responseCode == 409){
+      // bucket already exists
+      res = 0;
     }
   }
   if(ptmpfp != NULL){

--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -135,7 +135,6 @@ function stop_s3proxy {
 # Mount the bucket, function arguments passed to s3fs in addition to
 # a set of common arguments.  
 function start_s3fs {
-
     # Public bucket if PUBLIC is set
     if [ -n "${PUBLIC}" ]; then
         AUTH_OPT="-o public_bucket=1"

--- a/test/s3proxy.conf
+++ b/test/s3proxy.conf
@@ -1,5 +1,5 @@
 s3proxy.secure-endpoint=https://127.0.0.1:8080
-s3proxy.authorization=aws-v4
+s3proxy.authorization=aws-v2-or-v4
 s3proxy.identity=local-identity
 s3proxy.credential=local-credential
 s3proxy.keystore-path=keystore.jks


### PR DESCRIPTION
Remove unneeded comments; single part limits ensure that the tests
exercise multipart code paths even with smaller files.
References #971.