### PR TITLE
Fixed simple copy with nocpoyapi and modify flag in fdcache

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -512,6 +512,17 @@ function test_rm_rf_dir {
    fi
 }
 
+function test_copy_file {
+   describe "Test simple copy"
+
+   dd if=/dev/urandom of=/tmp/simple_file bs=1024 count=1
+   cp /tmp/simple_file copied_simple_file
+   cmp /tmp/simple_file copied_simple_file
+
+   rm /tmp/simple_file
+   rm copied_simple_file
+}
+
 function test_write_after_seek_ahead {
    describe "Test writes succeed after a seek ahead"
    dd if=/dev/zero of=testfile seek=1 count=1 bs=1024
@@ -589,6 +600,7 @@ function add_all_tests {
     add_tests test_mtime_file
     add_tests test_update_time
     add_tests test_rm_rf_dir
+    add_tests test_copy_file
     add_tests test_write_after_seek_ahead
     add_tests test_overwrite_existing_file_range
     add_tests test_concurrency


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1098 

### Details
On OSX, when the nocopyapi option was specified, the simple cp command failed.
It was detected by adding a simple cp command with a test case.

Unlike writing to a file with dd, when using the cp command, a callback such as chmod is called.
During the write callback process, the chmod callback was called and the file size was not updated, causing a problem.
This problem was caused by overwriting the size when opening an existing fd with FdManager::Open().

In addition to this modification, this PR also deletes FdEntity::is_modify flag.
This is_modify flag which indicates cache modification, should not be  managed by the FdEntity class(object), but by each element of FdEntity::pagelist.
In other words, add a modify flag to fdpage instead and manage modify status for individual fdpages.
As a result, there is a performance degradation for checking the modify state, but I believe it is insignificant.

This additional fix is ​​the same as that included in the #1098 PR.
(#1098 PR will be rebased)
