### PR TITLE
Dynamically determine whether lseek extended options are supported

### DIFF
--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -232,6 +232,8 @@ class FdManager
     static bool            check_cache_dir_exist;
     static off_t           free_disk_space; // limit free disk space
     static std::string     check_cache_output;
+    static bool            checked_lseek;
+    static bool            have_lseek_hole;
 
     fdent_map_t            fent;
 
@@ -265,6 +267,7 @@ class FdManager
     static bool IsSafeDiskSpace(const char* path, off_t size);
     static void FreeReservedDiskSpace(off_t size);
     static bool ReserveDiskSpace(off_t size);
+    static bool HaveLseekHole(void);
 
     // Return FdEntity associated with path, returning NULL on error.  This operation increments the reference count; callers must decrement via Close after use.
     FdEntity* GetFdEntity(const char* path, int existfd = -1);

--- a/src/sighandlers.cpp
+++ b/src/sighandlers.cpp
@@ -93,6 +93,11 @@ void S3fsSignals::HandlerUSR1(int sig)
 
 bool S3fsSignals::SetUsr1Handler(const char* path)
 {
+  if(!FdManager::HaveLseekHole()){
+    S3FS_PRN_ERR("Could not set SIGUSR1 for checking cache, because this system does not support SEEK_DATA/SEEK_HOLE in lseek function.");
+    return false;
+  }
+
   // set output file
   if(!FdManager::SetCacheCheckOutput(path)){
     S3FS_PRN_ERR("Could not set output file(%s) for checking cache.", path ? path : "null(stdout)");


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1354 

### Details
This PR is a code to avoid that s3fs cannot be built when whence SEEK_HOLE/SEEK_DATA of the lseek function is undefined.
Also, in the runtime environment where lseek cannot recognize these whence, s3fs will not start up with an error if the set_check_cache_sigusr1 option is specified.

This fix will broaden the build and run environments.

However, I think that we do not want to change the target OS supported by s3fs by this fix does.
The environment that can be built/executed is increase to wide, but the OS environment that can be officially supported follows the contents discussed in #1354.
