### PR TITLE
Fixed about ParallelMixMultipartUpload

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -186,7 +186,8 @@ private:
 //----------------------------------------------
 // class S3fsCurl
 //----------------------------------------------
-class PageList;
+#include "fdcache.h"    // for fdpage_list_t
+
 class S3fsCurl;
 
 // Prototype function for lazy setup options for curl handle
@@ -415,7 +416,7 @@ class S3fsCurl
     static bool InitMimeType(const std::string& strFile);
     static bool DestroyS3fsCurl(void);
     static int ParallelMultipartUploadRequest(const char* tpath, headers_t& meta, int fd);
-    static int ParallelMixMultipartUploadRequest(const char* tpath, headers_t& meta, int fd, const PageList& pagelist);
+    static int ParallelMixMultipartUploadRequest(const char* tpath, headers_t& meta, int fd, const fdpage_list_t& mixuppages);
     static int ParallelGetObjectRequest(const char* tpath, int fd, off_t start, ssize_t size);
     static bool CheckIAMCredentialUpdate(void);
 

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -21,7 +21,6 @@
 #define FD_CACHE_H_
 
 #include <sys/statvfs.h>
-#include "curl.h"
 
 //------------------------------------------------
 // CacheFileStat
@@ -92,9 +91,8 @@ class PageList
 
   private:
     void Clear(void);
-    bool Compress(bool force_modified = false);
+    bool Compress();
     bool Parse(off_t new_pos);
-    bool RawGetUnloadPageList(fdpage_list_t& dlpages, off_t offset, off_t size);
 
   public:
     static void FreeList(fdpage_list_t& list);
@@ -112,14 +110,13 @@ class PageList
     bool FindUnloadedPage(off_t start, off_t& resstart, off_t& ressize) const;
     off_t GetTotalUnloadedPageSize(off_t start = 0, off_t size = 0) const;    // size=0 is checking to end of list
     int GetUnloadedPages(fdpage_list_t& unloaded_list, off_t start = 0, off_t size = 0) const;  // size=0 is checking to end of list
-    bool GetLoadPageListForMultipartUpload(fdpage_list_t& dlpages);
-    bool GetMultipartSizeList(fdpage_list_t& mplist, off_t partsize) const;
+    bool GetPageListsForMultipartUpload(fdpage_list_t& dlpages, fdpage_list_t& mixuppages, off_t max_partsize);
 
     bool IsModified(void) const;
     bool ClearAllModified(void);
 
     bool Serialize(CacheFileStat& file, bool is_output, ino_t inode);
-    void Dump(void);
+    void Dump(void) const;
 };
 
 //------------------------------------------------

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -846,6 +846,34 @@ function test_cache_file_stat() {
     rm_test_file "${BIG_FILE}"
 }
 
+function test_mix_upload_entities() {
+    #
+    # Make test file
+    #
+    dd if=/dev/urandom of=${BIG_FILE} bs=$BIG_FILE_LENGTH count=1
+
+    #
+    # If the cache option is enabled, delete the cache of uploaded files.
+    #
+    if [ -f ${CACHE_DIR}/${TEST_BUCKET_1}/${BIG_FILE} ]; then
+        rm -f ${CACHE_DIR}/${TEST_BUCKET_1}/${BIG_FILE}
+    fi
+    if [ -f ${CACHE_DIR}/.${TEST_BUCKET_1}.stat/${BIG_FILE} ]; then
+        rm -f ${CACHE_DIR}/.${TEST_BUCKET_1}.stat/${BIG_FILE}
+    fi
+
+    #
+    # Do a partial write to the file.
+    #
+    echo -n "0123456789ABCDEF" | dd of=${BIG_FILE} bs=1 count=16 seek=0 conv=notrunc
+    echo -n "0123456789ABCDEF" | dd of=${BIG_FILE} bs=1 count=16 seek=8192 conv=notrunc
+    echo -n "0123456789ABCDEF" | dd of=${BIG_FILE} bs=1 count=16 seek=1073152 conv=notrunc
+    echo -n "0123456789ABCDEF" | dd of=${BIG_FILE} bs=1 count=16 seek=26214400 conv=notrunc
+    echo -n "0123456789ABCDEF" | dd of=${BIG_FILE} bs=1 count=16 seek=26222592 conv=notrunc
+
+    rm_test_file "${BIG_FILE}"
+}
+
 function test_ut_ossfs {
     echo "Testing ossfs python ut..."
     export TEST_BUCKET_MOUNT_POINT=$TEST_BUCKET_MOUNT_POINT_1
@@ -890,6 +918,7 @@ function add_all_tests {
     add_tests test_write_multiple_offsets_backwards
     add_tests test_content_type
     add_tests test_truncate_cache
+    add_tests test_mix_upload_entities
     add_tests test_ut_ossfs
     if `ps -ef | grep -v grep | grep s3fs | grep -q use_cache`; then
         add_tests test_cache_file_stat


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a(or some issues) 

## Details
The following bugs were found in the processing of mixed multipart upload.

### Details of the bug
For example, there is a 500MB file and it doesn't exist in the s3fs cache file yet.
In this case, if user perform the following operations on the target file, the result will be different for each.

- Write a few bytes from the 400th MB and close the file.  
This is working correctly.
- Write from the 0th byte to within 5MB.  
It fails with a 400 HTTP error(EIO).
- Write data from 495MB to the end of the file.  
It fails with a 400 HTTP error(EIO).  
It also unnecessarily downloads before uploading, which reduces performance.

These fatal errors are `EntityTooSmall`.

### Cause
In the processing of mixed multipart upload, there was a mistake in the calculation of the range of Copy and Upload.  
It may be possible to complete normally, but it will fail depending on the write position without the cache file.

### Fixes
Made following fixes.

#### Download and upload range processing
In case of mixed multi-part upload, the insufficient area is downloaded in advance by s3fs because of the minimum upload range.  
For this reason, it is necessary to calculate the areas of Copy and Uoload.  
But there were some bugs in this logic.  
For fixing, the following functions that performed these processes were changed/deleted.  

- PageList::GetPageListForMultipartUpload  
It was rewritten significantly.  
And the function name(PageList::GetPageListsForMultipartUpload) and arguments have also been changed.
- PageList::RawGetUnloadPageList  
It has been absorbed in PageList::GetPageListsForMultipartUpload, is no longer needed, and has been removed.
- PageList::GetMultipartSizeList  
It has been absorbed in PageList::GetPageListsForMultipartUpload, is no longer needed, and has been removed.
- PageList::Compress  
It has been modified to prepare local functions to operate on fdcache_list_t and only call it.
- S3fsCurl::ParallelMixMultipartUploadRequest  
This has changed with the changes to GetPageListsForMultipartUpload.
- FdEntity::RowFlush  
Changes such as calling ParallelMixMultipartUploadRequest

#### Others
- Changed PageList::Dump to const.
- Cleaned up #include due to file dependency.

### Impact
In mixed multipart upload, EIO(HTTP response code=400) problem may be the same cause as this PR.  
Also, there are times when performance is poor, which may also be affecting it.(Performance gets worse because it downloads a range that does not need to be downloaded due to a bug.)
