### PR TITLE
Use 64-bit off_t when computing digests

### DIFF
--- a/src/common_auth.cpp
+++ b/src/common_auth.cpp
@@ -54,7 +54,7 @@ string s3fs_get_content_md5(int fd)
     return Signature;
 }
 
-string s3fs_md5sum(int fd, off_t start, ssize_t size)
+string s3fs_md5sum(int fd, off_t start, off_t size)
 {
     size_t digestlen = get_md5_digest_length();
     unsigned char* md5hex;
@@ -69,7 +69,7 @@ string s3fs_md5sum(int fd, off_t start, ssize_t size)
     return md5;
 }
 
-string s3fs_sha256sum(int fd, off_t start, ssize_t size)
+string s3fs_sha256sum(int fd, off_t start, off_t size)
 {
     size_t digestlen = get_sha256_digest_length();
     char sha256[2 * digestlen + 1];

--- a/src/gnutls_auth.cpp
+++ b/src/gnutls_auth.cpp
@@ -190,17 +190,17 @@ size_t get_md5_digest_length()
 }
 
 #ifdef USE_GNUTLS_NETTLE
-unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
+unsigned char* s3fs_md5hexsum(int fd, off_t start, off_t size)
 {
     struct md5_ctx ctx_md5;
     unsigned char  buf[512];
-    ssize_t        bytes;
+    off_t          bytes;
     unsigned char* result;
 
     memset(buf, 0, 512);
     md5_init(&ctx_md5);
 
-    for(ssize_t total = 0; total < size; total += bytes){
+    for(off_t total = 0; total < size; total += bytes){
         bytes = 512 < (size - total) ? 512 : (size - total);
         bytes = pread(fd, buf, bytes, start + total);
         if(0 == bytes){
@@ -222,12 +222,12 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
 
 #else // USE_GNUTLS_NETTLE
 
-unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
+unsigned char* s3fs_md5hexsum(int fd, off_t start, off_t size)
 {
     gcry_md_hd_t ctx_md5;
     gcry_error_t err;
     char    buf[512];
-    ssize_t bytes;
+    off_t bytes;
     unsigned char* result;
 
     if(-1 == size){
@@ -235,7 +235,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
         if(-1 == fstat(fd, &st)){
             return NULL;
         }
-        size = static_cast<ssize_t>(st.st_size);
+        size = st.st_size;
     }
 
     memset(buf, 0, 512);
@@ -244,7 +244,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
         return NULL;
     }
 
-    for(ssize_t total = 0; total < size; total += bytes){
+    for(off_t total = 0; total < size; total += bytes){
         bytes = 512 < (size - total) ? 512 : (size - total);
         bytes = pread(fd, buf, bytes, start + total);
         if(0 == bytes){
@@ -290,17 +290,17 @@ bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char*
     return true;
 }
 
-unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
+unsigned char* s3fs_sha256hexsum(int fd, off_t start, off_t size)
 {
     struct sha256_ctx ctx_sha256;
     unsigned char     buf[512];
-    ssize_t           bytes;
+    off_t             bytes;
     unsigned char*    result;
 
     memset(buf, 0, 512);
     sha256_init(&ctx_sha256);
 
-    for(ssize_t total = 0; total < size; total += bytes){
+    for(off_t total = 0; total < size; total += bytes){
         bytes = 512 < (size - total) ? 512 : (size - total);
         bytes = pread(fd, buf, bytes, start + total);
         if(0 == bytes){
@@ -341,12 +341,12 @@ bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char*
     return true;
 }
 
-unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
+unsigned char* s3fs_sha256hexsum(int fd, off_t start, off_t size)
 {
     gcry_md_hd_t   ctx_sha256;
     gcry_error_t   err;
     char           buf[512];
-    ssize_t        bytes;
+    off_t          bytes;
     unsigned char* result;
 
     if(-1 == size){
@@ -354,7 +354,7 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
         if(-1 == fstat(fd, &st)){
             return NULL;
         }
-        size = static_cast<ssize_t>(st.st_size);
+        size = st.st_size;
     }
 
     memset(buf, 0, 512);
@@ -363,7 +363,7 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
         return NULL;
     }
 
-    for(ssize_t total = 0; total < size; total += bytes){
+    for(off_t total = 0; total < size; total += bytes){
         bytes = 512 < (size - total) ? 512 : (size - total);
         bytes = pread(fd, buf, bytes, start + total);
         if(0 == bytes){

--- a/src/nss_auth.cpp
+++ b/src/nss_auth.cpp
@@ -152,11 +152,11 @@ size_t get_md5_digest_length()
     return MD5_LENGTH;
 }
 
-unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
+unsigned char* s3fs_md5hexsum(int fd, off_t start, off_t size)
 {
     PK11Context*   md5ctx;
     unsigned char  buf[512];
-    ssize_t        bytes;
+    off_t          bytes;
     unsigned char* result;
     unsigned int   md5outlen;
 
@@ -165,13 +165,13 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
         if(-1 == fstat(fd, &st)){
             return NULL;
         }
-        size = static_cast<ssize_t>(st.st_size);
+        size = st.st_size;
     }
 
     memset(buf, 0, 512);
     md5ctx = PK11_CreateDigestContext(SEC_OID_MD5);
 
-    for(ssize_t total = 0; total < size; total += bytes){
+    for(off_t total = 0; total < size; total += bytes){
         bytes = 512 < (size - total) ? 512 : (size - total);
         bytes = pread(fd, buf, bytes, start + total);
         if(0 == bytes){
@@ -218,11 +218,11 @@ bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char*
     return true;
 }
 
-unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
+unsigned char* s3fs_sha256hexsum(int fd, off_t start, off_t size)
 {
     PK11Context*   sha256ctx;
     unsigned char  buf[512];
-    ssize_t        bytes;
+    off_t          bytes;
     unsigned char* result;
     unsigned int   sha256outlen;
 
@@ -231,13 +231,13 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
         if(-1 == fstat(fd, &st)){
             return NULL;
         }
-        size = static_cast<ssize_t>(st.st_size);
+        size = st.st_size;
     }
 
     memset(buf, 0, 512);
     sha256ctx = PK11_CreateDigestContext(SEC_OID_SHA256);
 
-    for(ssize_t total = 0; total < size; total += bytes){
+    for(off_t total = 0; total < size; total += bytes){
         bytes = 512 < (size - total) ? 512 : (size - total);
         bytes = pread(fd, buf, bytes, start + total);
         if(0 == bytes){

--- a/src/openssl_auth.cpp
+++ b/src/openssl_auth.cpp
@@ -255,11 +255,11 @@ size_t get_md5_digest_length()
     return MD5_DIGEST_LENGTH;
 }
 
-unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
+unsigned char* s3fs_md5hexsum(int fd, off_t start, off_t size)
 {
     MD5_CTX md5ctx;
     char    buf[512];
-    ssize_t bytes;
+    off_t   bytes;
     unsigned char* result;
 
     if(-1 == size){
@@ -267,13 +267,13 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size)
         if(-1 == fstat(fd, &st)){
             return NULL;
         }
-        size = static_cast<ssize_t>(st.st_size);
+        size = st.st_size;
     }
 
     memset(buf, 0, 512);
     MD5_Init(&md5ctx);
 
-    for(ssize_t total = 0; total < size; total += bytes){
+    for(off_t total = 0; total < size; total += bytes){
         bytes = 512 < (size - total) ? 512 : (size - total);
         bytes = pread(fd, buf, bytes, start + total);
         if(0 == bytes){
@@ -317,12 +317,12 @@ bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char*
     return true;
 }
 
-unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
+unsigned char* s3fs_sha256hexsum(int fd, off_t start, off_t size)
 {
     const EVP_MD*  md = EVP_get_digestbyname("sha256");
     EVP_MD_CTX*    sha256ctx;
     char           buf[512];
-    ssize_t        bytes;
+    off_t          bytes;
     unsigned char* result;
 
     if(-1 == size){
@@ -330,14 +330,14 @@ unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size)
         if(-1 == fstat(fd, &st)){
             return NULL;
         }
-        size = static_cast<ssize_t>(st.st_size);
+        size = st.st_size;
     }
 
     sha256ctx = EVP_MD_CTX_create();
     EVP_DigestInit_ex(sha256ctx, md, NULL);
 
     memset(buf, 0, 512);
-    for(ssize_t total = 0; total < size; total += bytes){
+    for(off_t total = 0; total < size; total += bytes){
         bytes = 512 < (size - total) ? 512 : (size - total);
         bytes = pread(fd, buf, bytes, start + total);
         if(0 == bytes){

--- a/src/s3fs_auth.h
+++ b/src/s3fs_auth.h
@@ -31,8 +31,8 @@
 // in common_auth.cpp
 //
 std::string s3fs_get_content_md5(int fd);
-std::string s3fs_md5sum(int fd, off_t start, ssize_t size);
-std::string s3fs_sha256sum(int fd, off_t start, ssize_t size);
+std::string s3fs_md5sum(int fd, off_t start, off_t size);
+std::string s3fs_sha256sum(int fd, off_t start, off_t size);
 
 //
 // in xxxxxx_auth.cpp
@@ -45,10 +45,10 @@ bool s3fs_destroy_crypt_mutex(void);
 bool s3fs_HMAC(const void* key, size_t keylen, const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen);
 bool s3fs_HMAC256(const void* key, size_t keylen, const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen);
 size_t get_md5_digest_length(void);
-unsigned char* s3fs_md5hexsum(int fd, off_t start, ssize_t size);
+unsigned char* s3fs_md5hexsum(int fd, off_t start, off_t size);
 bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char** digest, unsigned int* digestlen);
 size_t get_sha256_digest_length(void);
-unsigned char* s3fs_sha256hexsum(int fd, off_t start, ssize_t size);
+unsigned char* s3fs_sha256hexsum(int fd, off_t start, off_t size);
 
 #endif // S3FS_AUTH_H_
 


### PR DESCRIPTION
This allows 32-bit platforms like Raspberry Pi to upload single-part
objects larger than 2 GB.