### PR TITLE
Fix directory authority

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2422,12 +2422,12 @@ static int s3fs_opendir(const char* _path, struct fuse_file_info* fi)
 {
     WTF8_ENCODE(path)
     int result;
-    int mask = (O_RDONLY != (fi->flags & O_ACCMODE) ? W_OK : R_OK) | X_OK;
+    int mask = (O_RDONLY != (fi->flags & O_ACCMODE) ? W_OK : R_OK);
 
     S3FS_PRN_INFO("[path=%s][flags=0x%x]", path, fi->flags);
 
     if(0 == (result = check_object_access(path, mask, NULL))){
-        result = check_parent_object_access(path, mask);
+        result = check_parent_object_access(path, X_OK);
     }
     S3FS_MALLOCTRIM(0);
 
@@ -2575,7 +2575,7 @@ static int s3fs_readdir(const char* _path, void* buf, fuse_fill_dir_t filler, of
 
     S3FS_PRN_INFO("[path=%s]", path);
 
-    if(0 != (result = check_object_access(path, X_OK, NULL))){
+    if(0 != (result = check_object_access(path, R_OK, NULL))){
         return result;
     }
 


### PR DESCRIPTION
### Relevant Issue (if applicable)

Non-root user can't access mounted s3fs directory when parent directory have only executable bit and current directory have readable bit.
"ls" command failed with "Operation not permitted".

### Details

#### Directory Configuration
```
parent_dir(mode 0111)
  read_only_dir(mode 0444)
    txt(normal file)
```

First of all change current directory to parent_dir

#### XFS(use normal vfs)
```
[parent_dir]$ \ls                           
ls: cannot open directory .: Permission denied   
[parent_dir]$ \ls read_only_dir                   
txt                                                                
[parent_dir]$ \ls read_only_dir/txt               
ls: cannot access read_only_dir/txt: Permission denied                                                           
```

#### s3fs(change before)
```
[parent_dir]$ \ls                                     
ls: cannot open directory .: Permission denied                        
[parent_dir]$ \ls read_only_dir                      
ls: cannot open directory read_only_dir: Operation not permitted      
[parent_dir]$ \ls read_only_dir/txt                  
ls: cannot access read_only_dir/txt: Operation not permitted          
```

#### s3fs(change after)
```
[parent_dir]$ ls                           
ls: cannot open directory .: Permission denied              
[parent_dir]$ \ls read_only_dir            
txt                                                         
[parent_dir]$ \ls read_only_dir/txt        
ls: cannot access read_only_dir/txt: Operation not permitted
```
