### PR TITLE
Changed a condition of the atime test(fixed #1477)

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -672,7 +672,7 @@ function test_update_time() {
     #
     # "touch -a" -> update ctime/atime, not update mtime
     #
-    if ! cat /proc/mounts | grep "^s3fs $TEST_BUCKET_MOUNT_POINT_1 " | grep -e noatime -e relatime >/dev/null; then
+    if ! cat /proc/mounts | grep "^s3fs " | grep "$TEST_BUCKET_MOUNT_POINT_1 " | grep -e noatime -e relatime >/dev/null; then
         touch -a $TEST_TEXT_FILE
         atime=`get_atime $TEST_TEXT_FILE`
         ctime=`get_ctime $TEST_TEXT_FILE`
@@ -820,7 +820,7 @@ function test_update_directory_time() {
     #
     # "touch -a" -> update ctime/atime, not update mtime
     #
-    if ! cat /proc/mounts | grep "^s3fs $TEST_BUCKET_MOUNT_POINT_1 " | grep -e noatime -e relatime >/dev/null; then
+    if ! cat /proc/mounts | grep "^s3fs " | grep "$TEST_BUCKET_MOUNT_POINT_1 " | grep -e noatime -e relatime >/dev/null; then
         touch -a $TEST_DIR
         atime=`get_atime $TEST_DIR`
         ctime=`get_ctime $TEST_DIR`


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1477

### Details
The conditions added in #1477 were too strict.
Since the mount path may be a relative path, the grep parameters used in the condition have been separated.

@gaul This is a slight change to the condition modified in #1477.

