### PR TITLE
Disable builder for linux-ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,11 +140,14 @@ jobs:
         - travis_wait 30 make check -C test
         - test/filter-suite-log.sh test/test-suite.log
 
+  exclude:
+    - if: os = linux-ppc64le  # TODO: travis-ci.com cannot use Java 7 which S3Proxy requires
+
 #
 # Local variables:
 # tab-width: 4
 # c-basic-offset: 4
 # End:
-# vim600: noet sw=4 ts=4 fdm=marker
-# vim<600: noet sw=4 ts=4
+# vim600: expandtab sw=4 ts=4 fdm=marker
+# vim<600: expandtab sw=4 ts=4
 #


### PR DESCRIPTION
This works around a travis-ci.com Java/S3Proxy incompatibility.  Also
fix vim formatting.  References #1415.