### PR TITLE
not call put headers if not exist pending meta

### DIFF
--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -51,6 +51,7 @@ class FdEntity
         std::string     cachepath;      // local cache file path
                                         // (if this is empty, does not load/save pagelist.)
         std::string     mirrorpath;     // mirror file path to local cache file path
+        volatile bool            is_meta_pending;
 
     private:
         static int FillFile(int fd, unsigned char byte, off_t size, off_t start);


### PR DESCRIPTION
### Relevant Issue (if applicable)
The repair code in [1404](https://github.com/s3fs-fuse/s3fs-fuse/pull/1404)  still have some problem, there is no need to call put_headers method if not exist pending meta，