### PR TITLE
Lock fdent_data_lock before accessing pagelist

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1788,6 +1788,12 @@ bool FdEntity::RenamePath(const string& newpath, string& fentmapkey)
   return true;
 }
 
+bool FdEntity::IsModified(void) const
+{
+  AutoLock auto_data_lock(const_cast<pthread_mutex_t *>(&fdent_data_lock));
+  return pagelist.IsModified();
+}
+
 bool FdEntity::GetStats(struct stat& st, bool lock_already_held)
 {
   AutoLock auto_lock(&fdent_lock, lock_already_held ? AutoLock::ALREADY_LOCKED : AutoLock::NONE);
@@ -1882,6 +1888,7 @@ bool FdEntity::GetSize(off_t& size)
     return false;
   }
 
+  AutoLock auto_data_lock(&fdent_data_lock);
   size = pagelist.Size();
   return true;
 }

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -185,7 +185,7 @@ class FdEntity
     const char* GetPath(void) const { return path.c_str(); }
     bool RenamePath(const std::string& newpath, std::string& fentmapkey);
     int GetFd(void) const { return fd; }
-    bool IsModified(void) const { return pagelist.IsModified(); }
+    bool IsModified(void) const;
     bool MergeOrgMeta(headers_t& updatemeta);
 
     bool GetStats(struct stat& st, bool lock_already_held = false);

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -97,6 +97,7 @@ class AutoLock
     ~AutoLock();
 
   private:
+    AutoLock(const AutoLock&);
     pthread_mutex_t* const auto_mutex;
     bool is_lock_acquired;
 };


### PR DESCRIPTION
Found via ThreadSanitizer.  References #1353.  References #1362.