### PR TITLE
use correct content-type when overwriting and copying files

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2961,13 +2961,14 @@ int S3fsCurl::PutHeadRequest(const char* tpath, headers_t& meta, bool is_copy)
   responseHeaders.clear();
   bodydata.Clear();
 
+  string contype       = S3fsCurl::LookupMimeType(string(tpath));
+  requestHeaders = curl_slist_sort_insert(requestHeaders, "Content-Type", contype.c_str());
+
   // Make request headers
   for(headers_t::iterator iter = meta.begin(); iter != meta.end(); ++iter){
     string key   = lower(iter->first);
     string value = iter->second;
-    if(key == "content-type"){
-      requestHeaders = curl_slist_sort_insert(requestHeaders, iter->first.c_str(), value.c_str());
-    }else if(key.substr(0, 9) == "x-amz-acl"){
+    if(key.substr(0, 9) == "x-amz-acl"){
       // not set value, but after set it.
     }else if(key.substr(0, 10) == "x-amz-meta"){
       requestHeaders = curl_slist_sort_insert(requestHeaders, iter->first.c_str(), value.c_str());
@@ -3106,12 +3107,13 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
     requestHeaders = curl_slist_sort_insert(requestHeaders, "Content-MD5", strMD5.c_str());
   }
 
+  string contype       = S3fsCurl::LookupMimeType(string(tpath));
+  requestHeaders = curl_slist_sort_insert(requestHeaders, "Content-Type", contype.c_str());
+
   for(headers_t::iterator iter = meta.begin(); iter != meta.end(); ++iter){
     string key   = lower(iter->first);
     string value = iter->second;
-    if(key == "content-type"){
-      requestHeaders = curl_slist_sort_insert(requestHeaders, iter->first.c_str(), value.c_str());
-    }else if(key.substr(0, 9) == "x-amz-acl"){
+    if(key.substr(0, 9) == "x-amz-acl"){
       // not set value, but after set it.
     }else if(key.substr(0, 10) == "x-amz-meta"){
       requestHeaders = curl_slist_sort_insert(requestHeaders, iter->first.c_str(), value.c_str());
@@ -3714,13 +3716,14 @@ int S3fsCurl::CopyMultipartPostSetup(const char* from, const char* to, int part_
   bodydata.Clear();
   headdata.Clear();
 
+  string contype       = S3fsCurl::LookupMimeType(string(to));
+  requestHeaders = curl_slist_sort_insert(requestHeaders, "Content-Type", contype.c_str());
+
   // Make request headers
   for(headers_t::iterator iter = meta.begin(); iter != meta.end(); ++iter){
     string key   = lower(iter->first);
     string value = iter->second;
-    if(key == "content-type"){
-      requestHeaders = curl_slist_sort_insert(requestHeaders, iter->first.c_str(), value.c_str());
-    }else if(key == "x-amz-copy-source"){
+    if(key == "x-amz-copy-source"){
       requestHeaders = curl_slist_sort_insert(requestHeaders, iter->first.c_str(), value.c_str());
     }else if(key == "x-amz-copy-source-range"){
       requestHeaders = curl_slist_sort_insert(requestHeaders, iter->first.c_str(), value.c_str());

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -76,11 +76,9 @@ function test_mv_file {
     fi
     
     #check the renamed file content-type
-    INFO_STR=`aws_cli s3api head-object --bucket ${TEST_BUCKET_1} --key $1/${ALT_TEST_TEXT_FILE}`
-    if [[ "${INFO_STR}" != *"text/plain"* ]]
+    if [ -f "/etc/mime.types" ]
     then
-       echo "moved file content-type is not as expected expected:text/plain got:$INFO_STR"
-       return 1
+      check_content_type "$1/$ALT_TEST_TEXT_FILE" "text/plain"
     fi
 
     # Check the contents of the alt file
@@ -352,12 +350,7 @@ function test_multipart_copy {
     fi
 
     #check the renamed file content-type
-    INFO_STR=`aws_cli s3api head-object --bucket ${TEST_BUCKET_1} --key $1/${BIG_FILE}-copy`
-    if [[ "${INFO_STR}" != *"application/octet-stream"* ]]
-    then
-       echo "moved file content-type is not as expected expected:application/octet-stream got:$INFO_STR"
-       return 1
-    fi
+    check_content_type "$1/${BIG_FILE}-copy" "application/octet-stream"
 
     rm -f "/tmp/${BIG_FILE}"
     rm_test_file "${BIG_FILE}-copy"

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -249,6 +249,14 @@ function get_mtime() {
         stat -c %Y "$1"
     fi
 }
+function check_content_type() {
+    INFO_STR=`aws_cli s3api head-object --bucket ${TEST_BUCKET_1} --key $1`
+    if [[ "${INFO_STR}" != *"$2"* ]]
+    then
+        echo "moved file content-type is not as expected expected:$2 got:${INFO_STR}"
+        exit 1
+    fi
+}
 
 function aws_cli() {
     AWS_ACCESS_KEY_ID=local-identity AWS_SECRET_ACCESS_KEY=local-credential aws $* --endpoint-url "${S3_URL}" --no-verify-ssl 


### PR DESCRIPTION
When overwriting and copying a file, we need to use /etc/mime.types to decide the file Content-Type, rather than cached meta Content-Type。

### Details
When overwriting and copying files, s3fs use the original file Content-Type meta cache，the cached Content-Type may be not correct, for example the file upload by a machine doest not have file /etc/mine.types。So in order to allow user fixed the wrong Content-Type,  we need to use /etc/mime.types to decide the file Content-Type。