### PR TITLE
Fixed filter-suite-log.sh for on osx

### DIFF
--- a/test/filter-suite-log.sh
+++ b/test/filter-suite-log.sh
@@ -59,7 +59,7 @@ fi
 # 2 : passed line of end of one small test(specified in test-utils.sh)
 # 3 : failed line of end of one small test(specified in test-utils.sh)
 #
-grep -n -e '^test_.*: ".*"' -o -e '^test_.* passed' -o -e '^test_.* failed' ${SUITELOG} 2>/dev/null | sed 's/:test_.*: ".*"/ 1/g' | sed 's/:test_.* passed/ 2/g' | sed 's/:test_.* failed/ 3/g' > ${TMP_LINENO_FILE}
+grep -n -e 'test_.*: ".*"' -o -e 'test_.* passed' -o -e 'test_.* failed' ${SUITELOG} 2>/dev/null | sed 's/:test_.*: ".*"/ 1/g' | sed 's/:test_.* passed/ 2/g' | sed 's/:test_.* failed/ 3/g' > ${TMP_LINENO_FILE}
 
 #
 # Loop for printing result


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1099

### Details
It was corrected because it might not be possible to filter when there are not enough new lines in the message.
This converges the phenomenon that occurred in OSX.
