### PR TITLE
Fixed multipart copy and its retry handler

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -314,6 +314,8 @@ class S3fsCurl
     int                  b_ssekey_pos;         // backup for retrying
     std::string          b_ssevalue;           // backup for retrying
     sse_type_t           b_ssetype;            // backup for retrying
+    std::string          b_from;               // backup for retrying(for copy request)
+    headers_t            b_meta;               // backup for retrying(for copy request)
     std::string          op;                   // the HTTP verb of the request ("PUT", "GET", etc.)
     std::string          query_string;         // request query string
     Semaphore            *sem;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -834,6 +834,9 @@ static int put_headers(const char* path, headers_t& meta, bool is_copy)
 
   if(buf.st_size >= FIVE_GB){
     // multipart
+    if(nocopyapi || nomultipart){
+      return -EFBIG;    // File too large
+    }
     if(0 != (result = s3fscurl.MultipartHeadRequest(path, buf.st_size, meta, is_copy))){
       return result;
     }


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1102

### Details
The concurrent write test failed when multipart copy failed and retry is executed.
This function and retry handler was incorrect, those were a mistake in the processing, and those implementation was insufficient.
If you change the permissions of a file larger than 5GB, multipart copy processing will be performed, but these will fail in the retry processing.