### PR TITLE
Fixed MultiRead method to exit after waiting other parts at error

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -4150,6 +4150,8 @@ int S3fsMultiCurl::MultiPerform()
 
 int S3fsMultiCurl::MultiRead()
 {
+  int result = 0;
+
   for(s3fscurllist_t::iterator iter = clist_req.begin(); iter != clist_req.end(); ++iter) {
     S3fsCurl* s3fscurl = *iter;
 
@@ -4187,7 +4189,9 @@ int S3fsMultiCurl::MultiRead()
       S3FS_PRN_ERR("failed a request(Unknown response code: %s)", s3fscurl->url.c_str());
     }
 
-    if(!isRetry){
+    if(!isRetry || 0 != result){
+      // If an EIO error has already occurred, it will be terminated
+      // immediately even if retry processing is required. 
       s3fscurl->DestroyCurlHandle();
       delete s3fscurl;
 
@@ -4200,8 +4204,8 @@ int S3fsMultiCurl::MultiRead()
         if(NULL != retrycurl){
           clist_all.push_back(retrycurl);
         }else{
-          // Could not set up callback.
-          return -EIO;
+          // set EIO and wait for other parts.
+          result = -EIO;
         }
       }
       if(s3fscurl != retrycurl){
@@ -4212,7 +4216,14 @@ int S3fsMultiCurl::MultiRead()
   }
   clist_req.clear();
 
-  return 0;
+  if(0 != result){
+    // If an EIO error has already occurred, clear all retry objects.
+    for(s3fscurllist_t::iterator iter = clist_all.begin(); iter != clist_all.end(); ++iter){
+      delete (*iter);
+    }
+    clist_all.clear();
+  }
+  return result;
 }
 
 int S3fsMultiCurl::Request()


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
In multipart processing, when a part reaches the retry count limit due to get some error, an error(EIO) was returned at reaching limit.
However, this is wrong, and the S3fsMultiCurl::MultiRead() method must wait for receiving all part results before returning an error(EIO).
