### PR TITLE
Added a class for automating fdentity reference counts

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -46,6 +46,7 @@ s3fs_SOURCES = \
     fdcache_entity.cpp \
     fdcache_page.cpp \
     fdcache_stat.cpp \
+    fdcache_auto.cpp \
     addhead.cpp \
     sighandlers.cpp \
     autolock.cpp \

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -76,7 +76,7 @@ class FdManager
       static bool HaveLseekHole(void);
 
       // Return FdEntity associated with path, returning NULL on error.  This operation increments the reference count; callers must decrement via Close after use.
-      FdEntity* GetFdEntity(const char* path, int existfd = -1);
+      FdEntity* GetFdEntity(const char* path, int existfd = -1, bool increase_ref = true);
       FdEntity* Open(const char* path, headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, bool force_tmpfile = false, bool is_create = true, bool no_fd_lock_wait = false);
       FdEntity* ExistOpen(const char* path, int existfd = -1, bool ignore_existfd = false);
       void Rename(const std::string &from, const std::string &to);

--- a/src/fdcache_auto.cpp
+++ b/src/fdcache_auto.cpp
@@ -1,0 +1,144 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2007 Takeshi Nakatani <ggtakec.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+
+#include "common.h"
+#include "s3fs.h"
+#include "fdcache_auto.h"
+#include "fdcache.h"
+
+//------------------------------------------------
+// AutoFdEntity methods
+//------------------------------------------------
+AutoFdEntity::AutoFdEntity() : pFdEntity(NULL)
+{
+}
+
+// [NOTE]
+// The copy constructor should not be called, then this is private method.
+// Even if it is called, the consistency of the number of
+// references can be maintained, but this case is not assumed.
+//
+AutoFdEntity::AutoFdEntity(AutoFdEntity& other) : pFdEntity(NULL)
+{
+    S3FS_PRN_WARN("This method should not be called. Please check the caller.");
+
+    if(other.pFdEntity){
+        other.pFdEntity->Dup();
+        pFdEntity = other.pFdEntity;
+    }
+}
+
+AutoFdEntity::~AutoFdEntity()
+{
+    Close();
+}
+
+bool AutoFdEntity::Close()
+{
+    if(pFdEntity){
+        if(!FdManager::get()->Close(pFdEntity)){
+            S3FS_PRN_ERR("Failed to close fdentity.");
+            return false;
+        }
+        pFdEntity = NULL;
+    }
+    return true;
+}
+
+// [NOTE]
+// This method touches the internal fdentity with.
+// This is used to keep the file open.
+//
+bool AutoFdEntity::Detach()
+{
+    if(!pFdEntity){
+        S3FS_PRN_ERR("Does not have a associated FdEntity.");
+        return false;
+    }
+    pFdEntity = NULL;
+    return true;
+}
+
+// [NOTE]
+// This method calls the FdManager method without incrementing the
+// reference count.
+// This means that it will only be used to map to a file descriptor
+// that was already open.
+//
+FdEntity* AutoFdEntity::GetFdEntity(const char* path, int existfd, bool increase_ref)
+{
+    Close();
+
+    if(NULL == (pFdEntity = FdManager::get()->GetFdEntity(path, existfd, increase_ref))){
+        S3FS_PRN_ERR("Could not find fd(file=%s, existfd=%d)", path, existfd);
+        return NULL;
+    }
+    return pFdEntity;
+}
+
+FdEntity* AutoFdEntity::Open(const char* path, headers_t* pmeta, off_t size, time_t time, bool force_tmpfile, bool is_create, bool no_fd_lock_wait)
+{
+    Close();
+
+    if(NULL == (pFdEntity = FdManager::get()->Open(path, pmeta, size, time, force_tmpfile, is_create, no_fd_lock_wait))){
+        return NULL;
+    }
+    return pFdEntity;
+}
+
+FdEntity* AutoFdEntity::ExistOpen(const char* path, int existfd, bool ignore_existfd)
+{
+    Close();
+
+    if(NULL == (pFdEntity = FdManager::get()->ExistOpen(path, existfd, ignore_existfd))){
+        return NULL;
+    }
+    return pFdEntity;
+}
+
+// [NOTE]
+// This operator should not be called, then this is private method.
+// Even if it is called, the consistency of the number of
+// references can be maintained, but this case is not assumed.
+//
+bool AutoFdEntity::operator=(AutoFdEntity& other)
+{
+    S3FS_PRN_WARN("This method should not be called. Please check the caller.");
+
+    Close();
+
+    if(other.pFdEntity){
+        other.pFdEntity->Dup();
+        pFdEntity = other.pFdEntity;
+    }
+    return true;
+}
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/

--- a/src/fdcache_auto.h
+++ b/src/fdcache_auto.h
@@ -1,0 +1,63 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef S3FS_FDCACHE_AUTO_H_
+#define S3FS_FDCACHE_AUTO_H_
+
+#include "fdcache_entity.h"
+
+//------------------------------------------------
+// class AutoFdEntity
+//------------------------------------------------
+// A class that opens fdentiry and closes it automatically.
+// This class object is used to prevent inconsistencies in
+// the number of references in fdentiry.
+// The methods are wrappers to the method of the FdManager class.
+//
+class AutoFdEntity
+{
+  private:
+      FdEntity* pFdEntity;
+
+  private:
+      AutoFdEntity(AutoFdEntity& other);
+      bool operator=(AutoFdEntity& other);
+
+  public:
+      AutoFdEntity();
+      ~AutoFdEntity();
+
+      bool Close(void);
+      bool Detach(void);
+      FdEntity* GetFdEntity(const char* path, int existfd = -1, bool increase_ref = true);
+      FdEntity* Open(const char* path, headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, bool force_tmpfile = false, bool is_create = true, bool no_fd_lock_wait = false);
+      FdEntity* ExistOpen(const char* path, int existfd = -1, bool ignore_existfd = false);
+};
+
+#endif // S3FS_FDCACHE_AUTO_H_
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -75,6 +75,7 @@ class FdEntity
         int Open(headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, bool no_fd_lock_wait = false);
         bool OpenAndLoadAll(headers_t* pmeta = NULL, off_t* size = NULL, bool force_load = false);
         int Dup(bool lock_already_held = false);
+        int GetRefCnt(void) const { return refcnt; }                // [NOTE] Use only debugging
 
         const char* GetPath(void) const { return path.c_str(); }
         bool RenamePath(const std::string& newpath, std::string& fentmapkey);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1385 #1387 

### Details
Due to a bug in the number of references in the file descriptor of a cache file, I have added a class that allows the destructor to automatically decrement the number of references.
By using this class other than fdcache related class, we can prevent the leakage of the number of references.

Checking the number of references by test is difficult.
Therefore, this additional class AutoFdEntity prevents inconsistencies in the number of references.

Also, when the cache file is left open at the end of the s3fs process (when there is a high possibility of a problem), a warning is output.

