### PR TITLE
Upgrade Travis macOS builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,6 @@ matrix:
           else
             exit 1;
           fi
-        - sudo ln -s /usr/local/opt/coreutils/bin/gstdbuf /usr/local/bin/stdbuf
       script:
         - ./autogen.sh
         - PKG_CONFIG_PATH=/usr/local/opt/curl/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig ./configure CXXFLAGS='-std=c++03 -DS3FS_PTHREAD_ERRORCHECK=1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
             HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/homebrew-cask;
           fi
         - HOMEBREW_NO_AUTO_UPDATE=1 brew cask install osxfuse
-        - S3FS_BREW_PACKAGES='awscli cppcheck truncate';
+        - S3FS_BREW_PACKAGES='awscli cppcheck';
           for s3fs_brew_pkg in ${S3FS_BREW_PACKAGES}; do
             brew list | grep -q ${s3fs_brew_pkg};
             if [ $? -eq 0 ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
         - test/filter-suite-log.sh test/test-suite.log
 
     - os: osx
-      osx_image: xcode9.2
+      osx_image: xcode9.3
       cache:
         directories:
           - $HOME/Library/Caches/Homebrew


### PR DESCRIPTION
Addresses warnings of the form:

> Warning: You are using macOS 10.12.
>
> We (and Apple) do not provide support for this old version.
>
> You will encounter build failures with some formulae.