### PR TITLE
Convert file offsets from size_t to off_t

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3172,7 +3172,7 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
   }
   S3fsCurl::AddUserAgent(hCurl);                                // put User-Agent
 
-  S3FS_PRN_INFO3("uploading... [path=%s][fd=%d][size=%jd]", tpath, fd, (intmax_t)(-1 != fd ? st.st_size : 0));
+  S3FS_PRN_INFO3("uploading... [path=%s][fd=%d][size=%lld]", tpath, fd, static_cast<long long int>(-1 != fd ? st.st_size : 0));
 
   int result = RequestPerform();
   delete bodydata;
@@ -3186,7 +3186,7 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
 
 int S3fsCurl::PreGetObjectRequest(const char* tpath, int fd, off_t start, ssize_t size, sse_type_t ssetype, string& ssevalue)
 {
-  S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%jd]", SAFESTRPTR(tpath), (intmax_t)start, (intmax_t)size);
+  S3FS_PRN_INFO3("[tpath=%s][start=%lld][size=%jd]", SAFESTRPTR(tpath), static_cast<long long int>(start), (intmax_t)size);
 
   if(!tpath || -1 == fd || 0 > start || 0 > size){
     return -1;
@@ -3239,7 +3239,7 @@ int S3fsCurl::GetObjectRequest(const char* tpath, int fd, off_t start, ssize_t s
 {
   int result;
 
-  S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%jd]", SAFESTRPTR(tpath), (intmax_t)start, (intmax_t)size);
+  S3FS_PRN_INFO3("[tpath=%s][start=%lld][size=%jd]", SAFESTRPTR(tpath), static_cast<long long int>(start), (intmax_t)size);
 
   if(!tpath){
     return -1;
@@ -3625,7 +3625,7 @@ int S3fsCurl::AbortMultipartUpload(const char* tpath, string& upload_id)
 
 int S3fsCurl::UploadMultipartPostSetup(const char* tpath, int part_num, const string& upload_id)
 {
-  S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%jd][part=%d]", SAFESTRPTR(tpath), (intmax_t)(partdata.startpos), (intmax_t)(partdata.size), part_num);
+  S3FS_PRN_INFO3("[tpath=%s][start=%lld][size=%lld][part=%d]", SAFESTRPTR(tpath), static_cast<long long int>(partdata.startpos), static_cast<long long int>(partdata.size), part_num);
 
   if(-1 == partdata.fd || -1 == partdata.startpos || -1 == partdata.size){
     return -1;
@@ -3685,7 +3685,7 @@ int S3fsCurl::UploadMultipartPostRequest(const char* tpath, int part_num, const 
 {
   int result;
 
-  S3FS_PRN_INFO3("[tpath=%s][start=%jd][size=%jd][part=%d]", SAFESTRPTR(tpath), (intmax_t)(partdata.startpos), (intmax_t)(partdata.size), part_num);
+  S3FS_PRN_INFO3("[tpath=%s][start=%lld][size=%lld][part=%d]", SAFESTRPTR(tpath), static_cast<long long int>(partdata.startpos), static_cast<long long int>(partdata.size), part_num);
 
   // setup
   if(0 != (result = S3fsCurl::UploadMultipartPostSetup(tpath, part_num, upload_id))){
@@ -3925,9 +3925,9 @@ int S3fsCurl::MultipartUploadRequest(const char* tpath, headers_t& meta, int fd,
   return 0;
 }
 
-int S3fsCurl::MultipartUploadRequest(const string& upload_id, const char* tpath, int fd, off_t offset, size_t size, etaglist_t& list)
+int S3fsCurl::MultipartUploadRequest(const string& upload_id, const char* tpath, int fd, off_t offset, off_t size, etaglist_t& list)
 {
-  S3FS_PRN_INFO3("[upload_id=%s][tpath=%s][fd=%d][offset=%jd][size=%jd]", upload_id.c_str(), SAFESTRPTR(tpath), fd, (intmax_t)offset, (intmax_t)size);
+  S3FS_PRN_INFO3("[upload_id=%s][tpath=%s][fd=%d][offset=%lld][size=%lld]", upload_id.c_str(), SAFESTRPTR(tpath), fd, static_cast<long long int>(offset), static_cast<long long int>(size));
 
   // duplicate fd
   int fd2;

--- a/src/curl.h
+++ b/src/curl.h
@@ -110,7 +110,7 @@ struct filepart
   std::string etag;         // expected etag value
   int         fd;           // base file(temporary full file) descriptor
   off_t       startpos;     // seek fd point for uploading
-  ssize_t     size;         // uploading size
+  off_t       size;         // uploading size
   etaglist_t* etaglist;     // use only parallel upload
   int         etagpos;      // use only parallel upload
 
@@ -487,7 +487,7 @@ class S3fsCurl
     int AbortMultipartUpload(const char* tpath, std::string& upload_id);
     int MultipartHeadRequest(const char* tpath, off_t size, headers_t& meta, bool is_copy);
     int MultipartUploadRequest(const char* tpath, headers_t& meta, int fd, bool is_copy);
-    int MultipartUploadRequest(const std::string& upload_id, const char* tpath, int fd, off_t offset, size_t size, etaglist_t& list);
+    int MultipartUploadRequest(const std::string& upload_id, const char* tpath, int fd, off_t offset, off_t size, etaglist_t& list);
     int MultipartRenameRequest(const char* from, const char* to, headers_t& meta, off_t size);
 
     // methods(variables)

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -56,10 +56,10 @@ class CacheFileStat
 struct fdpage
 {
   off_t  offset;
-  size_t bytes;
+  off_t  bytes;
   bool   loaded;
 
-  fdpage(off_t start = 0, size_t size = 0, bool is_loaded = false)
+  fdpage(off_t start = 0, off_t  size = 0, bool is_loaded = false)
            : offset(start), bytes(size), loaded(is_loaded) {}
 
   off_t next(void) const { return (offset + bytes); }
@@ -87,18 +87,18 @@ class PageList
   public:
     static void FreeList(fdpage_list_t& list);
 
-    explicit PageList(size_t size = 0, bool is_loaded = false);
+    explicit PageList(off_t size = 0, bool is_loaded = false);
     ~PageList();
 
-    bool Init(size_t size, bool is_loaded);
-    size_t Size(void) const;
-    bool Resize(size_t size, bool is_loaded);
+    bool Init(off_t size, bool is_loaded);
+    off_t Size(void) const;
+    bool Resize(off_t size, bool is_loaded);
 
-    bool IsPageLoaded(off_t start = 0, size_t size = 0) const;                  // size=0 is checking to end of list
-    bool SetPageLoadedStatus(off_t start, size_t size, bool is_loaded = true, bool is_compress = true);
-    bool FindUnloadedPage(off_t start, off_t& resstart, size_t& ressize) const;
-    size_t GetTotalUnloadedPageSize(off_t start = 0, size_t size = 0) const;    // size=0 is checking to end of list
-    int GetUnloadedPages(fdpage_list_t& unloaded_list, off_t start = 0, size_t size = 0) const;  // size=0 is checking to end of list
+    bool IsPageLoaded(off_t start = 0, off_t size = 0) const;                  // size=0 is checking to end of list
+    bool SetPageLoadedStatus(off_t start, off_t size, bool is_loaded = true, bool is_compress = true);
+    bool FindUnloadedPage(off_t start, off_t& resstart, off_t& ressize) const;
+    off_t GetTotalUnloadedPageSize(off_t start = 0, off_t size = 0) const;    // size=0 is checking to end of list
+    int GetUnloadedPages(fdpage_list_t& unloaded_list, off_t start = 0, off_t size = 0) const;  // size=0 is checking to end of list
 
     bool Serialize(CacheFileStat& file, bool is_output);
     void Dump(void);
@@ -122,15 +122,15 @@ class FdEntity
     FILE*           pfile;          // file pointer(tmp file or cache file)
     bool            is_modify;      // if file is changed, this flag is true
     headers_t       orgmeta;        // original headers at opening
-    size_t          size_orgmeta;   // original file size in original headers
+    off_t           size_orgmeta;   // original file size in original headers
 
     std::string     upload_id;      // for no cached multipart uploading when no disk space
     etaglist_t      etaglist;       // for no cached multipart uploading when no disk space
     off_t           mp_start;       // start position for no cached multipart(write method only)
-    size_t          mp_size;        // size for no cached multipart(write method only)
+    off_t           mp_size;        // size for no cached multipart(write method only)
 
   private:
-    static int FillFile(int fd, unsigned char byte, size_t size, off_t start);
+    static int FillFile(int fd, unsigned char byte, off_t size, off_t start);
 
     void Clear(void);
     int OpenMirrorFile(void);
@@ -145,8 +145,8 @@ class FdEntity
     void Close(void);
     bool IsOpen(void) const { return (-1 != fd); }
     bool IsMultiOpened(void) const { return refcnt > 1; }
-    int Open(headers_t* pmeta = NULL, ssize_t size = -1, time_t time = -1, bool no_fd_lock_wait = false);
-    bool OpenAndLoadAll(headers_t* pmeta = NULL, size_t* size = NULL, bool force_load = false);
+    int Open(headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, bool no_fd_lock_wait = false);
+    bool OpenAndLoadAll(headers_t* pmeta = NULL, off_t* size = NULL, bool force_load = false);
     int Dup();
 
     const char* GetPath(void) const { return path.c_str(); }
@@ -158,16 +158,16 @@ class FdEntity
     int SetMtime(time_t time);
     bool UpdateCtime(void);
     bool UpdateMtime(void);
-    bool GetSize(size_t& size);
+    bool GetSize(off_t& size);
     bool SetMode(mode_t mode);
     bool SetUId(uid_t uid);
     bool SetGId(gid_t gid);
     bool SetContentType(const char* path);
 
-    int Load(off_t start = 0, size_t size = 0);                 // size=0 means loading to end
-    int NoCacheLoadAndPost(off_t start = 0, size_t size = 0);   // size=0 means loading to end
+    int Load(off_t start = 0, off_t size = 0);                 // size=0 means loading to end
+    int NoCacheLoadAndPost(off_t start = 0, off_t size = 0);   // size=0 means loading to end
     int NoCachePreMultipartPost(void);
-    int NoCacheMultipartPost(int tgfd, off_t start, size_t size);
+    int NoCacheMultipartPost(int tgfd, off_t start, off_t size);
     int NoCacheCompleteMultipartPost(void);
 
     int RowFlush(const char* tpath, bool force_sync = false);
@@ -176,7 +176,7 @@ class FdEntity
     ssize_t Read(char* bytes, off_t start, size_t size, bool force_load = false);
     ssize_t Write(const char* bytes, off_t start, size_t size);
 
-    bool ReserveDiskSpace(size_t size);
+    bool ReserveDiskSpace(off_t size);
     void CleanupCache();
 };
 typedef std::map<std::string, class FdEntity*> fdent_map_t;   // key=path, value=FdEntity*
@@ -194,12 +194,12 @@ class FdManager
     static bool            is_lock_init;
     static std::string     cache_dir;
     static bool            check_cache_dir_exist;
-    static size_t          free_disk_space; // limit free disk space
+    static off_t           free_disk_space; // limit free disk space
 
     fdent_map_t            fent;
 
   private:
-    static uint64_t GetFreeDiskSpace(const char* path);
+    static off_t GetFreeDiskSpace(const char* path);
     void CleanupCacheDirInternal(const std::string &path = "");
 
   public:
@@ -220,15 +220,15 @@ class FdManager
     static bool SetCheckCacheDirExist(bool is_check);
     static bool CheckCacheDirExist(void);
 
-    static size_t GetEnsureFreeDiskSpace(void) { return FdManager::free_disk_space; }
-    static size_t SetEnsureFreeDiskSpace(size_t size);
-    static bool IsSafeDiskSpace(const char* path, size_t size);
-    static void FreeReservedDiskSpace(size_t size);
-    bool ReserveDiskSpace(size_t size);
+    static off_t GetEnsureFreeDiskSpace(void) { return FdManager::free_disk_space; }
+    static off_t SetEnsureFreeDiskSpace(off_t size);
+    static bool IsSafeDiskSpace(const char* path, off_t size);
+    static void FreeReservedDiskSpace(off_t size);
+    bool ReserveDiskSpace(off_t size);
 
     // Return FdEntity associated with path, returning NULL on error.  This operation increments the reference count; callers must decrement via Close after use.
     FdEntity* GetFdEntity(const char* path, int existfd = -1);
-    FdEntity* Open(const char* path, headers_t* pmeta = NULL, ssize_t size = -1, time_t time = -1, bool force_tmpfile = false, bool is_create = true, bool no_fd_lock_wait = false);
+    FdEntity* Open(const char* path, headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, bool force_tmpfile = false, bool is_create = true, bool no_fd_lock_wait = false);
     FdEntity* ExistOpen(const char* path, int existfd = -1, bool ignore_existfd = false);
     void Rename(const std::string &from, const std::string &to);
     bool Close(FdEntity* ent);


### PR DESCRIPTION
The latter is 64-bits on 32-bit platforms when specifying
`-D_FILE_OFFSET_BITS=64`.  This allows early Raspberry Pis to use files
larger than 2 GB.  It also cleans up some ugly casting.  Fixes #620.
Fixes #656.