### PR TITLE
Added stats cache expire option for test

### DIFF
--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -193,6 +193,8 @@ function start_s3fs {
             -o createbucket \
             ${AUTH_OPT} \
             ${DIRECT_IO_OPT} \
+            -o stat_cache_expire=1 \
+            -o stat_cache_interval_expire=1 \
             -o dbglevel=${DBGLEVEL:=info} \
             -o retries=3 \
             -f \

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -309,6 +309,7 @@ function test_external_modification {
 function test_read_external_object() {
     describe "create objects via aws CLI and read via s3fs"
     OBJECT_NAME="$(basename $PWD)/${TEST_TEXT_FILE}"
+    sleep 3
     echo "test" | aws_cli cp - "s3://${TEST_BUCKET_1}/${OBJECT_NAME}"
     cmp ${TEST_TEXT_FILE} <(echo "test")
     rm -f ${TEST_TEXT_FILE}


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1062 #1110 #1111 #1119 #1120

### Details
In the test of enable_noobj_cache option, test_read_external_object fails in many cases.
This is probably due to caching and maintaining stats information for non-existent files.
Therefore, the expiry time of the stats cache is set to 1 second, and it is made to cache out before starting the test_read_external_object test.
