### PR TITLE
Use off_t for read sizes

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1457,7 +1457,7 @@ S3fsCurl* S3fsCurl::ParallelGetObjectRetryCallback(S3fsCurl* s3fscurl)
     return newcurl;
 }
 
-int S3fsCurl::ParallelGetObjectRequest(const char* tpath, int fd, off_t start, ssize_t size)
+int S3fsCurl::ParallelGetObjectRequest(const char* tpath, int fd, off_t start, off_t size)
 {
     S3FS_PRN_INFO3("[tpath=%s][fd=%d]", SAFESTRPTR(tpath), fd);
 
@@ -1467,7 +1467,7 @@ int S3fsCurl::ParallelGetObjectRequest(const char* tpath, int fd, off_t start, s
         S3FS_PRN_WARN("Failed to get SSE type for file(%s).", SAFESTRPTR(tpath));
     }
     int        result = 0;
-    ssize_t    remaining_bytes;
+    off_t      remaining_bytes;
 
     // cycle through open fd, pulling off 10MB chunks at a time
     for(remaining_bytes = size; 0 < remaining_bytes; ){
@@ -3139,7 +3139,7 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
     return result;
 }
 
-int S3fsCurl::PreGetObjectRequest(const char* tpath, int fd, off_t start, ssize_t size, sse_type_t ssetype, std::string& ssevalue)
+int S3fsCurl::PreGetObjectRequest(const char* tpath, int fd, off_t start, off_t size, sse_type_t ssetype, std::string& ssevalue)
 {
     S3FS_PRN_INFO3("[tpath=%s][start=%lld][size=%lld]", SAFESTRPTR(tpath), static_cast<long long>(start), static_cast<long long>(size));
 
@@ -3189,7 +3189,7 @@ int S3fsCurl::PreGetObjectRequest(const char* tpath, int fd, off_t start, ssize_
     return 0;
 }
 
-int S3fsCurl::GetObjectRequest(const char* tpath, int fd, off_t start, ssize_t size)
+int S3fsCurl::GetObjectRequest(const char* tpath, int fd, off_t start, off_t size)
 {
     int result;
 

--- a/src/curl.h
+++ b/src/curl.h
@@ -178,7 +178,7 @@ class S3fsCurl
         const unsigned char* b_postdata;           // backup for retrying
         int                  b_postdata_remaining; // backup for retrying
         off_t                b_partdata_startpos;  // backup for retrying
-        ssize_t              b_partdata_size;      // backup for retrying
+        off_t                b_partdata_size;      // backup for retrying
         int                  b_ssekey_pos;         // backup for retrying
         std::string          b_ssevalue;           // backup for retrying
         sse_type_t           b_ssetype;            // backup for retrying
@@ -273,7 +273,7 @@ class S3fsCurl
         static bool DestroyS3fsCurl(void);
         static int ParallelMultipartUploadRequest(const char* tpath, headers_t& meta, int fd);
         static int ParallelMixMultipartUploadRequest(const char* tpath, headers_t& meta, int fd, const fdpage_list_t& mixuppages);
-        static int ParallelGetObjectRequest(const char* tpath, int fd, off_t start, ssize_t size);
+        static int ParallelGetObjectRequest(const char* tpath, int fd, off_t start, off_t size);
         static bool CheckIAMCredentialUpdate(void);
 
         // class methods(variables)
@@ -363,8 +363,8 @@ class S3fsCurl
         int HeadRequest(const char* tpath, headers_t& meta);
         int PutHeadRequest(const char* tpath, headers_t& meta, bool is_copy);
         int PutRequest(const char* tpath, headers_t& meta, int fd);
-        int PreGetObjectRequest(const char* tpath, int fd, off_t start, ssize_t size, sse_type_t ssetype, std::string& ssevalue);
-        int GetObjectRequest(const char* tpath, int fd, off_t start = -1, ssize_t size = -1);
+        int PreGetObjectRequest(const char* tpath, int fd, off_t start, off_t size, sse_type_t ssetype, std::string& ssevalue);
+        int GetObjectRequest(const char* tpath, int fd, off_t start = -1, off_t size = -1);
         int CheckBucket(void);
         int ListBucketRequest(const char* tpath, const char* query);
         int PreMultipartPostRequest(const char* tpath, headers_t& meta, std::string& upload_id, bool is_copy);


### PR DESCRIPTION
This fixes an issue with large `multipart_size` on 32-bit platforms like
Raspberry Pi.