### PR TITLE
Expose base parameter in s3fs_strtoofft

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1327,7 +1327,7 @@ S3fsCurl* S3fsCurl::UploadMultipartPostRetryCallback(S3fsCurl* s3fscurl)
   if(!get_keyword_value(s3fscurl->url, "partNumber", part_num_str)){
     return NULL;
   }
-  part_num = s3fs_strtoofft(part_num_str.c_str(), /*is_base_16=*/ false);
+  part_num = s3fs_strtoofft(part_num_str.c_str(), /*base=*/ 10);
 
   if(s3fscurl->retry_count >= S3fsCurl::retries){
     S3FS_PRN_ERR("Over retry count(%d) limit(%s:%d).", s3fscurl->retry_count, s3fscurl->path.c_str(), part_num);
@@ -1369,7 +1369,7 @@ S3fsCurl* S3fsCurl::CopyMultipartPostRetryCallback(S3fsCurl* s3fscurl)
   if(!get_keyword_value(s3fscurl->url, "partNumber", part_num_str)){
     return NULL;
   }
-  part_num = s3fs_strtoofft(part_num_str.c_str(), /*is_base_16=*/ false);
+  part_num = s3fs_strtoofft(part_num_str.c_str(), /*base=*/ 10);
 
   if(s3fscurl->retry_count >= S3fsCurl::retries){
     S3FS_PRN_ERR("Over retry count(%d) limit(%s:%d).", s3fscurl->retry_count, s3fscurl->path.c_str(), part_num);
@@ -1722,7 +1722,7 @@ bool S3fsCurl::SetIAMCredentials(const char* response)
   S3fsCurl::AWSAccessToken       = keyval[string(S3fsCurl::IAM_token_field)];
 
   if(S3fsCurl::is_ibm_iam_auth){
-    S3fsCurl::AWSAccessTokenExpire = s3fs_strtoofft(keyval[string(S3fsCurl::IAM_expiry_field)].c_str(), /*is_base_16=*/ false);
+    S3fsCurl::AWSAccessTokenExpire = s3fs_strtoofft(keyval[string(S3fsCurl::IAM_expiry_field)].c_str(), /*base=*/ 10);
   }else{
     S3fsCurl::AWSAccessKeyId       = keyval[string(IAMCRED_ACCESSKEYID)];
     S3fsCurl::AWSSecretAccessKey   = keyval[string(IAMCRED_SECRETACCESSKEY)];

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4516,7 +4516,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 1; // continue for fuse option
     }
     if(0 == STR2NCMP(arg, "umask=")){
-      s3fs_umask = s3fs_strtoofft(strchr(arg, '=') + sizeof(char), /*is_base_16=*/ false);
+      s3fs_umask = s3fs_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 8);
       s3fs_umask &= (S_IRWXU | S_IRWXG | S_IRWXO);
       is_s3fs_umask = true;
       return 1; // continue for fuse option
@@ -4526,7 +4526,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 1; // continue for fuse option
     }
     if(0 == STR2NCMP(arg, "mp_umask=")){
-      mp_umask = s3fs_strtoofft(strchr(arg, '=') + sizeof(char), /*is_base_16=*/ false);
+      mp_umask = s3fs_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 8);
       mp_umask &= (S_IRWXU | S_IRWXG | S_IRWXO);
       is_mp_umask = true;
       return 0;

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -53,11 +53,11 @@ template std::string str(unsigned long long value);
 static const char hexAlphabet[] = "0123456789ABCDEF";
 
 // replacement for C++11 std::stoll
-off_t s3fs_strtoofft(const char* str, bool is_base_16)
+off_t s3fs_strtoofft(const char* str, int base)
 {
   errno = 0;
   char *temp;
-  long long result = strtoll(str, &temp, is_base_16 ? 16 : 10);
+  long long result = strtoll(str, &temp, base);
 
   if(temp == str || *temp != '\0'){
     throw std::invalid_argument("s3fs_strtoofft");

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -36,7 +36,7 @@ static inline int STR2NCMP(const char *str1, const char *str2) { return strncmp(
 template <class T> std::string str(T value);
 
 // Convert string to off_t.  Throws std::invalid_argument and std::out_of_range on bad input.
-off_t s3fs_strtoofft(const char* str, bool is_base_16 = false);
+off_t s3fs_strtoofft(const char* str, int base = 0);
 
 std::string trim_left(const std::string &s, const std::string &t = SPACES);
 std::string trim_right(const std::string &s, const std::string &t = SPACES);

--- a/src/test_string_util.cpp
+++ b/src/test_string_util.cpp
@@ -85,11 +85,11 @@ void test_strtoofft()
   }catch(std::exception &e){
     // expected
   }
-  ASSERT_EQUALS(s3fs_strtoofft("A", /*is_base_16=*/ true), static_cast<off_t>(10L));
-  ASSERT_EQUALS(s3fs_strtoofft("F", /*is_base_16=*/ true), static_cast<off_t>(15L));
-  ASSERT_EQUALS(s3fs_strtoofft("a", /*is_base_16=*/ true), static_cast<off_t>(10L));
-  ASSERT_EQUALS(s3fs_strtoofft("f", /*is_base_16=*/ true), static_cast<off_t>(15L));
-  ASSERT_EQUALS(s3fs_strtoofft("deadbeef", /*is_base_16=*/ true), static_cast<off_t>(3735928559L));
+  ASSERT_EQUALS(s3fs_strtoofft("A", /*base=*/ 16), static_cast<off_t>(10L));
+  ASSERT_EQUALS(s3fs_strtoofft("F", /*base=*/ 16), static_cast<off_t>(15L));
+  ASSERT_EQUALS(s3fs_strtoofft("a", /*base=*/ 16), static_cast<off_t>(10L));
+  ASSERT_EQUALS(s3fs_strtoofft("f", /*base=*/ 16), static_cast<off_t>(15L));
+  ASSERT_EQUALS(s3fs_strtoofft("deadbeef", /*base=*/ 16), static_cast<off_t>(3735928559L));
 }
 
 void test_wtf8_encoding()


### PR DESCRIPTION
This fixes a regression from ccf3e7bfa201428e06e2d97a70f277de981102e4
which caused the misparsing of octal inputs for the `mp_umask` and `umask`
flags.  It also allows some callers to be more precise about their
decimal inputs.