### PR TITLE
Added direct_io option for test on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       before_install:
-        - HOMEBREW_NO_AUTO_UPDATE=1 brew tap caskroom/cask
+        - brew tap caskroom/cask
         - HOMEBREW_NO_AUTO_UPDATE=1 brew cask install osxfuse
         - HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli cppcheck truncate
         - if [ -f /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ]; then sudo chmod +s /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ; elif [ -f /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ]; then sudo chmod +s /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ; fi

--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -152,6 +152,13 @@ function start_s3fs {
         VALGRIND_EXEC="valgrind ${VALGRIND} --log-socket=127.0.1.1"
     fi
 
+    # On OSX only, we need to specify the direct_io flag.
+    if [ `uname` = "Darwin" ]; then
+       DIRECT_IO_OPT="-o direct_io"
+    else
+       DIRECT_IO_OPT=""
+    fi
+
     # Common s3fs options:
     #
     # TODO: Allow all these options to be overridden with env variables
@@ -185,6 +192,7 @@ function start_s3fs {
             -o use_xattr=1 \
             -o createbucket \
             ${AUTH_OPT} \
+            ${DIRECT_IO_OPT} \
             -o dbglevel=${DBGLEVEL:=info} \
             -o retries=3 \
             -f \

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -9,9 +9,6 @@ function test_append_file {
     describe "Testing append to file ..."
 
     # Write a small test file
-    if [ `uname` = "Darwin" ]; then
-       cat /dev/null > ${TEST_TEXT_FILE}
-    fi
     for x in `seq 1 $TEST_TEXT_FILE_LENGTH`
     do
        echo "echo ${TEST_TEXT} to ${TEST_TEXT_FILE}"
@@ -336,9 +333,6 @@ function test_rename_before_close {
 function test_multipart_upload {
     describe "Testing multi-part upload ..."
 
-    if [ `uname` = "Darwin" ]; then
-       cat /dev/null > $BIG_FILE
-    fi
     dd if=/dev/urandom of="/tmp/${BIG_FILE}" bs=$BIG_FILE_LENGTH count=1
     dd if="/tmp/${BIG_FILE}" of="${BIG_FILE}" bs=$BIG_FILE_LENGTH count=1
 
@@ -356,9 +350,6 @@ function test_multipart_upload {
 function test_multipart_copy {
     describe "Testing multi-part copy ..."
 
-    if [ `uname` = "Darwin" ]; then
-       cat /dev/null > $BIG_FILE
-    fi
     dd if=/dev/urandom of="/tmp/${BIG_FILE}" bs=$BIG_FILE_LENGTH count=1
     dd if="/tmp/${BIG_FILE}" of="${BIG_FILE}" bs=$BIG_FILE_LENGTH count=1
     mv "${BIG_FILE}" "${BIG_FILE}-copy"


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1062 

### Details
In the osxfuse, when updating or reading a file, the update of stats information may be delayed.
To avoid this, specify the direct_io option.
This removes the useless test code pointed out in #1062 .

When using the direct_io option, osxfuse 3.8.0 or later is required. (There is a bug of redirect append in the previous version)
