### PR TITLE
Refixed strict processing of MultiRead method

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -300,7 +300,7 @@ class S3fsCurl
     headers_t            responseHeaders;      // header data by HeaderCallback
     BodyData             bodydata;             // body data by WriteMemoryCallback
     BodyData             headdata;             // header data by WriteMemoryCallback
-    long                 LastResponseCode;
+    volatile long        LastResponseCode;
     const unsigned char* postdata;             // use by post method and read callback function.
     int                  postdata_remaining;   // use by post method and read callback function.
     filepart             partdata;             // use by multipart upload/get object callback


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1130 

### Details
S3fsCurl::LastResponseCode has been changed so that the value is set when curl_easy_getinfo() is called and completes normally or reaches the maximum number of retries.
And, the code of the S3fsCurl::RequestPerform() method has been revised.
