### PR TITLE
Fix use_cache='' handling

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -2178,7 +2178,7 @@ off_t           FdManager::free_disk_space = 0;
 //------------------------------------------------
 bool FdManager::SetCacheDir(const char* dir)
 {
-  if(!dir || '\0' == dir[0]){
+  if(!dir || '\0' == dir[0] || 0 == strcmp(dir, "''") || 0 == strcmp(dir, "\"\"")){
     cache_dir = "";
   }else{
     cache_dir = dir;


### PR DESCRIPTION
Do not use "/''" as cache directory when mounting with fstab

### Relevant Issue (if applicable)
 #1016 

### Details
When mounting from fstab it actually called with `use_cache=''` argument and it creates and uses `/''` directory as cache
