### PR TITLE
Fixed signature error due to case of hex string

### DIFF
--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -163,7 +163,7 @@ std::string urlEncode(const std::string &s)
             result += c;
         }else{
             result += "%";
-            result += s3fs_hex(&c, 1);
+            result += s3fs_hex(&c, 1, false);
         }
     }
     return result;
@@ -193,7 +193,7 @@ std::string urlEncode2(const std::string &s)
             result += c;
         }else{
             result += "%";
-            result += s3fs_hex(&c, 1);
+            result += s3fs_hex(&c, 1, false);
         }
     }
     return result;
@@ -373,9 +373,12 @@ bool convert_unixtime_from_option_arg(const char* argv, time_t& unixtime)
     return true;
 }
 
-std::string s3fs_hex(const unsigned char* input, size_t length)
+std::string s3fs_hex(const unsigned char* input, size_t length, bool lower)
 {
-    static const char hexAlphabet[] = "0123456789abcdef";
+    static const char hexLower[] = "0123456789abcdef";
+    static const char hexUpper[] = "0123456789ABCDEF";
+
+    const char* hexAlphabet = (lower ? hexLower : hexUpper);
     std::string hex;
     for(size_t pos = 0; pos < length; ++pos){
         hex += hexAlphabet[input[pos] / 16];

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -92,7 +92,7 @@ bool get_keyword_value(std::string& target, const char* keyword, std::string& va
 //
 // For binary string
 //
-std::string s3fs_hex(const unsigned char* input, size_t length);
+std::string s3fs_hex(const unsigned char* input, size_t length, bool lower = true);
 char* s3fs_base64(const unsigned char* input, size_t length);
 unsigned char* s3fs_decode64(const char* input, size_t* plength);
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1433

### Details
The Travis-CI execution result at the time of PR of #1433 was good, but after merging to master, the following error(example) occurred and I could not pass through Travis-CI.
```
s3fs: [ERR] curl.cpp:RequestPerform(2246): HTTP response code 403, returning EPERM. Body Text: <?xml version='1.0' encoding='UTF-8'?><Error><Code>SignatureDoesNotMatch</Code><Message>Forbidden</Message><RequestId>4442587FB7D0A2F9</RequestId></Error>
```
This seems to be due to the difference in case in URL encoding, so I modified the code.
