### PR TITLE
Suppressed a lot of message output about cache cleanup

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -2732,7 +2732,7 @@ bool FdManager::ChangeEntityToTempPath(FdEntity* ent, const char* path)
 
 void FdManager::CleanupCacheDir()
 {
-  S3FS_PRN_INFO("cache cleanup requested");
+  //S3FS_PRN_DBG("cache cleanup requested");
 
   if(!FdManager::IsCacheDir()){
     return;
@@ -2741,9 +2741,9 @@ void FdManager::CleanupCacheDir()
   AutoLock auto_lock_no_wait(&FdManager::cache_cleanup_lock, AutoLock::NO_WAIT);
 
   if(auto_lock_no_wait.isLockAcquired()){
-    S3FS_PRN_INFO("cache cleanup started");
+    //S3FS_PRN_DBG("cache cleanup started");
     CleanupCacheDirInternal("");
-    S3FS_PRN_INFO("cache cleanup ended");
+    //S3FS_PRN_DBG("cache cleanup ended");
   }else{
     // wait for other thread to finish cache cleanup
     AutoLock auto_lock(&FdManager::cache_cleanup_lock);

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -676,11 +676,11 @@ function test_clean_up_cache() {
     describe "Test clean up cache"
 
     dir="many_files"
-    count=256
+    count=25
     mkdir -p $dir
 
     for x in $(seq $count); do
-        dd if=/dev/urandom of=$dir/file-$x bs=1048576 count=1
+        dd if=/dev/urandom of=$dir/file-$x bs=10485760 count=1
     done
 
     file_cnt=$(ls $dir | wc -l)


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
#### Log level doe cache cleanup
Suppress debug messages when clearing the cache and starting and completing it.
Although the output is at the INFO level, the log may be too large in TravisCI and the build may fail.
Changed to DBG level and commented out.
#### test_clean_up_cache test
In the test_clean_up_cache() test, I changed the test to 10MB * 25 files instead of 1MB * 256 files, and reduced the log output.