### PR TITLE
Added atime and Corrected atime/mtime/ctime operations

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -771,9 +771,21 @@ bool convert_header_to_stat(const char* path, const headers_t& meta, struct stat
 
     // mtime
     pst->st_mtime = get_mtime(meta);
+    if(pst->st_mtime < 0){
+        pst->st_mtime = 0L;
+    }
 
     // ctime
     pst->st_ctime = get_ctime(meta);
+    if(pst->st_ctime < 0){
+        pst->st_ctime = 0L;
+    }
+
+    // atime
+    pst->st_atime = get_atime(meta);
+    if(pst->st_atime < 0){
+        pst->st_atime = 0L;
+    }
 
     // size
     pst->st_size = get_size(meta);

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -51,7 +51,8 @@ class FdEntity
         std::string     cachepath;      // local cache file path
                                         // (if this is empty, does not load/save pagelist.)
         std::string     mirrorpath;     // mirror file path to local cache file path
-        volatile bool            is_meta_pending;
+        volatile bool   is_meta_pending;
+        volatile time_t holding_mtime;  // if mtime is updated while the file is open, it is set time_t value
 
     private:
         static int FillFile(int fd, unsigned char byte, off_t size, off_t start);
@@ -85,9 +86,14 @@ class FdEntity
 
         bool GetStats(struct stat& st, bool lock_already_held = false);
         int SetCtime(time_t time, bool lock_already_held = false);
-        int SetMtime(time_t time, bool lock_already_held = false);
+        int SetAtime(time_t time, bool lock_already_held = false);
+        int SetMCtime(time_t mtime, time_t ctime, bool lock_already_held = false);
         bool UpdateCtime();
-        bool UpdateMtime();
+        bool UpdateAtime();
+        bool UpdateMtime(bool clear_holding_mtime = false);
+        bool UpdateMCtime();
+        bool SetHoldingMtime(time_t mtime, bool lock_already_held = false);
+        bool ClearHoldingMtime(bool lock_already_held = false);
         bool GetSize(off_t& size);
         bool GetXattr(std::string& xattr);
         bool SetXattr(const std::string& xattr);

--- a/src/metaheader.h
+++ b/src/metaheader.h
@@ -40,9 +40,9 @@ typedef std::map<std::string, std::string, header_nocase_cmp> headers_t;
 //-------------------------------------------------------------------
 // Functions
 //-------------------------------------------------------------------
-time_t get_mtime(const char *s);
 time_t get_mtime(const headers_t& meta, bool overcheck = true);
 time_t get_ctime(const headers_t& meta, bool overcheck = true);
+time_t get_atime(const headers_t& meta, bool overcheck = true);
 off_t get_size(const char *s);
 off_t get_size(const headers_t& meta);
 mode_t get_mode(const char *s, int base = 0);

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -586,52 +586,261 @@ function test_mtime_file {
 function test_update_time() {
     describe "Testing update time function ..."
 
+    #
     # create the test
+    #
     mk_test_file
+    base_atime=`get_atime $TEST_TEXT_FILE`
+    base_ctime=`get_ctime $TEST_TEXT_FILE`
+    base_mtime=`get_mtime $TEST_TEXT_FILE`
+    sleep 2
+
+    #
+    # chmod -> update only ctime
+    #
+    chmod +x $TEST_TEXT_FILE
+    atime=`get_atime $TEST_TEXT_FILE`
     ctime=`get_ctime $TEST_TEXT_FILE`
     mtime=`get_mtime $TEST_TEXT_FILE`
-
-    sleep 2
-    chmod +x $TEST_TEXT_FILE
-
-    ctime2=`get_ctime $TEST_TEXT_FILE`
-    mtime2=`get_mtime $TEST_TEXT_FILE`
-    if [ $ctime -eq $ctime2 -o $mtime -ne $mtime2 ]; then
-       echo "Expected updated ctime: $ctime != $ctime2 and same mtime: $mtime == $mtime2"
+    if [ $base_atime -ne $atime -o $base_ctime -eq $ctime -o $base_mtime -ne $mtime ]; then
+       echo "chmod expected updated ctime: $base_ctime != $ctime and same mtime: $base_mtime == $mtime, atime: $base_atime == $atime"
        return 1
     fi
-
+    base_ctime=$ctime
     sleep 2
+
+    #
+    # chown -> update only ctime
+    #
     chown $UID $TEST_TEXT_FILE
-
-    ctime3=`get_ctime $TEST_TEXT_FILE`
-    mtime3=`get_mtime $TEST_TEXT_FILE`
-    if [ $ctime2 -eq $ctime3 -o $mtime2 -ne $mtime3 ]; then
-       echo "Expected updated ctime: $ctime2 != $ctime3 and same mtime: $mtime2 == $mtime3"
+    atime=`get_atime $TEST_TEXT_FILE`
+    ctime=`get_ctime $TEST_TEXT_FILE`
+    mtime=`get_mtime $TEST_TEXT_FILE`
+    if [ $base_atime -ne $atime -o $base_ctime -eq $ctime -o $base_mtime -ne $mtime ]; then
+       echo "chown expected updated ctime: $base_ctime != $ctime and same mtime: $base_mtime == $mtime, atime: $base_atime == $atime"
        return 1
     fi
-
+    base_ctime=$ctime
     sleep 2
+
+    #
+    # set_xattr -> update only ctime
+    #
     set_xattr key value $TEST_TEXT_FILE
-
-    ctime4=`get_ctime $TEST_TEXT_FILE`
-    mtime4=`get_mtime $TEST_TEXT_FILE`
-    if [ $ctime3 -eq $ctime4 -o $mtime3 -ne $mtime4 ]; then
-       echo "Expected updated ctime: $ctime3 != $ctime4 and same mtime: $mtime3 == $mtime4"
+    atime=`get_atime $TEST_TEXT_FILE`
+    ctime=`get_ctime $TEST_TEXT_FILE`
+    mtime=`get_mtime $TEST_TEXT_FILE`
+    if [ $base_atime -ne $atime -o $base_ctime -eq $ctime -o $base_mtime -ne $mtime ]; then
+       echo "set_xattr expected updated ctime: $base_ctime != $ctime and same mtime: $base_mtime == $mtime, atime: $base_atime == $atime"
        return 1
     fi
-
+    base_ctime=$ctime
     sleep 2
-    echo foo >> $TEST_TEXT_FILE
 
-    ctime5=`get_ctime $TEST_TEXT_FILE`
-    mtime5=`get_mtime $TEST_TEXT_FILE`
-    if [ $ctime4 -eq $ctime5 -o $mtime4 -eq $mtime5 ]; then
-       echo "Expected updated ctime: $ctime4 != $ctime5 and updated mtime: $mtime4 != $mtime5"
+    #
+    # touch -> update ctime/atime/mtime
+    #
+    touch $TEST_TEXT_FILE
+    atime=`get_atime $TEST_TEXT_FILE`
+    ctime=`get_ctime $TEST_TEXT_FILE`
+    mtime=`get_mtime $TEST_TEXT_FILE`
+    if [ $base_atime -eq $atime -o $base_ctime -eq $ctime -o $base_mtime -eq $mtime ]; then
+       echo "touch expected updated ctime: $base_ctime != $ctime, mtime: $base_mtime != $mtime, atime: $base_atime != $atime"
+       return 1
+    fi
+    base_atime=$atime
+    base_mtime=$mtime
+    base_ctime=$ctime
+    sleep 2
+
+    #
+    # "touch -a" -> update ctime/atime, not update mtime
+    #
+    touch -a $TEST_TEXT_FILE
+    atime=`get_atime $TEST_TEXT_FILE`
+    ctime=`get_ctime $TEST_TEXT_FILE`
+    mtime=`get_mtime $TEST_TEXT_FILE`
+    if [ $base_atime -eq $atime -o $base_ctime -eq $ctime -o $base_mtime -ne $mtime ]; then
+       echo "touch with -a option expected updated ctime: $base_ctime != $ctime, atime: $base_atime != $atime and same mtime: $base_mtime == $mtime"
+       return 1
+    fi
+    base_atime=$atime
+    base_ctime=$ctime
+    sleep 2
+
+    #
+    # append -> update ctime/mtime, not update atime
+    #
+    echo foo >> $TEST_TEXT_FILE
+    atime=`get_atime $TEST_TEXT_FILE`
+    ctime=`get_ctime $TEST_TEXT_FILE`
+    mtime=`get_mtime $TEST_TEXT_FILE`
+    if [ $base_atime -ne $atime -o $base_ctime -eq $ctime -o $base_mtime -eq $mtime ]; then
+       echo "append expected updated ctime: $base_ctime != $ctime, mtime: $base_mtime != $mtime and same atime: $base_atime == $atime"
+       return 1
+    fi
+    base_mtime=$mtime
+    base_ctime=$ctime
+    sleep 2
+
+    #
+    # cp -p -> update ctime, not update atime/mtime
+    #
+    TIME_TEST_TEXT_FILE=test-s3fs-time.txt
+    cp -p $TEST_TEXT_FILE $TIME_TEST_TEXT_FILE
+    atime=`get_atime $TIME_TEST_TEXT_FILE`
+    ctime=`get_ctime $TIME_TEST_TEXT_FILE`
+    mtime=`get_mtime $TIME_TEST_TEXT_FILE`
+    if [ $base_atime -ne $atime -o $base_ctime -eq $ctime -o $base_mtime -ne $mtime ]; then
+       echo "cp with -p option expected updated ctime: $base_ctime != $ctime and same mtime: $base_mtime == $mtime, atime: $base_atime == $atime"
+       return 1
+    fi
+    sleep 2
+
+    #
+    # mv -> update ctime, not update atime/mtime
+    #
+    TIME2_TEST_TEXT_FILE=test-s3fs-time2.txt
+    mv $TEST_TEXT_FILE $TIME2_TEST_TEXT_FILE
+    atime=`get_atime $TIME2_TEST_TEXT_FILE`
+    ctime=`get_ctime $TIME2_TEST_TEXT_FILE`
+    mtime=`get_mtime $TIME2_TEST_TEXT_FILE`
+    if [ $base_atime -ne $atime -o $base_ctime -eq $ctime -o $base_mtime -ne $mtime ]; then
+       echo "mv expected updated ctime: $base_ctime != $ctime and same mtime: $base_mtime == $mtime, atime: $base_atime == $atime"
        return 1
     fi
 
-    rm_test_file
+    rm_test_file $TIME_TEST_TEXT_FILE
+    rm_test_file $TIME2_TEST_TEXT_FILE
+}
+
+function test_update_directory_time() {
+    describe "Testing update time for directory function ..."
+
+    #
+    # create the directory and sub-directory and a file in directory
+    #
+    TIME_TEST_SUBDIR="$TEST_DIR/testsubdir"
+    TIME_TEST_FILE_INDIR="$TEST_DIR/testfile"
+    mk_test_dir
+    mkdir $TIME_TEST_SUBDIR
+    touch $TIME_TEST_FILE_INDIR
+
+    base_atime=`get_atime $TEST_DIR`
+    base_ctime=`get_ctime $TEST_DIR`
+    base_mtime=`get_mtime $TEST_DIR`
+    subdir_atime=`get_atime $TIME_TEST_SUBDIR`
+    subdir_ctime=`get_ctime $TIME_TEST_SUBDIR`
+    subdir_mtime=`get_mtime $TIME_TEST_SUBDIR`
+    subfile_atime=`get_atime $TIME_TEST_FILE_INDIR`
+    subfile_ctime=`get_ctime $TIME_TEST_FILE_INDIR`
+    subfile_mtime=`get_mtime $TIME_TEST_FILE_INDIR`
+    sleep 2
+
+    #
+    # chmod -> update only ctime
+    #
+    chmod 0777 $TEST_DIR
+    atime=`get_atime $TEST_DIR`
+    ctime=`get_ctime $TEST_DIR`
+    mtime=`get_mtime $TEST_DIR`
+    if [ $base_atime -ne $atime -o $base_ctime -eq $ctime -o $base_mtime -ne $mtime ]; then
+       echo "chmod expected updated ctime: $base_ctime != $ctime and same mtime: $base_mtime == $mtime, atime: $base_atime == $atime"
+       return 1
+    fi
+    base_ctime=$ctime
+    sleep 2
+
+    #
+    # chown -> update only ctime
+    #
+    chown $UID $TEST_DIR
+    atime=`get_atime $TEST_DIR`
+    ctime=`get_ctime $TEST_DIR`
+    mtime=`get_mtime $TEST_DIR`
+    if [ $base_atime -ne $atime -o $base_ctime -eq $ctime -o $base_mtime -ne $mtime ]; then
+       echo "chown expected updated ctime: $base_ctime != $ctime and same mtime: $base_mtime == $mtime, atime: $base_atime == $atime"
+       return 1
+    fi
+    base_ctime=$ctime
+    sleep 2
+
+    #
+    # set_xattr -> update only ctime
+    #
+    set_xattr key value $TEST_DIR
+    atime=`get_atime $TEST_DIR`
+    ctime=`get_ctime $TEST_DIR`
+    mtime=`get_mtime $TEST_DIR`
+    if [ $base_atime -ne $atime -o $base_ctime -eq $ctime -o $base_mtime -ne $mtime ]; then
+       echo "set_xattr expected updated ctime: $base_ctime != $ctime and same mtime: $base_mtime == $mtime, atime: $base_atime == $atime"
+       return 1
+    fi
+    base_ctime=$ctime
+    sleep 2
+
+    #
+    # touch -> update ctime/atime/mtime
+    #
+    touch $TEST_DIR
+    atime=`get_atime $TEST_DIR`
+    ctime=`get_ctime $TEST_DIR`
+    mtime=`get_mtime $TEST_DIR`
+    if [ $base_atime -eq $atime -o $base_ctime -eq $ctime -o $base_mtime -eq $mtime ]; then
+       echo "touch expected updated ctime: $base_ctime != $ctime, mtime: $base_mtime != $mtime, atime: $base_atime != $atime"
+       return 1
+    fi
+    base_atime=$atime
+    base_mtime=$mtime
+    base_ctime=$ctime
+    sleep 2
+
+    #
+    # "touch -a" -> update ctime/atime, not update mtime
+    #
+    touch -a $TEST_DIR
+    atime=`get_atime $TEST_DIR`
+    ctime=`get_ctime $TEST_DIR`
+    mtime=`get_mtime $TEST_DIR`
+    if [ $base_atime -eq $atime -o $base_ctime -eq $ctime -o $base_mtime -ne $mtime ]; then
+       echo "touch with -a option expected updated ctime: $base_ctime != $ctime, atime: $base_atime != $atime and same mtime: $base_mtime == $mtime"
+       return 1
+    fi
+    base_atime=$atime
+    base_ctime=$ctime
+    sleep 2
+
+    #
+    # mv -> update ctime, not update atime/mtime for taget directory
+    #       not update any for sub-directory and a file
+    #
+    TIME_TEST_DIR=timetestdir
+    TIME2_TEST_SUBDIR="$TIME_TEST_DIR/testsubdir"
+    TIME2_TEST_FILE_INDIR="$TIME_TEST_DIR/testfile"
+    mv $TEST_DIR $TIME_TEST_DIR
+    atime=`get_atime $TIME_TEST_DIR`
+    ctime=`get_ctime $TIME_TEST_DIR`
+    mtime=`get_mtime $TIME_TEST_DIR`
+    if [ $base_atime -ne $atime -o $base_ctime -eq $ctime -o $base_mtime -ne $mtime ]; then
+       echo "mv expected updated ctime: $base_ctime != $ctime and same mtime: $base_mtime == $mtime, atime: $base_atime == $atime"
+       return 1
+    fi
+    atime=`get_atime $TIME2_TEST_SUBDIR`
+    ctime=`get_ctime $TIME2_TEST_SUBDIR`
+    mtime=`get_mtime $TIME2_TEST_SUBDIR`
+    if [ $subdir_atime -ne $atime -o $subdir_ctime -ne $ctime -o $subdir_mtime -ne $mtime ]; then
+       echo "mv for sub-directory expected same ctime: $subdir_ctime == $ctime, mtime: $subdir_mtime == $mtime, atime: $subdir_atime == $atime"
+       return 1
+    fi
+    atime=`get_atime $TIME2_TEST_FILE_INDIR`
+    ctime=`get_ctime $TIME2_TEST_FILE_INDIR`
+    mtime=`get_mtime $TIME2_TEST_FILE_INDIR`
+    if [ $subfile_atime -ne $atime -o $subfile_ctime -ne $ctime -o $subfile_mtime -ne $mtime ]; then
+       echo "mv for a file in directory expected same ctime: $subfile_ctime == $ctime, mtime: $subfile_mtime == $mtime, atime: $subfile_atime == $atime"
+       return 1
+    fi
+
+    rm -r $TIME_TEST_DIR
 }
 
 function test_rm_rf_dir {
@@ -1080,6 +1289,7 @@ function add_all_tests {
     add_tests test_extended_attributes
     add_tests test_mtime_file
     add_tests test_update_time
+    add_tests test_update_directory_time
     add_tests test_rm_rf_dir
     add_tests test_copy_file
     add_tests test_write_after_seek_ahead

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -269,6 +269,14 @@ function get_mtime() {
     fi
 }
 
+function get_atime() {
+    if [ `uname` = "Darwin" ]; then
+        stat -f "%a" "$1"
+    else
+        stat -c "%X" "$1"
+    fi
+}
+
 function get_permissions() {
     if [ `uname` = "Darwin" ]; then
         stat -f "%p" "$1"


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Added access time (a time) just like a normal file system.  

I also reviewed the atime/ctime/mtime update patterns and made them the same as regular filesystems.  
(Currently, those update patterns are not the same as normal file operations.)  

The test case has been modified and the update of atime/mtime/ctime is regulated as follows according to the command.
- create file or `touch`  
update ctime, atime and mtime with same time value.
- `touch -a`  
update ctime and atime with same time value, mtime is kept.
- write file (ex. `echo *** > file`)  
update ctime and mtime with same time value, atime is kept.
- update attributes (ex. `chmod`)  
update only ctime, atime and mtime are kept.
- copy file with attributes (ex. `cp -p **** ****`)  
update only ctime, atime and mtime are kept.
- move file (ex. `mv **** ****`)  
update only ctime, atime and mtime are kept.

_This fix and current code do not support updating the stat time of the parent directory of the file which is updated._
_Further consideration is needed to support this, and it can be difficult to achieve._
_Because, if operating the file, PUT request etc will be called to update the parent directory(object), which causes problems with performance and the number of requests._
