### PR TITLE
Remove incorrect string prefix comparisons

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4105,7 +4105,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             FdManager::SetCacheDir(strchr(arg, '=') + sizeof(char));
             return 0;
         }
-        if(0 == STR2NCMP(arg, "check_cache_dir_exist")){
+        if(0 == strcmp(arg, "check_cache_dir_exist")){
             FdManager::SetCheckCacheDirExist(true);
             return 0;
         }
@@ -4283,7 +4283,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             is_ibm_iam_auth = true;
             return 0;
         }
-        if (0 == STR2NCMP(arg, "use_session_token")) {
+        if (0 == strcmp(arg, "use_session_token")) {
             is_use_session_token = true;
             return 0;
         }
@@ -4523,7 +4523,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             pathrequeststyle = true;
             return 0;
         }
-        if(0 == STR2NCMP(arg, "noua")){
+        if(0 == strcmp(arg, "noua")){
             S3fsCurl::SetUserAgentFlag(false);
             return 0;
         }


### PR DESCRIPTION
Previously flags like `-o nouafoobar` were parsed as `-o noua`.  Found
via:

```
grep STR2NCMP src/s3fs.cpp | grep -v '="'
```