### PR TITLE
Use Python 2 for write_multiple_offsets

### DIFF
--- a/test/write_multiple_offsets.py
+++ b/test/write_multiple_offsets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 
 import os
 import sys
@@ -11,7 +11,8 @@ filename = sys.argv[1]
 fd = os.open(filename, os.O_CREAT | os.O_TRUNC | os.O_WRONLY)
 try:
     for i in range(2, len(sys.argv), 2):
-        data = bytes("a" * int(sys.argv[i+1]), 'utf-8')
-        os.pwrite(fd, data, int(sys.argv[i]))
+        data = "a" * int(sys.argv[i+1])
+        os.lseek(fd, int(sys.argv[i]), os.SEEK_SET)
+        os.write(fd, data)
 finally:
     os.close(fd)


### PR DESCRIPTION
This aligns with `ut_test.py`.  Using an older Python also allows
compatibility with the older macOS 10.12 Travis CI.  References #1323.