### PR TITLE
Remove cache file when object time differs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install -qq attr cppcheck libfuse-dev openjdk-7-jdk
         - sudo update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
+        - sudo pip install --upgrade awscli
       script:
         - ./autogen.sh
         - ./configure CPPFLAGS='-I/usr/local/opt/openssl/include' CXXFLAGS='-std=c++03'
@@ -45,7 +46,7 @@ matrix:
       before_install:
         - HOMEBREW_NO_AUTO_UPDATE=1 brew tap caskroom/cask
         - HOMEBREW_NO_AUTO_UPDATE=1 brew cask install osxfuse
-        - HOMEBREW_NO_AUTO_UPDATE=1 brew install cppcheck gnu-sed truncate
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli cppcheck gnu-sed truncate
         - if [ -f /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ]; then sudo chmod +s /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ; elif [ -f /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ]; then sudo chmod +s /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ; fi
         - sudo ln -s /usr/local/opt/gnu-sed/bin/gsed /usr/local/bin/sed
         - sudo ln -s /usr/local/opt/coreutils/bin/gstdbuf /usr/local/bin/stdbuf
@@ -69,6 +70,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install -qq attr cppcheck libfuse-dev openjdk-7-jdk
         - sudo update-alternatives --set java /usr/lib/jvm/java-7-openjdk-ppc64el/jre/bin/java
+        - sudo pip install --upgrade awscli
       script:
         - ./autogen.sh
         - ./configure CPPFLAGS='-I/usr/local/opt/openssl/include' CXXFLAGS='-std=c++03'

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -842,6 +842,16 @@ int FdEntity::Open(headers_t* pmeta, ssize_t size, time_t time, bool no_fd_lock_
   if(!cachepath.empty()){
     // using cache
 
+    struct stat st;
+    if(stat(cachepath.c_str(), &st) == 0){
+      if(st.st_mtime < time){
+        S3FS_PRN_DBG("cache file stale, removing: %s", cachepath.c_str());
+        if(unlink(cachepath.c_str()) != 0){
+          return (0 == errno ? -EIO : -errno);
+        }
+      }
+    }
+
     // open cache and cache stat file, load page info.
     CacheFileStat cfstat(path.c_str());
 

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -295,6 +295,16 @@ function test_remove_nonempty_directory {
     rm_test_dir
 }
 
+function test_external_modification {
+    describe "Test external modification to an object"
+    echo "old" > ${TEST_TEXT_FILE}
+    OBJECT_NAME="$(basename $PWD)/${TEST_TEXT_FILE}"
+    sleep 2
+    echo "new new" | AWS_ACCESS_KEY_ID=local-identity AWS_SECRET_ACCESS_KEY=local-credential aws s3 --endpoint-url "${S3_URL}" --no-verify-ssl cp - "s3://${TEST_BUCKET_1}/${OBJECT_NAME}"
+    cmp ${TEST_TEXT_FILE} <(echo "new new")
+    rm -f ${TEST_TEXT_FILE}
+}
+
 function test_rename_before_close {
     describe "Testing rename before close ..."
     (
@@ -523,6 +533,7 @@ function test_overwrite_existing_file_range {
 }
 
 function test_concurrency {
+    describe "Test concurrent updates to a directory"
     for i in `seq 10`; do echo foo > $i; done
     for process in `seq 2`; do
         for i in `seq 100`; do
@@ -549,6 +560,7 @@ function add_all_tests {
     add_tests test_chown
     add_tests test_list
     add_tests test_remove_nonempty_directory
+    add_tests test_external_modification
     add_tests test_rename_before_close
     add_tests test_multipart_upload
     add_tests test_multipart_copy


### PR DESCRIPTION
Check the modification times to determine whether an object has
updated.  This relies on low clock skew between s3fs and the S3
server; a more robust approach could use the ETag.  Fixes #1047.