### PR TITLE
Fixed a bug about serializing from cache file

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -908,8 +908,8 @@ bool PageList::Serialize(CacheFileStat& file, bool is_output, ino_t inode)
         cache_inode = 0;
       }else{
         // current head format is "<inode>:<size>\n"
-        total       = cvt_strtoofft(strhead1.c_str(), /* base= */10);
-        cache_inode = static_cast<ino_t>(cvt_strtoofft(strhead2.c_str(), /* base= */10));
+        total       = cvt_strtoofft(strhead2.c_str(), /* base= */10);
+        cache_inode = static_cast<ino_t>(cvt_strtoofft(strhead1.c_str(), /* base= */10));
         if(0 == cache_inode){
           S3FS_PRN_ERR("wrong inode number in parsed cache stats.");
           delete[] ptmp;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1274 

### Details
There was a problem in the part that serialized from the stats information file of the cache file changed in PR of #1274.
It seems that the cache file was not functioning effectively from #1274 onwards to this PR.
This bug has been fixed by this PR.

In addition, I'm preparing the code corresponding to #1291, and it is planed to provide a function that can check the consistency of the cache file with that code.
