### PR TITLE
Updated .travis.yml for tapping homebrew/cask-cask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       before_install:
-        - brew tap caskroom/cask
+        - brew tap homebrew/homebrew-cask
         - HOMEBREW_NO_AUTO_UPDATE=1 brew cask install osxfuse
         - HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli cppcheck truncate
         - if [ -f /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ]; then sudo chmod +s /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ; elif [ -f /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ]; then sudo chmod +s /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ; fi


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Since caskroom/cask has been changed to homebrew/homebrew-cask, s3fs cannot be built on OSX.
Modified to use homebrew/homebrew-cask.
