### PR TITLE
Fixed flushing dirty data and compressed the cache size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ AC_PROG_CC
 AC_CHECK_HEADERS([sys/xattr.h])
 AC_CHECK_HEADERS([attr/xattr.h])
 AC_CHECK_HEADERS([sys/extattr.h])
+AC_CHECK_FUNCS([fallocate])
 
 CXXFLAGS="$CXXFLAGS -Wall -fno-exceptions -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2"
 

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -117,6 +117,7 @@ class FdEntity
         ssize_t Write(const char* bytes, off_t start, size_t size);
 
         bool ReserveDiskSpace(off_t size);
+        bool PunchHole(off_t start = 0, size_t size = 0);
 };
 
 typedef std::map<std::string, class FdEntity*> fdent_map_t;   // key=path, value=FdEntity*

--- a/src/fdcache_page.h
+++ b/src/fdcache_page.h
@@ -109,6 +109,7 @@ class PageList
         off_t GetTotalUnloadedPageSize(off_t start = 0, off_t size = 0) const;    // size=0 is checking to end of list
         int GetUnloadedPages(fdpage_list_t& unloaded_list, off_t start = 0, off_t size = 0) const;  // size=0 is checking to end of list
         bool GetPageListsForMultipartUpload(fdpage_list_t& dlpages, fdpage_list_t& mixuppages, off_t max_partsize);
+        bool GetNoDataPageLists(fdpage_list_t& nodata_pages, off_t start = 0, size_t size = 0);
 
         off_t BytesModified() const;
         bool IsModified() const;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1448 

### Details
Regarding the process when the max_dirty_data option is specified(the process of uploading while writing a file), the following two have been modified.

#### Fixed a bug
Changed the buffer that stores the return value when uploading(Flush) during the processing of s3fs_write.  
The return value of the s3fs_write function must be the number of bytes written, so it returned the wrong value(error code).  
Due to this, there were cases where uploading could not be performed normally.  

#### Cache file compression
In the process by max_dirty_data option, when uploading while writing the file, the contents of the cache file remained as it was.  
If it remains, it will take up disk space.  
After uploading, new code punches a HOLE in the cache file so that it clears blocks on the hard disk for cached data.  
This will minimize disk space pressure when uploading with max_dirty_data option.  

##### Cache file state when max_dirty_data option is **not specified**
- Cache file status(if uploading 66000044 bytes)  
```
644532 -rw------- 1 guest users 660000044 Nov  3 05:20 big.txt
```
- Cache file stat information (`.<Bucketname>/big.txt`)  
```
1351054:660000044
0:660000044:1:0
```
##### Cache file state when max_dirty_data option is **specified**
- Cache file status(if uploading 66000044 bytes)  
```
25012 -rw------- 1 guest users 660000044 Nov  3 05:20 big.txt
```
- Cache file stat information (`.<Bucketname>/big.txt`)  
```
1351054:660000044
0:634388480:0:0
634388480:25611564:1:0
```

In this way, the disk space is not used except for the last uploaded area.  

##### Notes
The fallocate() function is used for this process, and this function is a non-portable Linux-specific system call.  
Therefore, this function does not exist except on Linux base(ex: OSX).  
To avoid this, I check the fallocate function in configure and implement a dummy function if it does not exist.  
The dummy function is always failing and does not compress the cache file.  
This is a limitation on OSX etc.  