### PR TITLE
Avoid TravisCI timeouts in test execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
         - make cppcheck
         - make check -C src
         - modprobe fuse
-        - make check -C test
+        - travis_wait 30 make check -C test
         - test/filter-suite-log.sh test/test-suite.log
 
     - os: osx
@@ -85,9 +85,8 @@ matrix:
         - make cppcheck
         - make check -C src
         - if [ -f /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ]; then /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ; elif [ -f /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ]; then /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ; fi
-        - make check -C test
+        - travis_wait 30 make check -C test
         - test/filter-suite-log.sh test/test-suite.log
-
 
     - os: linux-ppc64le
       sudo: required
@@ -106,7 +105,7 @@ matrix:
         - make cppcheck
         - make check -C src
         - modprobe fuse
-        - make check -C test
+        - travis_wait 30 make check -C test
         - test/filter-suite-log.sh test/test-suite.log
 
 #


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Somtimes, in TravisCI the time for test execution may exceed 10 minutes, resulting in an error inadvertently.
The PR itself should be reviewed so that the test itself can be completed sooner, but as a temporary measure, this PR will extend the timeout.
