### PR TITLE
Remove references to Amazon S3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 #
-# s3fs - FUSE-based file system backed by Amazon S3
+# s3fs - FUSE-based file system backed by S3
 #
 # Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
 #

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# s3fs - FUSE-based file system backed by Amazon S3
+# s3fs - FUSE-based file system backed by S3
 #
 # Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #
-# s3fs - FUSE-based file system backed by Amazon S3
+# s3fs - FUSE-based file system backed by S3
 #
 # Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
 #

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 ######################################################################
-# s3fs - FUSE-based file system backed by Amazon S3
+# s3fs - FUSE-based file system backed by S3
 #
 # Copyright 2007-2008 Randy Rizun <rrizun@gmail.com>
 #

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 ######################################################################
-# s3fs - FUSE-based file system backed by Amazon S3
+# s3fs - FUSE-based file system backed by S3
 #
 # Copyright 2007-2008 Randy Rizun <rrizun@gmail.com>
 #

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,5 +1,5 @@
 ######################################################################
-# s3fs - FUSE-based file system backed by Amazon S3
+# s3fs - FUSE-based file system backed by S3
 #
 # Copyright 2007-2008 Randy Rizun <rrizun@gmail.com>
 #

--- a/doc/man/s3fs.1
+++ b/doc/man/s3fs.1
@@ -1,6 +1,6 @@
 .TH S3FS "1" "February 2011" "S3FS" "User Commands"
 .SH NAME
-S3FS \- FUSE-based file system backed by Amazon S3
+S3FS \- FUSE-based file system backed by S3
 .SH SYNOPSIS
 .SS mounting
 .TP
@@ -20,7 +20,7 @@ For unprivileged user.
 .TP
 \fBs3fs --incomplete-mpu-abort[=all | =<expire date format>] bucket
 .SH DESCRIPTION
-s3fs is a FUSE filesystem that allows you to mount an Amazon S3 bucket as a local filesystem. It stores files natively and transparently in S3 (i.e., you can use other programs to access the same files).
+s3fs is a FUSE filesystem that allows you to mount an S3 bucket as a local filesystem. It stores files natively and transparently in S3 (i.e., you can use other programs to access the same files).
 .SH AUTHENTICATION
 s3fs supports the standard AWS credentials file (https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html) stored in `${HOME}/.aws/credentials`.
 Alternatively, s3fs supports a custom passwd file. Only AWS credentials file format can be used when AWS session token is required.
@@ -86,13 +86,13 @@ this option replaces the old option use_rrs.
 Possible values: standard, standard_ia, onezone_ia, reduced_redundancy, and intelligent_tiering.
 .TP
 \fB\-o\fR use_rrs (default is disable)
-use Amazon's Reduced Redundancy Storage.
+use Reduced Redundancy Storage.
 this option can not be specified with use_sse.
 (can specify use_rrs=1 for old version)
 this option has been replaced by new storage_class option.
 .TP
 \fB\-o\fR use_sse (default is disable)
-Specify three type Amazon's Server-Site Encryption: SSE-S3, SSE-C or SSE-KMS. SSE-S3 uses Amazon S3-managed encryption keys, SSE-C uses customer-provided encryption keys, and SSE-KMS uses the master key which you manage in AWS KMS.
+Specify three types of Server-Side Encryption: SSE-S3, SSE-C or SSE-KMS. SSE-S3 uses S3-managed encryption keys, SSE-C uses customer-provided encryption keys, and SSE-KMS uses the master key which you manage in AWS KMS.
 You can specify "use_sse" or "use_sse=1" enables SSE-S3 type (use_sse=1 is old type parameter).
 Case of setting SSE-C, you can specify "use_sse=custom", "use_sse=custom:<custom key file path>" or "use_sse=<custom key file path>" (only <custom key file path> specified is old type parameter).
 You can use "c" for short "custom".
@@ -212,7 +212,7 @@ Set a non-Amazon host, e.g., https://example.com.
 Set a service path when the non-Amazon host requires a prefix.
 .TP
 \fB\-o\fR url (default="https://s3.amazonaws.com")
-sets the url to use to access Amazon S3. If you want to use HTTP, then you can set "url=http://s3.amazonaws.com".
+sets the url to use to access S3. If you want to use HTTP, then you can set "url=http://s3.amazonaws.com".
 If you do not use https, please specify the URL with the url option.
 .TP
 \fB\-o\fR endpoint (default="us-east-1")
@@ -356,7 +356,7 @@ Most of the generic mount options described in 'man mount' are supported (ro, rw
 There are many FUSE specific mount options that can be specified. e.g. allow_other. See the FUSE README for the full set.
 .SH NOTES
 .TP
-The maximum size of objects that s3fs can handle depends on Amazon S3. For example, up to 5 GB when using single PUT API. And up to 5 TB is supported when Multipart Upload API is used.
+The maximum size of objects that s3fs can handle depends on the S3 implementation. For example, up to 5 GB when using single PUT API. And up to 5 TB is supported when Multipart Upload API is used.
 .TP
 If enabled via the "use_cache" option, s3fs automatically maintains a local cache of files in the folder specified by use_cache. Whenever s3fs needs to read or write a file on S3, it first downloads the entire file locally to the folder specified by use_cache and operates on it. When fuse_release() is called, s3fs will re-upload the file to S3 if it has been changed. s3fs uses MD5 checksums to minimize downloads from S3.
 .TP

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 ######################################################################
-# s3fs - FUSE-based file system backed by Amazon S3
+# s3fs - FUSE-based file system backed by S3
 #
 # Copyright 2007-2008 Randy Rizun <rrizun@gmail.com>
 #

--- a/src/addhead.cpp
+++ b/src/addhead.cpp
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/addhead.h
+++ b/src/addhead.h
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/cache.h
+++ b/src/cache.h
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/common.h
+++ b/src/common.h
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/common_auth.cpp
+++ b/src/common_auth.cpp
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *
@@ -2655,7 +2655,7 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
 }
 
 //
