### PR TITLE
Remove recursive locking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
         - sudo pip install --upgrade awscli
       script:
         - ./autogen.sh
-        - ./configure CPPFLAGS='-I/usr/local/opt/openssl/include' CXXFLAGS='-std=c++03'
+        - ./configure CPPFLAGS='-I/usr/local/opt/openssl/include' CXXFLAGS='-std=c++03 -DS3FS_PTHREAD_ERRORCHECK=1'
         - make
         - make cppcheck
         - make check -C src
@@ -51,7 +51,7 @@ matrix:
         - sudo ln -s /usr/local/opt/coreutils/bin/gstdbuf /usr/local/bin/stdbuf
       script:
         - ./autogen.sh
-        - PKG_CONFIG_PATH=/usr/local/opt/curl/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig ./configure CXXFLAGS='-std=c++03'
+        - PKG_CONFIG_PATH=/usr/local/opt/curl/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig ./configure CXXFLAGS='-std=c++03 -DS3FS_PTHREAD_ERRORCHECK=1'
         - make
         - make cppcheck
         - make check -C src
@@ -72,7 +72,7 @@ matrix:
         - sudo pip install --upgrade awscli
       script:
         - ./autogen.sh
-        - ./configure CPPFLAGS='-I/usr/local/opt/openssl/include' CXXFLAGS='-std=c++03'
+        - ./configure CPPFLAGS='-I/usr/local/opt/openssl/include' CXXFLAGS='-std=c++03 -DS3FS_PTHREAD_ERRORCHECK=1'
         - make
         - make cppcheck
         - make check -C src

--- a/src/cache.h
+++ b/src/cache.h
@@ -120,9 +120,9 @@ class StatCache
     void ChangeNoTruncateFlag(const std::string& key, bool no_truncate);
 
     // Delete stat cache
-    bool DelStat(const char* key);
-    bool DelStat(std::string& key) {
-      return DelStat(key.c_str());
+    bool DelStat(const char* key, bool lock_already_held = false);
+    bool DelStat(std::string& key, bool lock_already_held = false) {
+      return DelStat(key.c_str(), lock_already_held);
     }
 };
 

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -148,15 +148,15 @@ class FdEntity
     bool IsMultiOpened(void) const { return refcnt > 1; }
     int Open(headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, bool no_fd_lock_wait = false);
     bool OpenAndLoadAll(headers_t* pmeta = NULL, off_t* size = NULL, bool force_load = false);
-    int Dup();
+    int Dup(bool lock_already_held = false);
 
     const char* GetPath(void) const { return path.c_str(); }
     void SetPath(const std::string &newpath) { path = newpath; }
     int GetFd(void) const { return fd; }
 
-    bool GetStats(struct stat& st);
+    bool GetStats(struct stat& st, bool lock_already_held = false);
     int SetCtime(time_t time);
-    int SetMtime(time_t time);
+    int SetMtime(time_t time, bool lock_already_held = false);
     bool UpdateCtime(void);
     bool UpdateMtime(void);
     bool GetSize(off_t& size);
@@ -165,7 +165,7 @@ class FdEntity
     bool SetGId(gid_t gid);
     bool SetContentType(const char* path);
 
-    int Load(off_t start = 0, off_t size = 0);                 // size=0 means loading to end
+    int Load(off_t start = 0, off_t size = 0, bool lock_already_held = false);  // size=0 means loading to end
     int NoCacheLoadAndPost(off_t start = 0, off_t size = 0);   // size=0 means loading to end
     int NoCachePreMultipartPost(void);
     int NoCacheMultipartPost(int tgfd, off_t start, off_t size);

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -86,14 +86,20 @@ typedef struct mvnode {
 
 class AutoLock
 {
-  private:
-    pthread_mutex_t* auto_mutex;
-    bool is_lock_acquired;
-
   public:
-    explicit AutoLock(pthread_mutex_t* pmutex, bool no_wait = false);
+    enum Type {
+      NO_WAIT = 1,
+      ALREADY_LOCKED = 2,
+      NONE = 0
+    };
+    explicit AutoLock(pthread_mutex_t* pmutex, Type type = NONE);
     bool isLockAcquired() const;
     ~AutoLock();
+
+  private:
+    pthread_mutex_t* const auto_mutex;
+    bool is_lock_acquired;
+    const Type type;
 };
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
Recursive locking is frowned upon and is incompatible with
`PTHREAD_MUTEX_ERRORCHECK`.  Also clean up `pthread_mutex_lock` error
checking.