### PR TITLE
Avoid null dereference

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -893,8 +893,9 @@ static int s3fs_getattr(const char* _path, struct stat* stbuf)
     }
     stbuf->st_blksize = 4096;
     stbuf->st_blocks  = get_blocks(stbuf->st_size);
+
+    S3FS_PRN_DBG("[path=%s] uid=%u, gid=%u, mode=%04o", path, (unsigned int)(stbuf->st_uid), (unsigned int)(stbuf->st_gid), stbuf->st_mode);
   }
-  S3FS_PRN_DBG("[path=%s] uid=%u, gid=%u, mode=%04o", path, (unsigned int)(stbuf->st_uid), (unsigned int)(stbuf->st_gid), stbuf->st_mode);
   S3FS_MALLOCTRIM(0);
 
   return result;


### PR DESCRIPTION
Found via clang-tidy.