-// Returns the Amazon AWS signature for the given parameters.
+// Returns the AWS signature for the given parameters.
 //
 // @param method e.g., "GET"
 // @param content_type e.g., "application/x-directory"

--- a/src/curl.h
+++ b/src/curl.h
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Takeshi Nakatani <ggtakec.com>
  *

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/gnutls_auth.cpp
+++ b/src/gnutls_auth.cpp
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/nss_auth.cpp
+++ b/src/nss_auth.cpp
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/openssl_auth.cpp
+++ b/src/openssl_auth.cpp
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/psemaphore.h
+++ b/src/psemaphore.h
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/s3fs.h
+++ b/src/s3fs.h
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/s3fs_auth.h
+++ b/src/s3fs_auth.h
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Takeshi Nakatani <ggtakec.com>
  *
@@ -1099,7 +1099,7 @@ void show_help ()
   show_usage();
   printf(
     "\n"
-    "Mount an Amazon S3 bucket as a file system.\n"
+    "Mount an S3 bucket as a file system.\n"
     "\n"
     "Usage:\n"
     "   mounting\n"
@@ -1152,14 +1152,14 @@ void show_help ()
     "        standard, standard_ia, onezone_ia, reduced_redundancy and intelligent_tiering.\n"
     "\n"
     "   use_rrs (default is disable)\n"
-    "      - use Amazon's Reduced Redundancy Storage.\n"
+    "      - use Reduced Redundancy Storage.\n"
     "        this option can not be specified with use_sse.\n"
     "        (can specify use_rrs=1 for old version)\n"
     "        this option has been replaced by new storage_class option.\n"
     "\n"
     "   use_sse (default is disable)\n"
-    "      - Specify three type Amazon's Server-Site Encryption: SSE-S3,\n"
-    "        SSE-C or SSE-KMS. SSE-S3 uses Amazon S3-managed encryption\n"
+    "      - Specify three types of Server-Side Encryption: SSE-S3,\n"
+    "        SSE-C or SSE-KMS. SSE-S3 uses S3-managed encryption\n"
     "        keys, SSE-C uses customer-provided encryption keys, and\n"
     "        SSE-KMS uses the master key which you manage in AWS KMS.\n"
     "        You can specify \"use_sse\" or \"use_sse=1\" enables SSE-S3\n"
@@ -1543,7 +1543,7 @@ void show_help ()
 void show_version()
 {
   printf(
-  "Amazon Simple Storage Service File System V%s (commit:%s) with %s\n"
+  "s3fs V%s (commit:%s) with %s\n"
   "Copyright (C) 2010 Randy Rizun <rrizun@gmail.com>\n"
   "License GPL2: GNU GPL version 2 <https://gnu.org/licenses/gpl.html>\n"
   "This is free software: you are free to change and redistribute it.\n"

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
  *

--- a/src/test_string_util.cpp
+++ b/src/test_string_util.cpp
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2014 Andrew Gaul <andrew@gaul.org>
  *

--- a/src/test_util.h
+++ b/src/test_util.h
@@ -1,5 +1,5 @@
 /*
- * s3fs - FUSE-based file system backed by Amazon S3
+ * s3fs - FUSE-based file system backed by S3
  *
  * Copyright(C) 2014 Andrew Gaul <andrew@gaul.org>
  *

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,5 @@
 ######################################################################
-# s3fs - FUSE-based file system backed by Amazon S3
+# s3fs - FUSE-based file system backed by S3
 #
 # Copyright 2007-2008 Randy Rizun <rrizun@gmail.com>
 #

--- a/test/filter-suite-log.sh
+++ b/test/filter-suite-log.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# s3fs - FUSE-based file system backed by Amazon S3
+# s3fs - FUSE-based file system backed by S3
 #
 # Copyright 2007-2008 Randy Rizun <rrizun@gmail.com>
 #

--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -4,14 +4,14 @@
 # Common code for starting an s3fs-fuse mountpoint and an S3Proxy instance 
 # to run tests against S3Proxy locally.
 #
-# To run against an Amazon S3 or other S3 provider, specify the following 
+# To run against a hosted S3 provider, specify the following
 # environment variables:
 #
 # S3FS_CREDENTIALS_FILE=keyfile      s3fs format key file
 # S3FS_PROFILE=name                  s3fs profile to use (overrides key file)
 # TEST_BUCKET_1=bucketname           Name of bucket to use 
 # S3PROXY_BINARY=""                  Specify empty string to skip S3Proxy start
-# S3_URL="https://s3.amazonaws.com"  Specify Amazon AWS as the S3 provider
+# S3_URL="https://s3.amazonaws.com"  Specify the S3 provider
 #
 # Example of running against Amazon S3 using a bucket named "bucket:
 #


### PR DESCRIPTION
s3fs works with a variety of S3 implementations and it should avoid
specifying Amazon S3 when not necessary.  Fixes #1298