### PR TITLE
Warn about missing MIME types instead of exiting

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -650,7 +650,7 @@ bool S3fsCurl::InitMimeType(const std::string& strFile)
       }
     }
     if(MimeFile.empty()){
-      S3FS_PRN_ERR("Could not find miime.types files, you have to create file(%s) or specify mime option for existing mime.types file.", errPaths.c_str());
+      S3FS_PRN_WARN("Could not find mime.types files, you have to create file(%s) or specify mime option for existing mime.types file.", errPaths.c_str());
       return false;
     }
   }
@@ -684,7 +684,7 @@ bool S3fsCurl::InitMimeType(const std::string& strFile)
     }
     S3FS_PRN_INIT_INFO("Loaded mime information from %s", MimeFile.c_str());
   }else{
-    S3FS_PRN_ERR("Could not load mime types from %s, please check the existence and permissions of this file.", MimeFile.c_str());
+    S3FS_PRN_WARN("Could not load mime types from %s, please check the existence and permissions of this file.", MimeFile.c_str());
     return false;
   }
   return true;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -5241,10 +5241,7 @@ int main(int argc, char* argv[])
 
   // init mime types for curl
   if(!S3fsCurl::InitMimeType(mimetype_file)){
-    S3FS_PRN_EXIT("Could not load mime types for curl library.");
-    S3fsCurl::DestroyS3fsCurl();
-    s3fs_destroy_global_ssl();
-    exit(EXIT_FAILURE);
+    S3FS_PRN_WARN("Missing MIME types prevents setting Content-Type on uploaded objects.");
   }
 
   // [NOTE]


### PR DESCRIPTION
s3fs uses the MIME types file to set Content-Type for uploaded
objects.  Most distribution packages should install this via
recommended (not required) dependencies.  Users compiling from source
may not have this installed and s3fs should not prevent launching
since most users do not care about Content-Type.  Instead warn about
MIME types absence.  Fixes #1270.