### PR TITLE
fix deadlock in clean up cache

### DIFF
--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -166,7 +166,6 @@ class FdEntity
 
     void Close(void);
     bool IsOpen(void) const { return (-1 != fd); }
-    bool IsMultiOpened(void) const { return refcnt > 1; }
     int Open(headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, bool no_fd_lock_wait = false);
     bool OpenAndLoadAll(headers_t* pmeta = NULL, off_t* size = NULL, bool force_load = false);
     int Dup(bool lock_already_held = false);
@@ -200,7 +199,6 @@ class FdEntity
     ssize_t Write(const char* bytes, off_t start, size_t size);
 
     bool ReserveDiskSpace(off_t size);
-    void CleanupCache();
 };
 typedef std::map<std::string, class FdEntity*> fdent_map_t;   // key=path, value=FdEntity*
 

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -258,6 +258,11 @@ function check_content_type() {
     fi
 }
 
+function get_disk_avail_size() {
+    DISK_AVAIL_SIZE=`BLOCKSIZE=$((1024 * 1024)) df $1 | awk '{print $4}' | tail -n 1`
+    echo ${DISK_AVAIL_SIZE}
+}
+
 function aws_cli() {
     AWS_ACCESS_KEY_ID=local-identity AWS_SECRET_ACCESS_KEY=local-credential aws $* --endpoint-url "${S3_URL}" --no-verify-ssl 
 }


### PR DESCRIPTION
@gaul ，the previous pull request is：https://github.com/s3fs-fuse/s3fs-fuse/pull/1146, still have some situations not fully considered, so I closed the previous pull request.

Deadlocks will appear in the following situations also：
thread A call s3fs_write, already get the fdent_data_lock and cache_cleanup_lock（for clean up cache dir）, after cleaning one file, and trying to get fd_manager_lock for Close the FdEntity.
thread B call s3fs_open for the same file，already get fd_manager_lock and fdent_lock, trying to get fdent_data_lock
the deadlock occured between thread A and thread B, because each thread wants to get the lock of another thread
so when cleanup a cache file, we should hold fd_manager_lock until it finished, if we cannot hold it, we can ignore it temporarily.

Another deadlock  condition is in NoCacheLoadAndPost, because it trying to hold fd_manager_lock after hold fdent_data_lock

In short，We should lock in the order fd_manager_lock->fdent_lock->fdent_data_lock， if we trying to hold fd_manager_lock after hold fdent_lock or fdent_data_lock，we should use try_lock. The NoCacheLoadAndPost deadlock condition I didn't find a nice way to solve it，but it will only triggered if didn't have enough disk after cleaned up cache. 