### PR TITLE
Interim fix for Travis macOS Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@
 #
 
 language: cpp
+dist: xenial
+os: linux
 
-matrix:
+jobs:
   include:
     - os: linux
       dist: trusty
@@ -29,7 +31,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install -qq attr cppcheck libfuse-dev openjdk-7-jdk
         - sudo update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
-        - sudo pip install --upgrade awscli
+        - sudo -H pip install --upgrade awscli
       script:
         - ./autogen.sh
         - ./configure CPPFLAGS='-I/usr/local/opt/openssl/include' CXXFLAGS='-std=c++03 -DS3FS_PTHREAD_ERRORCHECK=1'
@@ -57,20 +59,40 @@ matrix:
             rm -rf "$TAPS/caskroom/homebrew-cask";
           fi;
           if [ ! -f $HOME/.osx_cache/cached ]; then
-            brew tap homebrew/homebrew-cask;
+            echo "==> [Not found cache] brew tap homebrew/homebrew-cask";
+            echo "[NOTE]";
+            echo "If brew is executed without HOMEBREW_NO_AUTO_UPDATE=1,";
+            echo "python3 cannot be installed, so this is added as a temporary workaround.";
+            echo "If it is xcode 9.4 or higher, clear this patch.";
+            HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/homebrew-cask;
           else
+            echo "==> [Found cache] HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/homebrew-cask";
             HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/homebrew-cask;
           fi
         - HOMEBREW_NO_AUTO_UPDATE=1 brew cask install osxfuse
-        - S3FS_BREW_PACKAGES='awscli cppcheck truncate';
+        - S3FS_BREW_PACKAGES='cppcheck python3';
           for s3fs_brew_pkg in ${S3FS_BREW_PACKAGES}; do
             brew list | grep -q ${s3fs_brew_pkg};
             if [ $? -eq 0 ]; then
-              brew outdated | grep -q ${s3fs_brew_pkg} && HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade ${s3fs_brew_pkg};
+              brew outdated | grep -q ${s3fs_brew_pkg};
+              if [ $? -eq 0 ]; then
+                echo "==> Try to upgrade ${s3fs_brew_pkg}";
+                HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade ${s3fs_brew_pkg};
+              fi
             else
+              echo "==> Try to install ${s3fs_brew_pkg}";
               HOMEBREW_NO_AUTO_UPDATE=1 brew install ${s3fs_brew_pkg};
             fi;
           done
+        - pip3 --version;
+          if [ $? -eq 0 ]; then
+            echo "==> Try to install awscli by pip3";
+            sudo -H pip3 install awscli;
+          else
+            echo "==> Try to install awscli by pip";
+            curl https://bootstrap.pypa.io/get-pip.py | sudo python;
+            sudo -H pip install awscli --ignore-installed matplotlib;
+          fi
         - if [ -f /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ]; then
             sudo chmod +s /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs;
           elif [ -f /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ]; then
@@ -78,7 +100,14 @@ matrix:
           else
             exit 1;
           fi
-        - sudo ln -s /usr/local/opt/coreutils/bin/gstdbuf /usr/local/bin/stdbuf
+        - if [ ! -f /usr/local/bin/truncate ]; then
+            echo "==> Make symbolic link truncate to gtruncate";
+            sudo ln -s /usr/local/opt/coreutils/bin/gtruncate /usr/local/bin/truncate;
+          fi
+        - if [ ! -f /usr/local/bin/stdbuf ]; then
+            echo "==> Make symbolic link stdbuf to gstdbuf";
+            sudo ln -s /usr/local/opt/coreutils/bin/gstdbuf /usr/local/bin/stdbuf;
+          fi
       script:
         - ./autogen.sh
         - PKG_CONFIG_PATH=/usr/local/opt/curl/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig ./configure CXXFLAGS='-std=c++03 -DS3FS_PTHREAD_ERRORCHECK=1'
@@ -103,7 +132,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install -qq attr cppcheck libfuse-dev openjdk-7-jdk
         - sudo update-alternatives --set java /usr/lib/jvm/java-7-openjdk-ppc64el/jre/bin/java
-        - sudo pip install --upgrade awscli
+        - sudo -H pip install --upgrade awscli
       script:
         - ./autogen.sh
         - ./configure CPPFLAGS='-I/usr/local/opt/openssl/include' CXXFLAGS='-std=c++03 -DS3FS_PTHREAD_ERRORCHECK=1'

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -924,7 +924,7 @@ function test_mix_upload_entities() {
 }
 
 function test_ut_ossfs {
-    echo "Testing ossfs python ut..."
+    describe "Testing ossfs python ut..."
     export TEST_BUCKET_MOUNT_POINT=$TEST_BUCKET_MOUNT_POINT_1
     ../../ut_test.py
 }


### PR DESCRIPTION
## Relevant Issue (if applicable)
#1268 

## Details
### Overview
Travis macOS Build uses Travis cache to reduce build time.  
And I confirmed that the Travis macOS build was successful because the cache exists, but it failed when the cache was deleted.  
And I also found other issues, this PR is an interim fix for those.  

### Background about macOS build on Travis-CI
The build of macOS uses macOS 10.12 which is the image of Travis CI(xcode9.2).  
The reason for using this image is that it's a version that doesn't require an OS reboot after installing osxfuse.  
OS images of 10.13 or later require reboot, and we cannot be built and tested s3fs.  
So we need to continue to use 10.12.  

And Homebrew is not currently offering this version of the binary package as Apple has dropped 10.12 support.  
However, Homebrew offers build and install from source code instead of binary packages.  

### About changes
#### (1) If call brew tap without HOMEBREW_NO_AUTO_UPDATE=1, python3 cannot be installed
The failure reason is because Homebrew tries to install sqlite which is a python3 dependency, and fails.  
Currently, Travis macOS image (xcode9.2) fails to download the source package from sqlite.org site due to `No route` or `Timeout`.  
_The site has A and AAAA IP addresses, but both are in error._  

When there is no cache on travis, `HOMEBREW_NO_AUTO_UPDATE=1` was not attached, but `HOMEBREW_NO_AUTO_UPDATE=1` was provisionally specified in new code.  
Thus we can install python3.  

#### (2) awscli cannot be installed via Homebrew
For 10.12, Homebrew doesn't seem to install aswcli.  
So I changed it to install using pip.  

#### (3) truncate package
s3fs travis build had installed Homebrew's truncate package, which has been replaced by gnu's gtruncate provided by the coreutils package.  
Therefore, we do not install truncate.  

#### (4) cppcheck compatible
If we install cppcheck after running brew tap without `HOMEBREW_NO_AUTO_UPDATE=1`, cppcheck 2.1 will be installed.  
I found some errors detected in this version, so I fixed it(in curl.cpp).  
_In this PR code, HOMEBREW_NO_AUTO_UPDATE=1 is set, so 1.81 of cppcheck will be installed. However, the correction is added as a preventive measure._

#### (5) Modification of travis.yml
Incorporated some debugging messages and comments into .travis.yml.  
Moreover, the part where the warning was detected by the validation of Travis (matrix->jobs etc.) was corrected.

#### (6) Modification of test code
If testing without python3, skip the `write_multiple` test cases.  
I also fixed an incorrect call in `test_ut_ossfs` case.   

### Note
When merging this PR, please **clear the cache of master** on Travis-CI before merging.