### PR TITLE
Update install instructions for Debian and Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Many systems provide pre-built packages:
 * Debian 9 and Ubuntu 16.04 or newer:
 
   ```
-  sudo apt-get install s3fs
+  sudo apt install s3fs
   ```
 
 * Fedora 27 or newer:
 
   ```
-  sudo yum install s3fs-fuse
+  sudo dnf install s3fs-fuse
   ```
 
 * Gentoo:


### PR DESCRIPTION
### Details
Since Debian 8 and Ubuntu 14.04 `apt` is available and can be used instead of `apt-get`.

For Fedora, `dnf` has been the default package manager since Fedora 22.
