### PR TITLE
Do not create page when writing to an existing one

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2482,6 +2482,11 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
             result = -ENOENT;
             break;
 
+          case 416:
+            S3FS_PRN_INFO3("HTTP response code 416 was returned, returning EIO");
+            result = -EIO;
+            break;
+
           case 501:
             S3FS_PRN_INFO3("HTTP response code 501 was returned, returning ENOTSUP");
             S3FS_PRN_DBG("Body Text: %s", bodydata.str());

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -360,7 +360,7 @@ bool PageList::Compress(bool force_modified)
 bool PageList::Parse(off_t new_pos)
 {
   for(fdpage_list_t::iterator iter = pages.begin(); iter != pages.end(); ++iter){
-    if(new_pos == iter->offset){
+    if(new_pos >= iter->offset && new_pos < iter->next() && iter->modified){
       // nothing to do
       return true;
     }else if(iter->offset < new_pos && new_pos < iter->next()){

--- a/test/write_multiple_offsets.py
+++ b/test/write_multiple_offsets.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+# TODO: parse argv so that test script can issue multiple (offset, size) pairs
+
 import os
 import sys
 
@@ -8,11 +10,10 @@ data = bytes('a', 'utf-8')
 
 fd = os.open(filename, os.O_CREAT | os.O_TRUNC | os.O_WRONLY)
 try:
-    os.pwrite(fd, data, 1024)
-    os.pwrite(fd, data, 16 * 1024 * 1024)
-    os.pwrite(fd, data, 18 * 1024 * 1024)
+    os.pwrite(fd, data, 20 * 1024 * 1024 + 1)
+    os.pwrite(fd, data, 10 * 1024 * 1024)
 finally:
     os.close(fd)
 
 stat = os.lstat(filename)
-assert stat.st_size == 18 * 1024 * 1024 + 1
+assert stat.st_size == 20 * 1024 * 1024 + 2


### PR DESCRIPTION
This works around issues with random writes and the mixupload
optimization where an unloaded range could be created.  Also do not
retry requests on HTTP 416 since this is not a transient error.
References #1220.