### PR TITLE
Fixed errors detected by cppcheck 2.2

### DIFF
--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -76,6 +76,8 @@ struct curl_slist* curl_slist_sort_insert(struct curl_slist* list, const char* k
     }
     new_item->next = NULL;
 
+    // cppcheck-suppress unmatchedSuppression
+    // cppcheck-suppress nullPointerRedundantCheck
     for(lastpos = NULL, curpos = list; curpos; lastpos = curpos, curpos = curpos->next){
         std::string strcur = curpos->data;
         size_t pos;


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Fixed an error detected by cppcheck 2.2.
Errors detected in curl_utils.cpp: nullPointerRedundantCheck is probably a false positive.
I have set the pointer of the variable of etaglist_t to add_etag_list (), but an error was output because it is an auto variable.
For this error, To fix this the memory is allocated and a variable pointer is passed.