### PR TITLE
Use system sed on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,8 @@ matrix:
       before_install:
         - HOMEBREW_NO_AUTO_UPDATE=1 brew tap caskroom/cask
         - HOMEBREW_NO_AUTO_UPDATE=1 brew cask install osxfuse
-        - HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli cppcheck gnu-sed truncate
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli cppcheck truncate
         - if [ -f /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ]; then sudo chmod +s /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ; elif [ -f /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ]; then sudo chmod +s /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ; fi
-        - sudo ln -s /usr/local/opt/gnu-sed/bin/gsed /usr/local/bin/sed
         - sudo ln -s /usr/local/opt/coreutils/bin/gstdbuf /usr/local/bin/stdbuf
       script:
         - ./autogen.sh

--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -187,7 +187,7 @@ function start_s3fs {
             -o dbglevel=${DBGLEVEL:=info} \
             -o retries=3 \
             -f \
-            "${@}" | stdbuf -oL -eL sed -u "s/^/s3fs: /" &
+            "${@}" | stdbuf -oL -eL sed $SED_BUFFER_FLAG "s/^/s3fs: /" &
     )
 
     if [ `uname` = "Darwin" ]; then

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -537,7 +537,7 @@ function test_concurrency {
     for i in `seq 10`; do echo foo > $i; done
     for process in `seq 2`; do
         for i in `seq 100`; do
-            file=$(ls | sed -n "$(($RANDOM % 10 + 1)){p;q}")
+            file=$(ls | sed -n "$(($RANDOM % 10 + 1))p")
             cat $file >/dev/null || true
             rm -f $file
             echo foo > $i || true

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -14,6 +14,12 @@ BIG_FILE=big-file-s3fs.txt
 BIG_FILE_LENGTH=$((25 * 1024 * 1024))
 export RUN_DIR
 
+if [ `uname` = "Darwin" ]; then
+    export SED_BUFFER_FLAG="-l"
+else
+    export SED_BUFFER_FLAG="--unbuffered"
+fi
+
 function mk_test_file {
     if [ $# == 0 ]; then
         TEXT=$TEST_TEXT


### PR DESCRIPTION
This requires fewer developer customizations to work on macOS.
Requires some GNU workarounds.