### PR TITLE
Improved strictness of cache file stats(file)

### DIFF
--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -118,7 +118,7 @@ class PageList
     bool IsModified(void) const;
     bool ClearAllModified(void);
 
-    bool Serialize(CacheFileStat& file, bool is_output);
+    bool Serialize(CacheFileStat& file, bool is_output, ino_t inode);
     void Dump(void);
 };
 
@@ -136,6 +136,7 @@ class FdEntity
     std::string     path;           // object path
     int             fd;             // file descriptor(tmp file or cache file)
     FILE*           pfile;          // file pointer(tmp file or cache file)
+    ino_t           inode;          // inode number for cache file
     headers_t       orgmeta;        // original headers at opening
     off_t           size_orgmeta;   // original file size in original headers
 
@@ -151,8 +152,10 @@ class FdEntity
 
   private:
     static int FillFile(int fd, unsigned char byte, off_t size, off_t start);
+    static ino_t GetInode(int fd);
 
     void Clear(void);
+    ino_t GetInode(void);
     int OpenMirrorFile(void);
     bool SetAllStatus(bool is_loaded);                          // [NOTE] not locking
     //bool SetAllStatusLoaded(void) { return SetAllStatus(true); }


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1271 

### Details
This PR code was modified to strictly manage the file(cache file stats) that holds the state of the s3fs cache file.

If the user has caching turned on, s3fs will load the cache file status(information on the range where the file contents are cached) from this file when opening it.
And if user edits the file, the cache will change and the cache file stats will change as well.
This cache file stats is written out when the file is closed(and flushed).
That is, the cache file stats(file) is loaded when user opens the file and writes when user closes it.

Access to the cache file stats(file) is exclusively controlled within the s3fs process.
Therefore, input/output to this file is performed simultaneously with the cache file with exclusive control.

However, s3fs must ensure that the cache file and its status file (cache file stats) are paired.
In this PR, it is modified to write the cache file's inode number to the cache file stats(file).
And the inode number is checked when loading this file.

When loading the cache file stats(file) output by s3fs before PR, the inode is not checked and the access to cache file is allowed.
However, when the cache status changes and the file(object) is closed, the cache file stats(file) is written out in the new format.
This maintains backward compatibility.
Be careful, an error will occur if the cache file stats(file) created by this PR code is loaded by old s3fs version.
In this case, that cache won't load, and s3fs will get the file(object) from S3 server.

Please note that multiple s3fs processes can not use the same cache directory at the same time.
The s3fs cache does not support multiple s3fs processes.
