### PR TITLE
Specify Java 8 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ jobs:
       cache: apt
       before_install:
         - sudo apt-get update -qq
-        - sudo apt-get install -qq attr cppcheck libfuse-dev openjdk-7-jdk
-        - sudo update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
+        - sudo apt-get install -qq attr cppcheck libfuse-dev openjdk-8-jdk
         - sudo -H pip install --upgrade awscli
       script:
         - ./autogen.sh
@@ -127,8 +126,7 @@ jobs:
       before_install:
         - sudo add-apt-repository -y ppa:openjdk-r/ppa 
         - sudo apt-get update -qq
-        - sudo apt-get install -qq attr cppcheck libfuse-dev openjdk-7-jdk
-        - sudo update-alternatives --set java /usr/lib/jvm/java-7-openjdk-ppc64el/jre/bin/java
+        - sudo apt-get install -qq attr cppcheck libfuse-dev openjdk-8-jdk
         - sudo -H pip install --upgrade awscli
       script:
         - ./autogen.sh


### PR DESCRIPTION
The next version of S3Proxy will require at least Java 8 and Java 7
seems to have some incompatibility with travis-ci.com.
References #1415.