### PR TITLE
Prefer s3fs_strtoofft over atoi and strtol

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1323,7 +1323,7 @@ S3fsCurl* S3fsCurl::UploadMultipartPostRetryCallback(S3fsCurl* s3fscurl)
   if(!get_keyword_value(s3fscurl->url, "partNumber", part_num_str)){
     return NULL;
   }
-  part_num = atoi(part_num_str.c_str());
+  part_num = s3fs_strtoofft(part_num_str.c_str(), /*is_base_16=*/ false);
 
   if(s3fscurl->retry_count >= S3fsCurl::retries){
     S3FS_PRN_ERR("Over retry count(%d) limit(%s:%d).", s3fscurl->retry_count, s3fscurl->path.c_str(), part_num);
@@ -1365,7 +1365,7 @@ S3fsCurl* S3fsCurl::CopyMultipartPostRetryCallback(S3fsCurl* s3fscurl)
   if(!get_keyword_value(s3fscurl->url, "partNumber", part_num_str)){
     return NULL;
   }
-  part_num = atoi(part_num_str.c_str());
+  part_num = s3fs_strtoofft(part_num_str.c_str(), /*is_base_16=*/ false);
 
   if(s3fscurl->retry_count >= S3fsCurl::retries){
     S3FS_PRN_ERR("Over retry count(%d) limit(%s:%d).", s3fscurl->retry_count, s3fscurl->path.c_str(), part_num);
@@ -1716,7 +1716,7 @@ bool S3fsCurl::SetIAMCredentials(const char* response)
   S3fsCurl::AWSAccessToken       = keyval[string(S3fsCurl::IAM_token_field)];
 
   if(S3fsCurl::is_ibm_iam_auth){
-    S3fsCurl::AWSAccessTokenExpire = strtol(keyval[string(S3fsCurl::IAM_expiry_field)].c_str(), NULL, 10);
+    S3fsCurl::AWSAccessTokenExpire = s3fs_strtoofft(keyval[string(S3fsCurl::IAM_expiry_field)].c_str(), /*is_base_16=*/ false);
   }else{
     S3fsCurl::AWSAccessKeyId       = keyval[string(IAMCRED_ACCESSKEYID)];
     S3fsCurl::AWSSecretAccessKey   = keyval[string(IAMCRED_SECRETACCESSKEY)];

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4513,7 +4513,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 1; // continue for fuse option
     }
     if(0 == STR2NCMP(arg, "umask=")){
-      s3fs_umask = strtol(strchr(arg, '=') + sizeof(char), NULL, 0);
+      s3fs_umask = s3fs_strtoofft(strchr(arg, '=') + sizeof(char), /*is_base_16=*/ false);
       s3fs_umask &= (S_IRWXU | S_IRWXG | S_IRWXO);
       is_s3fs_umask = true;
       return 1; // continue for fuse option
@@ -4523,7 +4523,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 1; // continue for fuse option
     }
     if(0 == STR2NCMP(arg, "mp_umask=")){
-      mp_umask = strtol(strchr(arg, '=') + sizeof(char), NULL, 0);
+      mp_umask = s3fs_strtoofft(strchr(arg, '=') + sizeof(char), /*is_base_16=*/ false);
       mp_umask &= (S_IRWXU | S_IRWXG | S_IRWXO);
       is_mp_umask = true;
       return 0;


### PR DESCRIPTION
The former propagates errors consistently.