### PR TITLE
Not abort process by exception threw from s3fs_strtoofft

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4536,7 +4536,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 1; // continue for fuse option
     }
     if(0 == STR2NCMP(arg, "umask=")){
-      s3fs_umask = s3fs_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 8);
+      s3fs_umask = cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 8);
       s3fs_umask &= (S_IRWXU | S_IRWXG | S_IRWXO);
       is_s3fs_umask = true;
       return 1; // continue for fuse option
@@ -4546,7 +4546,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 1; // continue for fuse option
     }
     if(0 == STR2NCMP(arg, "mp_umask=")){
-      mp_umask = s3fs_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 8);
+      mp_umask = cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 8);
       mp_umask &= (S_IRWXU | S_IRWXG | S_IRWXO);
       is_mp_umask = true;
       return 0;
@@ -4562,7 +4562,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 0;
     }
     if(0 == STR2NCMP(arg, "retries=")){
-      S3fsCurl::SetRetries(static_cast<int>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char))));
+      S3fsCurl::SetRetries(static_cast<int>(cvt_strtoofft(strchr(arg, '=') + sizeof(char))));
       return 0;
     }
     if(0 == STR2NCMP(arg, "use_cache=")){
@@ -4578,7 +4578,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 0;
     }
     if(0 == STR2NCMP(arg, "multireq_max=")){
-      int maxreq = static_cast<int>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char)));
+      int maxreq = static_cast<int>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
       S3fsCurl::SetMaxMultiRequest(maxreq);
       return 0;
     }
@@ -4595,7 +4595,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       off_t rrs = 1;
       // for an old format.
       if(0 == STR2NCMP(arg, "use_rrs=")){
-        rrs = s3fs_strtoofft(strchr(arg, '=') + sizeof(char));
+        rrs = cvt_strtoofft(strchr(arg, '=') + sizeof(char));
       }
       if(0 == rrs){
         S3fsCurl::SetStorageClass(STANDARD);
@@ -4735,7 +4735,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 0;
     }
     if(0 == STR2NCMP(arg, "ssl_verify_hostname=")){
-      long sslvh = static_cast<long>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char)));
+      long sslvh = static_cast<long>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
       if(-1 == S3fsCurl::SetSslVerifyHostname(sslvh)){
         S3FS_PRN_EXIT("poorly formed argument to option: ssl_verify_hostname.");
         return -1;
@@ -4804,7 +4804,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 0;
     }
     if(0 == STR2NCMP(arg, "public_bucket=")){
-      off_t pubbucket = s3fs_strtoofft(strchr(arg, '=') + sizeof(char));
+      off_t pubbucket = cvt_strtoofft(strchr(arg, '=') + sizeof(char));
       if(1 == pubbucket){
         S3fsCurl::SetPublicBucket(true);
         // [NOTE]
@@ -4832,17 +4832,17 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
         return 0;
     }
     if(0 == STR2NCMP(arg, "connect_timeout=")){
-      long contimeout = static_cast<long>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char)));
+      long contimeout = static_cast<long>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
       S3fsCurl::SetConnectTimeout(contimeout);
       return 0;
     }
     if(0 == STR2NCMP(arg, "readwrite_timeout=")){
-      time_t rwtimeout = static_cast<time_t>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char)));
+      time_t rwtimeout = static_cast<time_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
       S3fsCurl::SetReadwriteTimeout(rwtimeout);
       return 0;
     }
     if(0 == STR2NCMP(arg, "list_object_max_keys=")){
-      int max_keys = static_cast<int>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char)));
+      int max_keys = static_cast<int>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
       if(max_keys < 1000){
         S3FS_PRN_EXIT("argument should be over 1000: list_object_max_keys");
         return -1;
@@ -4851,19 +4851,19 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 0;
     }
     if(0 == STR2NCMP(arg, "max_stat_cache_size=")){
-      unsigned long cache_size = static_cast<unsigned long>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char)));
+      unsigned long cache_size = static_cast<unsigned long>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
       StatCache::getStatCacheData()->SetCacheSize(cache_size);
       return 0;
     }
     if(0 == STR2NCMP(arg, "stat_cache_expire=")){
-      time_t expr_time = static_cast<time_t>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char)));
+      time_t expr_time = static_cast<time_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
       StatCache::getStatCacheData()->SetExpireTime(expr_time);
       return 0;
     }
     // [NOTE]
     // This option is for compatibility old version.
     if(0 == STR2NCMP(arg, "stat_cache_interval_expire=")){
-      time_t expr_time = static_cast<time_t>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char)));
+      time_t expr_time = static_cast<time_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
       StatCache::getStatCacheData()->SetExpireTime(expr_time, true);
       return 0;
     }
