### PR TITLE
Avoid misplaced const via removing unneeded typedef

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,6 @@ Checks: '
     -google-runtime-int,
     -google-runtime-references,
     misc-*,
-    -misc-misplaced-const,
     -misc-redundant-expression,
     -misc-unused-parameters,
     modernize-*,

--- a/src/addhead.cpp
+++ b/src/addhead.cpp
@@ -84,7 +84,7 @@ bool AdditionalHeader::Load(const char* file)
 
   // read file
   string   line;
-  PADDHEAD paddhead;
+  ADDHEAD *paddhead;
   while(getline(AH, line)){
     if('#' == line[0]){
       continue;
@@ -169,7 +169,7 @@ void AdditionalHeader::Unload()
   is_enable = false;
 
   for(addheadlist_t::iterator iter = addheadlist.begin(); iter != addheadlist.end(); iter = addheadlist.erase(iter)){
-    PADDHEAD paddhead = *iter;
+    ADDHEAD *paddhead = *iter;
     if(paddhead){
       if(paddhead->pregex){
         regfree(paddhead->pregex);
@@ -198,7 +198,7 @@ bool AdditionalHeader::AddHeader(headers_t& meta, const char* path) const
   // Because to allow duplicate key, and then scanning the entire table.
   //
   for(addheadlist_t::const_iterator iter = addheadlist.begin(); iter != addheadlist.end(); ++iter){
-    const PADDHEAD paddhead = *iter;
+    const ADDHEAD *paddhead = *iter;
     if(!paddhead){
       continue;
     }
@@ -251,7 +251,7 @@ bool AdditionalHeader::Dump() const
   ssdbg << "Additional Header list[" << addheadlist.size() << "] = {" << endl;
 
   for(addheadlist_t::const_iterator iter = addheadlist.begin(); iter != addheadlist.end(); ++iter, ++cnt){
-    const PADDHEAD paddhead = *iter;
+    const ADDHEAD *paddhead = *iter;
 
     ssdbg << "    [" << cnt << "] = {" << endl;
 

--- a/src/addhead.h
+++ b/src/addhead.h
@@ -31,9 +31,9 @@ typedef struct add_header{
   std::string   basestring;
   std::string   headkey;
   std::string   headvalue;
-}ADDHEAD, *PADDHEAD;
+}ADDHEAD;
 
-typedef std::vector<PADDHEAD>  addheadlist_t;
+typedef std::vector<ADDHEAD *> addheadlist_t;
 
 class AdditionalHeader
 {


### PR DESCRIPTION
Found via clang-tidy.