### PR TITLE
Move IBM information to Non Amazon S3 wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,6 @@ or(fstab)
 mybucket /path/to/mountpoint fuse.s3fs _netdev,allow_other,use_path_request_style,url=https://url.to.s3/ 0 0
 ```
 
-To use IBM IAM Authentication, use the `-o ibm_iam_auth` option, and specify the Service Instance ID and API Key in your credentials file:
-
-```
-echo SERVICEINSTANCEID:APIKEY > /path/to/passwd
-```
-
-The Service Instance ID is only required when using the `-o create_bucket` option.
-
 Note: You may also want to create the global credential file first
 
 ```


### PR DESCRIPTION
This gives consistency with other providers:

https://github.com/s3fs-fuse/s3fs-fuse/wiki/Non-Amazon-S3