### PR TITLE
Change test_concurrency test

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -532,17 +532,17 @@ function test_overwrite_existing_file_range {
 
 function test_concurrency {
     describe "Test concurrent updates to a directory"
-    for i in `seq 10`; do echo foo > $i; done
-    for process in `seq 2`; do
-        for i in `seq 100`; do
-            file=$(ls | sed -n "$(($RANDOM % 10 + 1))p")
+    for i in `seq 5`; do echo foo > $i; done
+    for process in `seq 10`; do
+        for i in `seq 5`; do
+            file=$(ls `seq 5` | sed -n "$(($RANDOM % 5 + 1))p")
             cat $file >/dev/null || true
             rm -f $file
-            echo foo > $i || true
+            echo foo > $file || true
         done &
     done
     wait
-    rm -f `seq 100`
+    rm -f `seq 5`
 }
 
 function test_open_second_fd {


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
This PR corrected and revised the test test_concurrency.

Fixed the following part of test_concurrency test.
- Number of test files  
Initial 10 pieces, 100 pieces after writing. The new tests were initially set to 5 after writing.
- Number of parallel executions  
The number of parallel executions has been changed from 2 to 10.
- Number of single processing loops  
It has been changed from 100 to 5. This is the same as the number of test files.
- File created in loop  
We randomly created 1 to 100 files, but changed to 1 to 5 files.
- Specify file name clearly  
This is because FUSE may create a special temporary file (a file name such as .fuse_hidden0000005000000001), which may cause the test to fail.

If I misunderstood the nature of this test, I will not adapt this PR.
The new fix is ​​to increase the number of parallels and reduce the number of files.
This has increased the chance of file collisions.

Also, increasing the number of parallels and reducing the number of single processing loops will reduce test time.
And the number of log lines at the time of error is also a quarter.
