### PR TITLE
Added mime option for strict checking of mime types file

### DIFF
--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -15,7 +15,11 @@ Keep in mind using the pre-built packages when available.
 * libcurl
 * libxml2
 * openssl
-* /etc/mime.types (the package providing depends on the OS)
+* mime.types (the package providing depends on the OS)
+	* s3fs tries to detect `/etc/mime.types` as default regardless of the OS
+	* Else s3fs tries to detect `/etc/apache2/mime.types` if OS is macOS
+	* s3fs exits with an error if these files are not exist
+	* Alternatively, you can set mime.types file path with `mime` option without detecting these default files
 * pkg-config (or your OS equivalent)
 
 2. Then compile from master via the following commands:

--- a/doc/man/s3fs.1
+++ b/doc/man/s3fs.1
@@ -326,6 +326,11 @@ Otherwise an error is returned.
 \fB\-o\fR requester_pays (default is disable)
 This option instructs s3fs to enable requests involving Requester Pays buckets (It includes the 'x-amz-request-payer=requester' entry in the request header).
 .TP
+\fB\-o\fR mime (default is "/etc/mime.types")
+Specify the path of the mime.types file.
+If this option is not specified, the existence of "/etc/mime.types" is checked, and that file is loaded as mime information.
+If this file does not exist on macOS, then "/etc/apache2/mime.types" is checked as well.
+.TP
 \fB\-o\fR dbglevel (default="crit")
 Set the debug message level. set value as crit (critical), err (error), warn (warning), info (information) to debug level. default debug level is critical.
 If s3fs run with "-d" option, the debug level is set information.

--- a/src/curl.h
+++ b/src/curl.h
@@ -355,7 +355,6 @@ class S3fsCurl
     static bool DestroyCryptMutex(void);
     static int CurlProgress(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow);
 
-    static bool InitMimeType(const char* MimeFile = NULL);
     static bool LocateBundle(void);
     static size_t HeaderCallback(void *data, size_t blockSize, size_t numBlocks, void *userPtr);
     static size_t WriteMemoryCallback(void *ptr, size_t blockSize, size_t numBlocks, void *data);
@@ -408,7 +407,8 @@ class S3fsCurl
 
   public:
     // class methods
-    static bool InitS3fsCurl(const char* MimeFile = NULL);
+    static bool InitS3fsCurl(void);
+    static bool InitMimeType(const std::string& strFile);
     static bool DestroyS3fsCurl(void);
     static int ParallelMultipartUploadRequest(const char* tpath, headers_t& meta, int fd);
     static int ParallelMixMultipartUploadRequest(const char* tpath, headers_t& meta, int fd, const PageList& pagelist);

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -123,6 +123,8 @@ std::string get_exist_directory_path(const std::string& path);
 bool check_exist_dir_permission(const char* dirpath);
 bool delete_files_in_dir(const char* dir, bool is_remove_own);
 
+bool compare_sysname(const char* target);
+
 time_t get_mtime(const char *s);
 time_t get_mtime(headers_t& meta, bool overcheck = true);
 time_t get_ctime(headers_t& meta, bool overcheck = true);

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -707,30 +707,16 @@ function test_content_type() {
 
     touch "test.txt"
     CONTENT_TYPE=$(aws_cli s3api head-object --bucket "${TEST_BUCKET_1}" --key "${DIR_NAME}/test.txt" | grep "ContentType")
-    if [ `uname` = "Darwin" ]; then
-        if ! echo $CONTENT_TYPE | grep -q "application/octet-stream"; then
-            echo "Unexpected Content-Type(MacOS): $CONTENT_TYPE"
-            return 1;
-        fi
-    else
-        if ! echo $CONTENT_TYPE | grep -q "text/plain"; then
-            echo "Unexpected Content-Type: $CONTENT_TYPE"
-            return 1;
-        fi
+    if ! echo $CONTENT_TYPE | grep -q "text/plain"; then
+        echo "Unexpected Content-Type: $CONTENT_TYPE"
+        return 1;
     fi
 
     touch "test.jpg"
     CONTENT_TYPE=$(aws_cli s3api head-object --bucket "${TEST_BUCKET_1}" --key "${DIR_NAME}/test.jpg" | grep "ContentType")
-    if [ `uname` = "Darwin" ]; then
-        if ! echo $CONTENT_TYPE | grep -q "application/octet-stream"; then
-            echo "Unexpected Content-Type(MacOS): $CONTENT_TYPE"
-            return 1;
-        fi
-    else
-        if ! echo $CONTENT_TYPE | grep -q "image/jpeg"; then
-            echo "Unexpected Content-Type: $CONTENT_TYPE"
-            return 1;
-        fi
+    if ! echo $CONTENT_TYPE | grep -q "image/jpeg"; then
+        echo "Unexpected Content-Type: $CONTENT_TYPE"
+        return 1;
     fi
 
     touch "test.bin"


### PR DESCRIPTION
## Relevant Issue (if applicable)
#1253 #1217 

## Details
### Background
The issue #1217 is that when s3fs cannot load the /etc/mime.types file, it uploads the Content-Type of all objects as application/octet-stream.
As pointed out in PR #1253, s3fs should not be able to build or start up.
This allows the user to notice that there is a problem with mime.types.

### What this PR changed
#### Added mime option
Added this option so that the user can specify the mime.types file path instead of /etc/mime.types(default).
I considered that the mime.types file path may be different depending on the environment by each user.
On non-macOS, the default mime.types path is /etc/mime.types. (this path is used when this option is not specified)
On macOS after Cataline, apache2.4 is pre-installed , so /etc/apache2/mime.types is the default for macOS.
This option gives user's environment flexibility.

### Exit if mime.types loading fails
s3fs exits with an error if the mime.types file(both default and user specified) fails to load.
This allows the user to know that there is problem with mime.types path.
Also, if s3fs can be started, mime.types can be loaded correctly, so it will solve #1217.

### Undo test evasion
I restored the content-types test for macOS that was avoided in #1237.
The error was occurred when testing code #1242 because /etc/mime.types did not exist on macOS.
My response and fixing to #1237 was temporary and wrong.
Therefore, I restored the original test to confirm that content-types can be set correctly on macOS.
