### PR TITLE
Always hold lock when accessing free_disk_space

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1986,8 +1986,15 @@ bool FdManager::CheckCacheDirExist()
   return true;
 }
 
+off_t FdManager::GetEnsureFreeDiskSpace()
+{
+  AutoLock auto_lock(&FdManager::reserved_diskspace_lock);
+  return FdManager::free_disk_space;
+}
+
 off_t FdManager::SetEnsureFreeDiskSpace(off_t size)
 {
+  AutoLock auto_lock(&FdManager::reserved_diskspace_lock);
   off_t old = FdManager::free_disk_space;
   FdManager::free_disk_space = size;
   return old;
@@ -2342,8 +2349,8 @@ void FdManager::CleanupCacheDirInternal(const std::string &path)
 
 bool FdManager::ReserveDiskSpace(off_t size)
 {
-  AutoLock auto_lock(&FdManager::reserved_diskspace_lock);
   if(IsSafeDiskSpace(NULL, size)){
+    AutoLock auto_lock(&FdManager::reserved_diskspace_lock);
     free_disk_space += size;
     return true;
   }

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -221,7 +221,7 @@ class FdManager
     static bool SetCheckCacheDirExist(bool is_check);
     static bool CheckCacheDirExist(void);
 
-    static off_t GetEnsureFreeDiskSpace(void) { return FdManager::free_disk_space; }
+    static off_t GetEnsureFreeDiskSpace();
     static off_t SetEnsureFreeDiskSpace(off_t size);
     static bool IsSafeDiskSpace(const char* path, off_t size);
     static void FreeReservedDiskSpace(off_t size);


### PR DESCRIPTION
Slightly reorder locks to avoid double locking.  Found via
ThreadSanitizer.