### PR TITLE
Eagerly initialize sysconf variables

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -5091,6 +5091,8 @@ int main(int argc, char* argv[])
   xmlInitParser();
   LIBXML_TEST_VERSION
 
+  init_sysconf_vars();
+
   // get program name - emulate basename
   program_name.assign(argv[0]);
   size_t found = program_name.find_last_of('/');

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -111,6 +111,7 @@ MVNODE *create_mvnode(const char *old_path, const char *new_path, bool is_dir, b
 MVNODE *add_mvnode(MVNODE** head, MVNODE** tail, const char *old_path, const char *new_path, bool is_dir, bool normdir = false);
 void free_mvnodes(MVNODE *head);
 
+void init_sysconf_vars();
 std::string get_username(uid_t uid);
 int is_uid_include_group(uid_t uid, gid_t gid);
 


### PR DESCRIPTION
Previously s3fs had races updating these shared variables.  Found via
ThreadSanitizer.