### PR TITLE
fix deadlock due to fdmanager_lock and fdent_data_lock

### DIFF
--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -236,7 +236,8 @@ class FdManager
 
     // Return FdEntity associated with path, returning NULL on error.  This operation increments the reference count; callers must decrement via Close after use.
     FdEntity* GetFdEntity(const char* path, int existfd = -1);
-    FdEntity* Open(const char* path, headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, bool force_tmpfile = false, bool is_create = true, bool no_fd_lock_wait = false);
+    FdEntity* Open(const char* path, headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, bool force_tmpfile = false,
+                   bool is_create = true, bool no_fd_lock_wait = false, bool no_manager_lock_wait = false);
     FdEntity* ExistOpen(const char* path, int existfd = -1, bool ignore_existfd = false);
     void Rename(const std::string &from, const std::string &to);
     bool Close(FdEntity* ent);


### PR DESCRIPTION
### Details
Deadlocks will appear in the following situations：
1. thread A call s3fs_read, already get the fdent_data_lock and cache_cleanup_lock（for clean up cache dir）, trying to get fd_manager_lock
2. thread B call s3fs_open， already get  fd_manager_lock  and fdent_lock, trying to get fdent_data_lock
3. the deadlock occured between thread A and thread B, because each thread wants to get the lock of another thread
so we should use pthread_mutex_trylock for fdmanager when clean up cache