### PR TITLE
Remove calls to append, assign, and at

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -517,7 +517,7 @@ bool S3fsCurl::LocateBundle()
                 return false;
             }
             BF.close();
-            S3fsCurl::curl_ca_bundle.assign(CURL_CA_BUNDLE); 
+            S3fsCurl::curl_ca_bundle = CURL_CA_BUNDLE;
             return true;
         }
     }else{
@@ -549,22 +549,22 @@ bool S3fsCurl::LocateBundle()
     std::ifstream BF("/etc/pki/tls/certs/ca-bundle.crt");
     if(BF.good()){
         BF.close();
-        S3fsCurl::curl_ca_bundle.assign("/etc/pki/tls/certs/ca-bundle.crt"); 
+        S3fsCurl::curl_ca_bundle = "/etc/pki/tls/certs/ca-bundle.crt";
     }else{
         BF.open("/etc/ssl/certs/ca-certificates.crt");
         if(BF.good()){
             BF.close();
-            S3fsCurl::curl_ca_bundle.assign("/etc/ssl/certs/ca-certificates.crt");
+            S3fsCurl::curl_ca_bundle = "/etc/ssl/certs/ca-certificates.crt";
         }else{
             BF.open("/usr/share/ssl/certs/ca-bundle.crt");
             if(BF.good()){
                 BF.close();
-                S3fsCurl::curl_ca_bundle.assign("/usr/share/ssl/certs/ca-bundle.crt");
+                S3fsCurl::curl_ca_bundle = "/usr/share/ssl/certs/ca-bundle.crt";
             }else{
                 BF.open("/usr/local/share/certs/ca-root.crt");
                 if(BF.good()){
                     BF.close();
-                    S3fsCurl::curl_ca_bundle.assign("/usr/share/ssl/certs/ca-bundle.crt");
+                    S3fsCurl::curl_ca_bundle = "/usr/share/ssl/certs/ca-bundle.crt";
                 }else{
                     S3FS_PRN_ERR("%s: /.../ca-bundle.crt is not readable", program_name.c_str());
                     return false;
@@ -3703,7 +3703,7 @@ bool S3fsCurl::UploadMultipartPostComplete()
             return false;
         }
     }
-    partdata.etaglist->at(partdata.etagpos).assign(it->second);
+    (*partdata.etaglist)[partdata.etagpos] = it->second;
     partdata.uploaded = true;
 
     return true;
@@ -3723,9 +3723,9 @@ bool S3fsCurl::CopyMultipartPostComplete()
     std::string etag;
     partdata.uploaded = simple_parse_xml(bodydata.str(), bodydata.size(), "ETag", etag);
     if(etag.size() >= 2 && *etag.begin() == '"' && *etag.rbegin() == '"'){
-        etag.assign(etag.substr(1, etag.size() - 2));
+        etag = etag.substr(1, etag.size() - 2);
     }
-    partdata.etaglist->at(partdata.etagpos).assign(etag);
+    (*partdata.etaglist)[partdata.etagpos] = etag;
 
     bodydata.Clear();
     headdata.Clear();

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -185,7 +185,7 @@ std::string get_canonical_headers(const struct curl_slist* list)
                 // skip empty-value headers (as they are discarded by libcurl)
                 continue;
             }
-            strhead       = strkey.append(":").append(strval);
+            strhead       = strkey + ":" + strval;
         }else{
             strhead       = trim(lower(strhead));
         }
@@ -214,7 +214,7 @@ std::string get_canonical_headers(const struct curl_slist* list, bool only_amz)
                 // skip empty-value headers (as they are discarded by libcurl)
                 continue;
             }
-            strhead       = strkey.append(":").append(strval);
+            strhead       = strkey + ":" + strval;
         }else{
             strhead       = trim(lower(strhead));
         }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3862,7 +3862,7 @@ static int get_access_keys()
     char * AWS_CREDENTIAL_FILE;
     AWS_CREDENTIAL_FILE = getenv("AWS_CREDENTIAL_FILE");
     if(AWS_CREDENTIAL_FILE != NULL){
-        passwd_file.assign(AWS_CREDENTIAL_FILE);
+        passwd_file = AWS_CREDENTIAL_FILE;
         if(!passwd_file.empty()){
             std::ifstream PF(passwd_file.c_str());
             if(PF.good()){
@@ -3888,8 +3888,8 @@ static int get_access_keys()
     char * HOME;
     HOME = getenv ("HOME");
     if(HOME != NULL){
-         passwd_file.assign(HOME);
-         passwd_file.append("/.passwd-s3fs");
+         passwd_file = HOME;
+         passwd_file += "/.passwd-s3fs";
          std::ifstream PF(passwd_file.c_str());
          if(PF.good()){
              PF.close();
@@ -3906,7 +3906,7 @@ static int get_access_keys()
      }
 
     // 5 - from the system default location
-    passwd_file.assign("/etc/passwd-s3fs"); 
+    passwd_file = "/etc/passwd-s3fs";
     std::ifstream PF(passwd_file.c_str());
     if(PF.good()){
         PF.close();
@@ -3966,7 +3966,7 @@ static int set_bucket(const char* arg)
             }
             mount_prefix = pmount_prefix;
             // remove trailing slash
-            if(mount_prefix.at(mount_prefix.size() - 1) == '/'){
+            if(mount_prefix[mount_prefix.size() - 1] == '/'){
                 mount_prefix = mount_prefix.substr(0, mount_prefix.size() - 1);
             }
         }
@@ -4687,7 +4687,7 @@ int main(int argc, char* argv[])
     init_sysconf_vars();
 
     // get program name - emulate basename
-    program_name.assign(argv[0]);
+    program_name = argv[0];
     size_t found = program_name.find_last_of('/');
     if(found != std::string::npos){
         program_name.replace(0, found+1, "");

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -259,7 +259,7 @@ bool get_keyword_value(std::string& target, const char* keyword, std::string& va
         return false;
     }
     spos += strlen(keyword);
-    if('=' != target.at(spos)){
+    if('=' != target[spos]){
         return false;
     }
     spos++;


### PR DESCRIPTION
`operator+`, `operator=`, and `operator[]` are more idiomatic and consistent
with the code base.