### PR TITLE
Protect curl_warnings_once with a mutex

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -108,6 +108,8 @@ class S3fsCurl
         };
 
         // class variables
+        static pthread_mutex_t  curl_warnings_lock;
+        static bool             curl_warnings_once;  // emit older curl warnings only once
         static pthread_mutex_t  curl_handles_lock;
         static struct callback_locks_t {
             pthread_mutex_t dns;


### PR DESCRIPTION
This allows ThreadSanitizer to run without warnings.