### PR TITLE
handle edge case when bucket name and first part of endpoint match

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -4689,7 +4689,7 @@ string prepare_url(const char* url)
   string path;
   string url_str = string(url);
   string token = string("/") + bucket;
-  int bucket_pos = url_str.find(token);
+  int bucket_pos;
   int bucket_length = token.size();
   int uri_length = 0;
 
@@ -4699,6 +4699,7 @@ string prepare_url(const char* url)
     uri_length = 7;
   }
   uri  = url_str.substr(0, uri_length);
+  bucket_pos = url_str.find(token, uri_length);
 
   if(!pathrequeststyle){
     hostname = bucket + "." + url_str.substr(uri_length, bucket_pos - uri_length);


### PR DESCRIPTION
### Relevant Issue (if applicable)
https://github.com/s3fs-fuse/s3fs-fuse/issues/1184

### Details
Fixes when the bucket name and first part of endpoint match by skipping the first part, either `https://` or `http://`
