### PR TITLE
Set directory MIME type to application/x-directory

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -671,6 +671,10 @@ void S3fsCurl::InitUserAgent()
 //
 string S3fsCurl::LookupMimeType(const string& name)
 {
+  if(!name.empty() && name[name.size() - 1] == '/'){
+    return "application/x-directory";
+  }
+
   string result("application/octet-stream");
   string::size_type last_pos = name.find_last_of('.');
   string::size_type first_pos = name.find_first_of('.');

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1109,7 +1109,6 @@ static int create_directory_object(const char* path, mode_t mode, time_t time, u
   }
 
   headers_t meta;
-  meta["Content-Type"]     = string("application/x-directory");
   meta["x-amz-meta-uid"]   = str(uid);
   meta["x-amz-meta-gid"]   = str(gid);
   meta["x-amz-meta-mode"]  = str(mode);

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -457,6 +457,8 @@ function test_special_characters {
         ls 'special~' 2>&1 | grep -q 'No such file or directory'
         ls 'specialµ' 2>&1 | grep -q 'No such file or directory'
     )
+
+    mkdir "TOYOTA TRUCK 8.2.2"
 }
 
 function test_symlink {
@@ -720,6 +722,13 @@ function test_content_type() {
     touch "test.bin"
     CONTENT_TYPE=$(aws_cli s3api head-object --bucket "${TEST_BUCKET_1}" --key "${DIR_NAME}/test.bin" | grep "ContentType")
     if ! echo $CONTENT_TYPE | grep -q "application/octet-stream"; then
+        echo "Unexpected Content-Type: $CONTENT_TYPE"
+        return 1;
+    fi
+
+    mkdir "test.dir"
+    CONTENT_TYPE=$(aws_cli s3api head-object --bucket "${TEST_BUCKET_1}" --key "${DIR_NAME}/test.dir/" | grep "ContentType")
+    if ! echo $CONTENT_TYPE | grep -q "application/x-directory"; then
         echo "Unexpected Content-Type: $CONTENT_TYPE"
         return 1;
     fi


### PR DESCRIPTION
Previously s3fs auto-detected the MIME type of directories like
"TOYOTA TRUCK 8.2.2" as application/x-troff-man.  This caused `get_mode`
to not set `S_IFDIR` which failed directory creation.  Instead force all
object names ending in / to application/x-directory.  Fixes #1183.