### PR TITLE
Generic compilation instructions: explain that /etc/mime.type is needed

### DIFF
--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -15,6 +15,7 @@ Keep in mind using the pre-built packages when available.
 * libcurl
 * libxml2
 * openssl
+* /etc/mime.types (the package providing depends on the OS)
 * pkg-config (or your OS equivalent)
 
 2. Then compile from master via the following commands:


### PR DESCRIPTION
### Relevant Issue (if applicable)

#1217

### Details

I would say having `/etc/mime.types` is a runtime requirement.

Without it s3fs-fuse does not fail but uploads all files as "application/octect-stream".

NOTE1: I don't know how this works at MacOS as I don't have a system to test it. Is it `/etc/mime.types` as well?
NOTE2: If this PR is accepted, we should probably check for `/etc/mime.types` at `configure.ac` and break the build if it's not available.
