### PR TITLE
Ignore case when comparing ETags

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -127,7 +127,7 @@ static string get_bucket_host()
   return url_to_host(host);
 }
 
-// compare ETag ignoring quotes
+// compare ETag ignoring quotes and case
 static bool etag_equals(std::string s1, std::string s2) {
   if(s1.length() > 1 && s1[0] == '\"' && s1[s1.length() - 1] == '\"'){
 	s1 = s1.substr(1, s1.size() - 2);
@@ -135,7 +135,7 @@ static bool etag_equals(std::string s1, std::string s2) {
   if(s2.length() > 1 && s2[0] == '\"' && s2[s2.length() - 1] == '\"'){
 	s2 = s2.substr(1, s2.size() - 2);
   }
-  return s1 == s2;
+  return 0 == strcasecmp(s1.c_str(), s2.c_str());
 }
 
 #if 0 // noused


### PR DESCRIPTION
This allows multipart upload to work with Alibaba OSS.
References #1297.