### PR TITLE
Fixed .gitignore for src/test_string_util.cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ missing
 *.trs
 default_commit_hash
 src/s3fs
-src/test_*
+src/test_string_util
 test/s3proxy-*
 
 #


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
src/test_string_util.cpp should be excluded in .gitignore.
