### PR TITLE
Use more descriptive names for digest functions

### DIFF
--- a/src/common_auth.cpp
+++ b/src/common_auth.cpp
@@ -34,17 +34,18 @@
 //-------------------------------------------------------------------
 std::string s3fs_get_content_md5(int fd)
 {
-    unsigned char* md5hex;
+    unsigned char* md5;
     char* base64;
     std::string Signature;
 
-    if(NULL == (md5hex = s3fs_md5hexsum(fd, 0, -1))){
+    if(NULL == (md5 = s3fs_md5_fd(fd, 0, -1))){
         return std::string("");
     }
-    if(NULL == (base64 = s3fs_base64(md5hex, get_md5_digest_length()))){
+    if(NULL == (base64 = s3fs_base64(md5, get_md5_digest_length()))){
+        delete[] md5;
         return std::string("");  // ENOMEM
     }
-    delete[] md5hex;
+    delete[] md5;
 
     Signature = base64;
     delete[] base64;
@@ -52,34 +53,19 @@ std::string s3fs_get_content_md5(int fd)
     return Signature;
 }
 
-std::string s3fs_md5sum(int fd, off_t start, off_t size)
-{
-    size_t digestlen = get_md5_digest_length();
-    unsigned char* md5hex;
-
-    if(NULL == (md5hex = s3fs_md5hexsum(fd, start, size))){
-        return std::string("");
-    }
-
-    std::string md5 = s3fs_hex(md5hex, digestlen);
-    delete[] md5hex;
-
-    return md5;
-}
-
-std::string s3fs_sha256sum(int fd, off_t start, off_t size)
+std::string s3fs_sha256_hex_fd(int fd, off_t start, off_t size)
 {
     size_t digestlen = get_sha256_digest_length();
-    unsigned char* sha256hex;
+    unsigned char* sha256;
 
-    if(NULL == (sha256hex = s3fs_sha256hexsum(fd, start, size))){
+    if(NULL == (sha256 = s3fs_sha256_fd(fd, start, size))){
         return std::string("");
     }
 
-    std::string sha256 = s3fs_hex(sha256hex, digestlen);
-    delete[] sha256hex;
+    std::string sha256hex = s3fs_hex(sha256, digestlen);
+    delete[] sha256;
 
-    return sha256;
+    return sha256hex;
 }
 
 /*

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2532,7 +2532,7 @@ void S3fsCurl::insertV4Headers()
     std::string payload_hash;
     switch (type) {
         case REQTYPE_PUT:
-            payload_hash = s3fs_sha256sum(b_infile == NULL ? -1 : fileno(b_infile), 0, -1);
+            payload_hash = s3fs_sha256_hex_fd(b_infile == NULL ? -1 : fileno(b_infile), 0, -1);
             break;
 
         case REQTYPE_COMPLETEMULTIPOST:
@@ -2547,7 +2547,7 @@ void S3fsCurl::insertV4Headers()
             }
 
         case REQTYPE_UPLOADMULTIPOST:
-            payload_hash = s3fs_sha256sum(partdata.fd, partdata.startpos, partdata.size);
+            payload_hash = s3fs_sha256_hex_fd(partdata.fd, partdata.startpos, partdata.size);
             break;
         default:
             break;
@@ -3557,7 +3557,7 @@ int S3fsCurl::UploadMultipartPostSetup(const char* tpath, int part_num, const st
 
     // make md5 and file pointer
     if(S3fsCurl::is_content_md5){
-        unsigned char *md5raw = s3fs_md5hexsum(partdata.fd, partdata.startpos, partdata.size);
+        unsigned char *md5raw = s3fs_md5_fd(partdata.fd, partdata.startpos, partdata.size);
         if(md5raw == NULL){
             S3FS_PRN_ERR("Could not make md5 for file(part %d)", part_num);
             return -1;

--- a/src/gnutls_auth.cpp
+++ b/src/gnutls_auth.cpp
@@ -188,7 +188,7 @@ size_t get_md5_digest_length()
 }
 
 #ifdef USE_GNUTLS_NETTLE
-unsigned char* s3fs_md5hexsum(int fd, off_t start, off_t size)
+unsigned char* s3fs_md5_fd(int fd, off_t start, off_t size)
 {
     struct md5_ctx ctx_md5;
     unsigned char  buf[512];
@@ -220,7 +220,7 @@ unsigned char* s3fs_md5hexsum(int fd, off_t start, off_t size)
 
 #else // USE_GNUTLS_NETTLE
 
-unsigned char* s3fs_md5hexsum(int fd, off_t start, off_t size)
+unsigned char* s3fs_md5_fd(int fd, off_t start, off_t size)
 {
     gcry_md_hd_t ctx_md5;
     gcry_error_t err;
@@ -288,7 +288,7 @@ bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char*
     return true;
 }
 
-unsigned char* s3fs_sha256hexsum(int fd, off_t start, off_t size)
+unsigned char* s3fs_sha256_fd(int fd, off_t start, off_t size)
 {
     struct sha256_ctx ctx_sha256;
     unsigned char     buf[512];
@@ -339,7 +339,7 @@ bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char*
     return true;
 }
 
-unsigned char* s3fs_sha256hexsum(int fd, off_t start, off_t size)
+unsigned char* s3fs_sha256_fd(int fd, off_t start, off_t size)
 {
     gcry_md_hd_t   ctx_sha256;
     gcry_error_t   err;

--- a/src/nss_auth.cpp
+++ b/src/nss_auth.cpp
@@ -150,7 +150,7 @@ size_t get_md5_digest_length()
     return MD5_LENGTH;
 }
 
-unsigned char* s3fs_md5hexsum(int fd, off_t start, off_t size)
+unsigned char* s3fs_md5_fd(int fd, off_t start, off_t size)
 {
     PK11Context*   md5ctx;
     unsigned char  buf[512];
@@ -216,7 +216,7 @@ bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char*
     return true;
 }
 
-unsigned char* s3fs_sha256hexsum(int fd, off_t start, off_t size)
+unsigned char* s3fs_sha256_fd(int fd, off_t start, off_t size)
 {
     PK11Context*   sha256ctx;
     unsigned char  buf[512];

--- a/src/openssl_auth.cpp
+++ b/src/openssl_auth.cpp
@@ -253,7 +253,7 @@ size_t get_md5_digest_length()
     return MD5_DIGEST_LENGTH;
 }
 
-unsigned char* s3fs_md5hexsum(int fd, off_t start, off_t size)
+unsigned char* s3fs_md5_fd(int fd, off_t start, off_t size)
 {
     MD5_CTX md5ctx;
     char    buf[512];
@@ -315,7 +315,7 @@ bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char*
     return true;
 }
 
-unsigned char* s3fs_sha256hexsum(int fd, off_t start, off_t size)
+unsigned char* s3fs_sha256_fd(int fd, off_t start, off_t size)
 {
     const EVP_MD*  md = EVP_get_digestbyname("sha256");
     EVP_MD_CTX*    sha256ctx;

--- a/src/s3fs_auth.h
+++ b/src/s3fs_auth.h
@@ -31,8 +31,7 @@
 // in common_auth.cpp
 //
 std::string s3fs_get_content_md5(int fd);
-std::string s3fs_md5sum(int fd, off_t start, off_t size);
-std::string s3fs_sha256sum(int fd, off_t start, off_t size);
+std::string s3fs_sha256_hex_fd(int fd, off_t start, off_t size);
 
 //
 // in xxxxxx_auth.cpp
@@ -45,10 +44,10 @@ bool s3fs_destroy_crypt_mutex(void);
 bool s3fs_HMAC(const void* key, size_t keylen, const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen);
 bool s3fs_HMAC256(const void* key, size_t keylen, const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen);
 size_t get_md5_digest_length(void);
-unsigned char* s3fs_md5hexsum(int fd, off_t start, off_t size);
+unsigned char* s3fs_md5_fd(int fd, off_t start, off_t size);
 bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char** digest, unsigned int* digestlen);
 size_t get_sha256_digest_length(void);
-unsigned char* s3fs_sha256hexsum(int fd, off_t start, off_t size);
+unsigned char* s3fs_sha256_fd(int fd, off_t start, off_t size);
 
 #endif // S3FS_AUTH_H_
 


### PR DESCRIPTION
Previously they used hex to refer to binary data which is confusing
since other `std::string` return types are actually hex.  Also remove
unused `s3fs_md5sum`.