### PR TITLE
Sign request immediately before sending

### DIFF
--- a/src/gnutls_auth.cpp
+++ b/src/gnutls_auth.cpp
@@ -196,17 +196,12 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
   ssize_t        bytes;
   unsigned char* result;
 
-  // seek to top of file.
-  if(-1 == lseek(fd, start, SEEK_SET)){
-    return NULL;
-  }
-
   memset(buf, 0, 512);
   md5_init(&ctx_md5);
 
   for(ssize_t total = 0; total < size; total += bytes){
     bytes = 512 < (size - total) ? 512 : (size - total);
-    bytes = read(fd, buf, bytes);
+    bytes = pread(fd, buf, bytes, start + total);
     if(0 == bytes){
       // end of file
       break;
@@ -220,11 +215,6 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
   }
   result = new unsigned char[get_md5_digest_length()];
   md5_digest(&ctx_md5, get_md5_digest_length(), result);
-
-  if(-1 == lseek(fd, start, SEEK_SET)){
-    delete[] result;
-    return NULL;
-  }
 
   return result;
 }
@@ -247,11 +237,6 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
     size = static_cast<ssize_t>(st.st_size);
   }
 
-  // seek to top of file.
-  if(-1 == lseek(fd, start, SEEK_SET)){
-    return NULL;
-  }
-
   memset(buf, 0, 512);
   if(GPG_ERR_NO_ERROR != (err = gcry_md_open(&ctx_md5, GCRY_MD_MD5, 0))){
     S3FS_PRN_ERR("MD5 context creation failure: %s/%s", gcry_strsource(err), gcry_strerror(err));
@@ -260,7 +245,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
 
   for(ssize_t total = 0; total < size; total += bytes){
     bytes = 512 < (size - total) ? 512 : (size - total);
-    bytes = read(fd, buf, bytes);
+    bytes = pread(fd, buf, bytes, start + total);
     if(0 == bytes){
       // end of file
       break;
@@ -276,11 +261,6 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
   result = new unsigned char[get_md5_digest_length()];
   memcpy(result, gcry_md_read(ctx_md5, 0), get_md5_digest_length());
   gcry_md_close(ctx_md5);
-
-  if(-1 == lseek(fd, start, SEEK_SET)){
-    delete[] result;
-    return NULL;
-  }
 
   return result;
 }
@@ -316,17 +296,12 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
   ssize_t           bytes;
   unsigned char*    result;
 
-  // seek to top of file.
-  if(-1 == lseek(fd, start, SEEK_SET)){
-    return NULL;
-  }
-
   memset(buf, 0, 512);
   sha256_init(&ctx_sha256);
 
   for(ssize_t total = 0; total < size; total += bytes){
     bytes = 512 < (size - total) ? 512 : (size - total);
-    bytes = read(fd, buf, bytes);
+    bytes = pread(fd, buf, bytes, start + total);
     if(0 == bytes){
       // end of file
       break;
@@ -340,11 +315,6 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
   }
   result = new unsigned char[get_sha256_digest_length()];
   sha256_digest(&ctx_sha256, get_sha256_digest_length(), result);
-
-  if(-1 == lseek(fd, start, SEEK_SET)){
-    delete[] result;
-    return NULL;
-  }
 
   return result;
 }
@@ -386,11 +356,6 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
     size = static_cast<ssize_t>(st.st_size);
   }
 
-  // seek to top of file.
-  if(-1 == lseek(fd, start, SEEK_SET)){
-    return NULL;
-  }
-
   memset(buf, 0, 512);
   if(GPG_ERR_NO_ERROR != (err = gcry_md_open(&ctx_sha256, GCRY_MD_SHA256, 0))){
     S3FS_PRN_ERR("SHA256 context creation failure: %s/%s", gcry_strsource(err), gcry_strerror(err));
@@ -399,7 +364,7 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
 
   for(ssize_t total = 0; total < size; total += bytes){
     bytes = 512 < (size - total) ? 512 : (size - total);
-    bytes = read(fd, buf, bytes);
+    bytes = pread(fd, buf, bytes, start + total);
     if(0 == bytes){
       // end of file
       break;
@@ -415,11 +380,6 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
   result = new unsigned char[get_sha256_digest_length()];
   memcpy(result, gcry_md_read(ctx_sha256, 0), get_sha256_digest_length());
   gcry_md_close(ctx_sha256);
-
-  if(-1 == lseek(fd, start, SEEK_SET)){
-    delete[] result;
-    return NULL;
-  }
 
   return result;
 }

--- a/src/nss_auth.cpp
+++ b/src/nss_auth.cpp
@@ -167,17 +167,12 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
     size = static_cast<ssize_t>(st.st_size);
   }
 
-  // seek to top of file.
-  if(-1 == lseek(fd, start, SEEK_SET)){
-    return NULL;
-  }
-
   memset(buf, 0, 512);
   md5ctx = PK11_CreateDigestContext(SEC_OID_MD5);
 
   for(ssize_t total = 0; total < size; total += bytes){
     bytes = 512 < (size - total) ? 512 : (size - total);
-    bytes = read(fd, buf, bytes);
+    bytes = pread(fd, buf, bytes, start + total);
     if(0 == bytes){
       // end of file
       break;
@@ -193,11 +188,6 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
   result = new unsigned char[get_md5_digest_length()];
   PK11_DigestFinal(md5ctx, result, &md5outlen, get_md5_digest_length());
   PK11_DestroyContext(md5ctx, PR_TRUE);
-
-  if(-1 == lseek(fd, start, SEEK_SET)){
-    delete[] result;
-    return NULL;
-  }
 
   return result;
 }
@@ -243,17 +233,12 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
     size = static_cast<ssize_t>(st.st_size);
   }
 
-  // seek to top of file.
-  if(-1 == lseek(fd, start, SEEK_SET)){
-    return NULL;
-  }
-
   memset(buf, 0, 512);
   sha256ctx = PK11_CreateDigestContext(SEC_OID_SHA256);
 
   for(ssize_t total = 0; total < size; total += bytes){
     bytes = 512 < (size - total) ? 512 : (size - total);
-    bytes = read(fd, buf, bytes);
+    bytes = pread(fd, buf, bytes, start + total);
     if(0 == bytes){
       // end of file
       break;
@@ -269,11 +254,6 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
   result = new unsigned char[get_sha256_digest_length()];
   PK11_DigestFinal(sha256ctx, result, &sha256outlen, get_sha256_digest_length());
   PK11_DestroyContext(sha256ctx, PR_TRUE);
-
-  if(-1 == lseek(fd, start, SEEK_SET)){
-    delete[] result;
-    return NULL;
-  }
 
   return result;
 }


### PR DESCRIPTION
Previously s3fs could create a long list of pre-signed requests which
could take longer than the default S3 clock skew limit of 15 minutes.
This also changes SHA-256 computation from single- to multi-threaded
since this is now computed in the worker threads.  Regression from
88cd8feb053980c808d67771d63a84ca25f6db8a.  Fixes #1019.