### PR TITLE
Adds requester_pays option to enable requests involving Requester Pays buckets

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -392,6 +392,7 @@ off_t            S3fsCurl::multipart_size      = MULTIPART_SIZE; // default
 bool             S3fsCurl::is_sigv4            = true;           // default
 bool             S3fsCurl::is_ua               = true;           // default
 bool             S3fsCurl::is_use_session_token = false;         // default
+bool             S3fsCurl::requester_pays      = false;          // default
 
 //-------------------------------------------------------------------
 // Class methods for S3fsCurl
@@ -2755,6 +2756,10 @@ void S3fsCurl::insertV4Headers()
   requestHeaders = curl_slist_sort_insert(requestHeaders, "x-amz-content-sha256", contentSHA256.c_str());
   requestHeaders = curl_slist_sort_insert(requestHeaders, "x-amz-date", date8601.c_str());
 	
+  if (S3fsCurl::IsRequesterPays()) {
+    requestHeaders = curl_slist_sort_insert(requestHeaders, "x-amz-request-payer", "requester");
+  }
+
   if(!S3fsCurl::IsPublicBucket()){
     string Signature = CalcSignature(op, realpath, query_string + (type == REQTYPE_PREMULTIPOST || type == REQTYPE_MULTILIST ? "=" : ""), strdate, contentSHA256, date8601);
     string auth = "AWS4-HMAC-SHA256 Credential=" + AWSAccessKeyId + "/" + strdate + "/" + endpoint +

--- a/src/curl.h
+++ b/src/curl.h
@@ -301,6 +301,7 @@ class S3fsCurl
     static off_t            multipart_size;
     static bool             is_sigv4;
     static bool             is_ua;             // User-Agent
+    static bool             requester_pays;
 
     // variables
     CURL*                hCurl;
@@ -477,6 +478,8 @@ class S3fsCurl
     static bool SetUserAgentFlag(bool isset) { bool bresult = S3fsCurl::is_ua; S3fsCurl::is_ua = isset; return bresult; }
     static bool IsUserAgentFlag(void) { return S3fsCurl::is_ua; }
     static void InitUserAgent(void);
+    static bool SetRequesterPays(bool flag) { bool old_flag = S3fsCurl::requester_pays; S3fsCurl::requester_pays = flag; return old_flag; }
+    static bool IsRequesterPays(void) { return S3fsCurl::requester_pays; }
 
     // methods
     bool CreateCurlHandle(bool only_pool = false, bool remake = false);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -5062,6 +5062,10 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       use_wtf8 = true;
       return 0;
     }
+    if(0 == strcmp(arg, "requester_pays")){
+      S3fsCurl::SetRequesterPays(true);
+      return 0;
+    }
 
     // [NOTE]
     // following option will be discarding, because these are not for fuse.


### PR DESCRIPTION
This PR adds `requester_pays` option, false by default, to enable requests involving Requester Pays buckets.

Related issue:
https://github.com/s3fs-fuse/s3fs-fuse/issues/635
