### PR TITLE
Moved the SIGUSR2 handler to S3fsSignals class

### DIFF
--- a/src/sighandlers.h
+++ b/src/sighandlers.h
@@ -41,6 +41,9 @@ class S3fsSignals
     static void HandlerUSR1(int sig);
     static void* CheckCacheWorker(void* arg);
 
+    static void HandlerUSR2(int sig);
+    static bool InitUsr2Handler(void);
+
     S3fsSignals();
     ~S3fsSignals();
 
@@ -53,6 +56,9 @@ class S3fsSignals
     static bool Destroy(void);
 
     static bool SetUsr1Handler(const char* path);
+
+    static s3fs_log_level SetLogLevel(s3fs_log_level level);
+    static s3fs_log_level BumpupLogLevel(void);
 };
 
 #endif // S3FS_SIGHANDLERS_H_


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1334 

### Details
Since a class summarizing the processing of the signal handlers has been added, the SIGUSR2 handler and its related processing have been moved to that class.
SIGUSR2 handler is set to bump up the debug log level.
Also, the debugging log level is set by a global variable(it is using a global variable because it is called from a macro in anywhere), but I also moved the operation function of this variable to that class.
Please note that the processing logic has not changed.

This will be a underplot as we will combine other signal handlers into S3fsSignals in the future.
