### PR TITLE
Retry with exponential backoff during 500 error

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2570,8 +2570,9 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
             result = -ENOTSUP;
             break;
 
+          case 500:
           case 503:
-            S3FS_PRN_INFO3("HTTP response code 503 was returned, slowing down");
+            S3FS_PRN_INFO3("HTTP response code %ld was returned, slowing down", responseCode);
             S3FS_PRN_DBG("Body Text: %s", bodydata.str());
             sleep(4 << retry_count);
             break;


### PR DESCRIPTION
Amazon suggests retrying on both 500 and 503:

https://aws.amazon.com/premiumsupport/knowledge-center/http-5xx-errors-s3/

Fixes #1251.