@@ -4880,7 +4880,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 0;
     }
     if(0 == STR2NCMP(arg, "parallel_count=") || 0 == STR2NCMP(arg, "parallel_upload=")){
-      int maxpara = static_cast<int>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char)));
+      int maxpara = static_cast<int>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
       if(0 >= maxpara){
         S3FS_PRN_EXIT("argument should be over 1: parallel_count");
         return -1;
@@ -4893,7 +4893,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 0;
     }
     if(0 == STR2NCMP(arg, "multipart_size=")){
-      off_t size = static_cast<off_t>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char)));
+      off_t size = static_cast<off_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
       if(!S3fsCurl::SetMultipartSize(size)){
         S3FS_PRN_EXIT("multipart_size option must be at least 5 MB.");
         return -1;
@@ -4901,7 +4901,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 0;
     }
     if(0 == STR2NCMP(arg, "ensure_diskfree=")){
-      off_t dfsize = s3fs_strtoofft(strchr(arg, '=') + sizeof(char)) * 1024 * 1024;
+      off_t dfsize = cvt_strtoofft(strchr(arg, '=') + sizeof(char)) * 1024 * 1024;
       if(dfsize < S3fsCurl::GetMultipartSize()){
         S3FS_PRN_WARN("specified size to ensure disk free space is smaller than multipart size, so set multipart size to it.");
         dfsize = S3fsCurl::GetMultipartSize();
@@ -4910,7 +4910,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
       return 0;
     }
     if(0 == STR2NCMP(arg, "singlepart_copy_limit=")){
-      singlepart_copy_limit = static_cast<int64_t>(s3fs_strtoofft(strchr(arg, '=') + sizeof(char))) * 1024;
+      singlepart_copy_limit = static_cast<int64_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char))) * 1024;
       return 0;
     }
     if(0 == STR2NCMP(arg, "ahbe_conf=")){

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -794,7 +794,7 @@ time_t get_mtime(const char *str)
       strmtime = strmtime.substr(0, pos);
     }
   }
-  return static_cast<time_t>(s3fs_strtoofft(strmtime.c_str()));
+  return static_cast<time_t>(cvt_strtoofft(strmtime.c_str()));
 }
 
 static time_t get_time(headers_t& meta, bool overcheck, const char *header)
@@ -821,7 +821,7 @@ time_t get_ctime(headers_t& meta, bool overcheck)
 
 off_t get_size(const char *s)
 {
-  return s3fs_strtoofft(s);
+  return cvt_strtoofft(s);
 }
 
 off_t get_size(headers_t& meta)
@@ -835,7 +835,7 @@ off_t get_size(headers_t& meta)
 
 mode_t get_mode(const char *s)
 {
-  return static_cast<mode_t>(s3fs_strtoofft(s));
+  return static_cast<mode_t>(cvt_strtoofft(s));
 }
 
 mode_t get_mode(headers_t& meta, const char* path, bool checkdir, bool forcedir)
@@ -917,7 +917,7 @@ mode_t get_mode(headers_t& meta, const char* path, bool checkdir, bool forcedir)
 
 uid_t get_uid(const char *s)
 {
-  return static_cast<uid_t>(s3fs_strtoofft(s));
+  return static_cast<uid_t>(cvt_strtoofft(s));
 }
 
 uid_t get_uid(headers_t& meta)
@@ -934,7 +934,7 @@ uid_t get_uid(headers_t& meta)
 
 gid_t get_gid(const char *s)
 {
-  return static_cast<gid_t>(s3fs_strtoofft(s));
+  return static_cast<gid_t>(cvt_strtoofft(s));
 }
 
 gid_t get_gid(headers_t& meta)

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -68,6 +68,41 @@ off_t s3fs_strtoofft(const char* str, int base)
   return result;
 }
 
+// wrapped s3fs_strtoofft()
+//
+// This function catches the s3fs_strtoofft () exception and returns a boolean value.
+//
+bool try_strtoofft(const char* str, off_t& value, int base)
+{
+  if(str){
+    try{
+      value = s3fs_strtoofft(str, base);
+    }catch(std::exception &e){
+      S3FS_PRN_WARN("something error is occurred in convert string(%s) to off_t.", str);
+      return false;
+    }
+  }else{
+    S3FS_PRN_WARN("parameter string is null.");
+    return false;
+  }
+  return true;
+}
+
+// wrapped try_strtoofft -> s3fs_strtoofft()
+//
+// This function returns 0 if a value that cannot be converted is specified.
+// Only call if 0 is considered an error and the operation can continue.
+//
+off_t cvt_strtoofft(const char* str, int base)
+{
+  off_t result = 0;
+  if(!try_strtoofft(str, result, base)){
+    S3FS_PRN_WARN("something error is occurred in convert string(%s) to off_t, thus return 0 as default.", (str ? str : "null"));
+    return 0;
+  }
+  return result;
+}
+
 string lower(string s)
 {
   // change each character of the string to lower case

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -37,6 +37,8 @@ template <class T> std::string str(T value);
 
 // Convert string to off_t.  Throws std::invalid_argument and std::out_of_range on bad input.
 off_t s3fs_strtoofft(const char* str, int base = 0);
+bool try_strtoofft(const char* str, off_t& value, int base = 0);
+off_t cvt_strtoofft(const char* str, int base = 0);
 
 std::string trim_left(const std::string &s, const std::string &t = SPACES);
 std::string trim_right(const std::string &s, const std::string &t = SPACES);

--- a/src/test_string_util.cpp
+++ b/src/test_string_util.cpp
@@ -20,10 +20,20 @@
 
 #include <limits>
 #include <stdint.h>
+#include <strings.h>
 #include <string>
+#include <map>
 
+#include "common.h"
 #include "string_util.h"
 #include "test_util.h"
+
+//-------------------------------------------------------------------
+// Global variables for test_string_util
+//-------------------------------------------------------------------
+bool foreground                   = false;
+s3fs_log_level debug_level        = S3FS_LOG_CRIT;
+std::string instance_name;
 
 void test_trim()
 {


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1256 #1191

### Details
Although the s3fs_strtoofft() function throws an exception, the process may abort because s3fs does not catch this exception.(ex. #1256 #1191 )
I prepared a wrap function that catches the exception and returns the result or the value(=default value 0).
The part that called each s3fs_strtoofft function is replaced with these wrap functions.
_The s3fs-fuse option analysis function may be left as it is. But it has been modified according to this change._

This fix also helps prevent unexpected aborts in exceptions, but rather to ease debugging difficulties when aborted.
