### PR TITLE
Use close-on-exec where possible

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,6 @@
 Checks: '
     -*,
+    android-*,
     bugprone-*,
     -bugprone-macro-parentheses,
     google-*,

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1406,7 +1406,7 @@ int S3fsCurl::ParallelMultipartUploadRequest(const char* tpath, headers_t& meta,
   S3FS_PRN_INFO3("[tpath=%s][fd=%d]", SAFESTRPTR(tpath), fd);
 
   // duplicate fd
-  if(-1 == (fd2 = dup(fd)) || 0 != lseek(fd2, 0, SEEK_SET)){
+  if(-1 == (fd2 = dup_fd_cloexec(fd)) || 0 != lseek(fd2, 0, SEEK_SET)){
     S3FS_PRN_ERR("Could not duplicate file descriptor(errno=%d)", errno);
     if(-1 != fd2){
       close(fd2);
@@ -3071,7 +3071,7 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
   if(-1 != fd){
     // duplicate fd
     int fd2;
-    if(-1 == (fd2 = dup(fd)) || -1 == fstat(fd2, &st) || 0 != lseek(fd2, 0, SEEK_SET) || NULL == (file = fdopen(fd2, "rb"))){
+    if(-1 == (fd2 = dup_fd_cloexec(fd)) || -1 == fstat(fd2, &st) || 0 != lseek(fd2, 0, SEEK_SET) || NULL == (file = fdopen(fd2, "rb"))){
       S3FS_PRN_ERR("Could not duplicate file descriptor(errno=%d)", errno);
       if(-1 != fd2){
         close(fd2);
@@ -3876,7 +3876,7 @@ int S3fsCurl::MultipartUploadRequest(const char* tpath, headers_t& meta, int fd,
   S3FS_PRN_INFO3("[tpath=%s][fd=%d]", SAFESTRPTR(tpath), fd);
 
   // duplicate fd
-  if(-1 == (fd2 = dup(fd)) || 0 != lseek(fd2, 0, SEEK_SET)){
+  if(-1 == (fd2 = dup_fd_cloexec(fd)) || 0 != lseek(fd2, 0, SEEK_SET)){
     S3FS_PRN_ERR("Could not duplicate file descriptor(errno=%d)", errno);
     if(-1 != fd2){
       close(fd2);
@@ -3930,7 +3930,7 @@ int S3fsCurl::MultipartUploadRequest(const string& upload_id, const char* tpath,
 
   // duplicate fd
   int fd2;
-  if(-1 == (fd2 = dup(fd)) || 0 != lseek(fd2, 0, SEEK_SET)){
+  if(-1 == (fd2 = dup_fd_cloexec(fd)) || 0 != lseek(fd2, 0, SEEK_SET)){
     S3FS_PRN_ERR("Could not duplicate file descriptor(errno=%d)", errno);
     if(-1 != fd2){
       close(fd2);

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -1033,6 +1033,19 @@ bool simple_parse_xml(const char* data, size_t len, const char* key, std::string
   return result;
 }
 
+int dup_fd_cloexec(int fd)
+{
+#if defined(__APPLE__)
+  int fd2;
+  if(-1 == (fd2 = dup(fd))){
+    return -1;
+  }
+  return fcntl(fd2, F_SETFD, FD_CLOEXEC);
+#else
+  return fcntl(fd, F_DUPFD_CLOEXEC);
+#endif
+}
+
 //-------------------------------------------------------------------
 // Help
 //-------------------------------------------------------------------

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -141,6 +141,9 @@ time_t get_lastmodified(headers_t& meta);
 bool is_need_check_obj_detail(headers_t& meta);
 bool simple_parse_xml(const char* data, size_t len, const char* key, std::string& value);
 
+// wrapper to work around broken macOS F_DUPFD_CLOEXEC behavior
+int dup_fd_cloexec(int fd);
+
 void show_usage(void);
 void show_help(void);
 void show_version(void);


### PR DESCRIPTION
This prevents theoretical security issues with untrusted child
processes.  Also remove two unneeded void non-parameters.  Found by
clang-tidy.