### PR TITLE
Specfiy pkg-config as a necessary dependency for compilation

### DIFF
--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -15,6 +15,7 @@ Keep in mind using the pre-built packages when available.
 * libcurl
 * libxml2
 * openssl
+* pkg-config (or your OS equivalent)
 
 2. Then compile from master via the following commands:
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Many systems provide pre-built packages:
   brew install s3fs
   ```
 
-Otherwise consult the [complation instructions](COMPILATION.md).
+Otherwise consult the [compilation instructions](COMPILATION.md).
 
 ## Examples
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
https://github.com/s3fs-fuse/s3fs-fuse/issues/723

### Details
I don't usually compile from source so having dependencies spelled out helps newbies like me. I have the comment `or your OS equivalent` because it was `pkgconf` on Manjaro.
