### PR TITLE
Prefer %zd and %zu for ssize_t and size_t

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1666,7 +1666,7 @@ int S3fsCurl::ParallelMixMultipartUploadRequest(const char* tpath, headers_t& me
       s3fscurl_para->b_partdata_size     = s3fscurl_para->partdata.size;
       s3fscurl_para->partdata.add_etag_list(&list);
 
-      S3FS_PRN_INFO3("Upload Part [tpath=%s][start=%jd][size=%jd][part=%jd]", SAFESTRPTR(tpath), (intmax_t)(iter->offset), (intmax_t)(iter->bytes), (intmax_t)(list.size()));
+      S3FS_PRN_INFO3("Upload Part [tpath=%s][start=%zd][size=%zd][part=%zu]", SAFESTRPTR(tpath), iter->offset, iter->bytes, list.size());
 
       // initiate upload part for parallel
       if(0 != (result = s3fscurl_para->UploadMultipartPostSetup(tpath, list.size(), upload_id))){
@@ -1687,7 +1687,7 @@ int S3fsCurl::ParallelMixMultipartUploadRequest(const char* tpath, headers_t& me
       s3fscurl_para->b_meta   = meta;
       s3fscurl_para->partdata.add_etag_list(&list);
 
-      S3FS_PRN_INFO3("Copy Part [tpath=%s][start=%jd][size=%jd][part=%jd]", SAFESTRPTR(tpath), (intmax_t)(iter->offset), (intmax_t)(iter->bytes), (intmax_t)(list.size()));
+      S3FS_PRN_INFO3("Copy Part [tpath=%s][start=%zd][size=%zd][part=%zu]", SAFESTRPTR(tpath), iter->offset, iter->bytes, list.size());
 
       // initiate upload part for parallel
       if(0 != (result = s3fscurl_para->CopyMultipartPostSetup(tpath, tpath, list.size(), upload_id, meta))){

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -84,7 +84,7 @@ static const int CHECK_CACHEFILE_PART_SIZE = 1024 * 16;	// Buffer size in PageLi
 #define CACHEDBG_FMT_WARN_OPEN  "\n           -> [W] This file is currently open and may not provide accurate analysis results."
 #define CACHEDBG_FMT_CRIT_HEAD  "           -> [C] %s"
 #define CACHEDBG_FMT_CRIT_HEAD2 "           -> [C] "
-#define CACHEDBG_FMT_PROB_BLOCK "                  0x%016jx(0x%016jx bytes)"
+#define CACHEDBG_FMT_PROB_BLOCK "                  0x%016zx(0x%016zx bytes)"
 
 //------------------------------------------------
 // CacheFileStat class methods
@@ -3342,14 +3342,14 @@ bool FdManager::RawCheckAllCache(FILE* fp, const char* cache_stat_top_dir, const
         if(!warn_area_list.empty()){
           S3FS_PRN_CACHE(fp, CACHEDBG_FMT_WARN_HEAD);
           for(fdpage_list_t::const_iterator witer = warn_area_list.begin(); witer != warn_area_list.end(); ++witer){
-            S3FS_PRN_CACHE(fp, CACHEDBG_FMT_PROB_BLOCK, (intmax_t)(witer->offset), (intmax_t)(witer->bytes));
+            S3FS_PRN_CACHE(fp, CACHEDBG_FMT_PROB_BLOCK, witer->offset, witer->bytes);
           }
         }
         if(!err_area_list.empty()){
           ++err_file_cnt;
           S3FS_PRN_CACHE(fp, CACHEDBG_FMT_ERR_HEAD);
           for(fdpage_list_t::const_iterator eiter = err_area_list.begin(); eiter != err_area_list.end(); ++eiter){
-            S3FS_PRN_CACHE(fp, CACHEDBG_FMT_PROB_BLOCK, (intmax_t)(eiter->offset), (intmax_t)(eiter->bytes));
+            S3FS_PRN_CACHE(fp, CACHEDBG_FMT_PROB_BLOCK, eiter->offset, eiter->bytes);
           }
         }
       }else{

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -885,7 +885,7 @@ static int s3fs_readlink(const char* _path, char* buf, size_t size)
     // Read
     ssize_t ressize;
     if(0 > (ressize = ent->Read(buf, 0, readsize))){
-      S3FS_PRN_ERR("could not read file(file=%s, ressize=%jd)", path, (intmax_t)ressize);
+      S3FS_PRN_ERR("could not read file(file=%s, ressize=%zd)", path, ressize);
       FdManager::get()->Close(ent);
       return static_cast<int>(ressize);
     }
@@ -988,7 +988,7 @@ static int s3fs_mknod(const char *_path, mode_t mode, dev_t rdev)
   int       result;
   struct fuse_context* pcxt;
 
-  S3FS_PRN_INFO("[path=%s][mode=%04o][dev=%ju]", path, mode, (uintmax_t)rdev);
+  S3FS_PRN_INFO("[path=%s][mode=%04o][dev=%llu]", path, mode, (unsigned long long)rdev);
 
   if(NULL == (pcxt = fuse_get_context())){
     return -EIO;
@@ -2214,7 +2214,7 @@ static int s3fs_read(const char* _path, char* buf, size_t size, off_t offset, st
   }
 
   if(0 > (res = ent->Read(buf, offset, size, false))){
-    S3FS_PRN_WARN("failed to read file(%s). result=%jd", path, (intmax_t)res);
+    S3FS_PRN_WARN("failed to read file(%s). result=%zd", path, res);
   }
   FdManager::get()->Close(ent);
 
@@ -2237,7 +2237,7 @@ static int s3fs_write(const char* _path, const char* buf, size_t size, off_t off
     S3FS_PRN_WARN("different fd(%d - %llu)", ent->GetFd(), (unsigned long long)(fi->fh));
   }
   if(0 > (res = ent->Write(buf, offset, size))){
-    S3FS_PRN_WARN("failed to write file(%s). result=%jd", path, (intmax_t)res);
+    S3FS_PRN_WARN("failed to write file(%s). result=%zd", path, res);
   }
   FdManager::get()->Close(ent);
 


### PR DESCRIPTION
This removes unnecessary casting.