### PR TITLE
Not trap chown command errors directly

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -233,7 +233,14 @@ function test_chown {
         ORIGINAL_PERMISSIONS=$(stat --format=%u:%g $TEST_TEXT_FILE)
     fi
 
-    chown 1000:1000 $TEST_TEXT_FILE;
+    # [NOTE]
+    # Prevents test interruptions due to permission errors, etc.
+    # If the chown command fails, an error will occur with the
+    # following judgment statement. So skip the chown command error.
+    # '|| true' was added due to a problem with Travis CI and MacOS
+    # and ensure_diskfree option.
+    #
+    chown 1000:1000 $TEST_TEXT_FILE || true
 
     # if they're the same, we have a problem.
     if [ `uname` = "Darwin" ]; then


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
If the test_chown() of the test script causes an error (mainly related to file permission) for the chown command, the script is trapped at that point.
This seems to occur when the ensure_diskfree option is specified in Travis CI of MacOS.
Even if the chown command error is not trapped directly, it can be detected as an error in the immediately following judgment statement.
Therefore, it is patched to avoid trapping chown command errors directly.
