### PR TITLE
return 0 after parsing "use_session_token" arg

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4285,6 +4285,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
         }
         if (0 == STR2NCMP(arg, "use_session_token")) {
             is_use_session_token = true;
+	    return 0;
         }
         if(0 == STR2NCMP(arg, "ibm_iam_endpoint=")){
             std::string endpoint_url;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4285,7 +4285,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
         }
         if (0 == STR2NCMP(arg, "use_session_token")) {
             is_use_session_token = true;
-	    return 0;
+            return 0;
         }
         if(0 == STR2NCMP(arg, "ibm_iam_endpoint=")){
             std::string endpoint_url;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#651 

### Details
I hope this might fix #651.

There's clearly an open bug in #651 confirmed by several users related to the parsing of `-o use_session_token`. Looking for anomalies in the source code, I noticed that there was a return value everywhere except here, so I suspect this may be (at least partially) responsible.