### PR TITLE
Rework s3fs pid handling

### DIFF
--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -225,9 +225,12 @@ function start_s3fs {
             -o dbglevel=${DBGLEVEL:=info} \
             -o retries=3 \
             -f \
-            "${@}" | stdbuf -oL -eL sed $SED_BUFFER_FLAG "s/^/s3fs: /" &
-        S3FS_PID=$!
-    )
+            "${@}" &
+        echo $! >&3
+    ) 3>pid | stdbuf -oL -eL sed $SED_BUFFER_FLAG "s/^/s3fs: /" &
+    sleep 1
+    export S3FS_PID=$(<pid)
+    rm -f pid
 
     if [ `uname` = "Darwin" ]; then
          set +o errexit

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -318,8 +318,8 @@ function test_external_directory_creation {
     describe "Test external directory creation ..."
     OBJECT_NAME="$(basename $PWD)/directory/${TEST_TEXT_FILE}"
     echo "data" | aws_cli s3 cp - "s3://${TEST_BUCKET_1}/${OBJECT_NAME}"
-    ls | grep directory
-    get_permissions directory | grep ^750$
+    ls | grep -q directory
+    get_permissions directory | grep -q 750$
     ls directory
     cmp <(echo "data") directory/${TEST_TEXT_FILE}
     rm -f directory/${TEST_TEXT_FILE}
@@ -1045,7 +1045,7 @@ function test_ut_ossfs {
 }
 
 function add_all_tests {
-    if `ps -ef | grep -v grep | grep s3fs | grep -q use_cache`; then
+    if ps u $S3FS_PID | grep -q use_cache; then
         add_tests test_cache_file_stat
     fi
     if ! ps u $S3FS_PID | grep -q ensure_diskfree && ! uname | grep -q Darwin; then


### PR DESCRIPTION
Previously `S3FS_PID` was not set in the correct shell and thus
`ps u $S3FS_PID` showed all programs.  This caused the flag detection to
fail when users ran other instances of s3fs with different flags.
References #1402.