### PR TITLE
Fixed test_write_multiple_offsets error on osx

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -652,8 +652,8 @@ function test_open_second_fd {
 
 function test_write_multiple_offsets {
     describe "test writing to multiple offsets"
-    ../../write_multiple_offsets.py ${TEST_TEXT_FILE}
-    rm_test_file
+    ../../write_multiple_offsets.py ${TEST_TEXT_FILE}.multioffset
+    rm_test_file ${TEST_TEXT_FILE}.multioffset
 }
 
 function add_all_tests {


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1171 

### Details
The cause of #1171 is not clear yet.
However, from the travis log, it seems the file size was not 0 even the file was opened with truncating.
(Further inspection is required for file cache clearing errors or file cache size calculation errors.)
In order to avoid test_write_multiple_offsets test issue, I will use another file name for this test.

After merging this fix, investigation continues for #1171 