### PR TITLE
Added Github Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,197 @@
+#
+# s3fs - FUSE-based file system backed by Amazon S3
+#
+# Copyright(C) 2007 Takeshi Nakatani <ggtakec.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+name: s3fs-fuse CI
+
+on:
+  push:
+  pull_request:
+  #
+  # CRON event is fire on every sunday(UTC).
+  #
+  schedule:
+    - cron: '0 0 * * 0'
+
+#
+# Jobs
+#
+# [NOTE]
+# Some tests using awscli may output a python warning.
+# The warning is about HTTPS connections using self-signed certificates.
+# That's why the PYTHONWARNINGS environment variable disables the
+# "Unverified HTTPS request" warning.
+#
+jobs:
+  Linux:
+    runs-on: ubuntu-latest
+
+    #
+    # build matrix for containers
+    #
+    strategy:
+      #
+      # do not stop jobs automatically if any of the jobs fail
+      #
+      fail-fast: false
+
+      #
+      # matrix for containers
+      #
+      matrix:
+        container:
+          - ubuntu:20.04
+          - ubuntu:18.04
+          - ubuntu:16.04
+          - debian:buster
+          - debian:stretch
+          - centos:centos8
+          - centos:centos7
+          - fedora:32
+          - fedora:31
+          - opensuse/leap:15
+
+    container:
+      image: ${{ matrix.container }}
+
+      options: "--privileged --cap-add SYS_ADMIN --device /dev/fuse"
+
+    env:
+      # [NOTE]
+      # Installation special environment variables for debian and ubuntu.
+      #
+      DEBIAN_FRONTEND:  noninteractive
+
+      # [NOTE]
+      # Since using a self-signed certificate and have not registered a certificate authority,
+      # we get a warning in python, so we suppress it(by PYTHONWARNINGS).
+      #
+      PYTHONWARNINGS:   "ignore:Unverified HTTPS request"
+
+    steps:
+      # [NOTE]
+      # On openSUSE, tar and gzip must be installed before action/checkout.
+      #
+      - name: Install packages before checkout
+        run: |
+          if [ "${{ matrix.container }}" = "opensuse/leap:15" ]; then zypper install -y tar gzip; fi
+
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      # [NOTE]
+      # Matters that depend on OS:VERSION are determined and executed in the following script.
+      # Please note that the option to configure (CONFIGURE_OPTIONS) is set in the environment variable.
+      #
+      - name: Install pacakagse
+        run: |
+          .github/workflows/linux-ci-helper.sh ${{ matrix.container }}
+
+      - name: Build
+        run: |
+          ./autogen.sh
+          /bin/sh -c "./configure ${CONFIGURE_OPTIONS}"
+          make
+
+      - name: Cppcheck
+        run: |
+          make cppcheck
+
+      - name: Test suite
+        run: |
+          make check -C test || (test/filter-suite-log.sh test/test-suite.log; exit 1)
+
+
+  # [NOTE]
+  # A case of "runs-on: macos-11.0" does not work,
+  # becase load_osxfuse returns exit code = 1.
+  # Maybe it needs to reboot. Apple said 
+  # "Installing a new kernel extension requires signing in as an Admin user. You must also restart your Mac to load the extension".
+  # Then we do not use macos 11 on Github Actions now.
+  #
+  macos10:
+    runs-on: macos-10.15
+
+    env:
+      # [NOTE]
+      # Since using a self-signed certificate and have not registered a certificate authority,
+      # we get a warning in python, so we suppress it(by PYTHONWARNINGS).
+      #
+      PYTHONWARNINGS:   "ignore:Unverified HTTPS request"
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Brew tap
+        run: |
+          TAPS="$(brew --repository)/Library/Taps";
+          if [ -e "$TAPS/caskroom/homebrew-cask" ]; then rm -rf "$TAPS/caskroom/homebrew-cask"; fi;
+          if [ ! -f $HOME/.osx_cache/cached ]; then HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/homebrew-cask; else HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/homebrew-cask; fi
+
+      - name: Install osxfuse
+        run: |
+          HOMEBREW_NO_AUTO_UPDATE=1 brew cask install osxfuse
+
+      - name: Install brew other packages
+        run: |
+          S3FS_BREW_PACKAGES='automake cppcheck python3 coreutils';
+          for s3fs_brew_pkg in ${S3FS_BREW_PACKAGES}; do if brew list | grep -q ${s3fs_brew_pkg}; then if brew outdated | grep -q ${s3fs_brew_pkg}; then HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade ${s3fs_brew_pkg}; fi; else HOMEBREW_NO_AUTO_UPDATE=1 brew install ${s3fs_brew_pkg}; fi; done;
+
+      - name: Install awscli
+        run: |
+          if pip3 --version; then pip3 install awscli; else curl https://bootstrap.pypa.io/get-pip.py | sudo python; pip install awscli --ignore-installed matplotlib; fi
+
+      - name: Check osxfuse permission
+        run: |
+          if [ -f /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ]; then sudo chmod +s /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs; elif [ -f /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ]; then sudo chmod +s /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse; else exit 1; fi
+
+      - name: Check truncate
+        run: |
+          if [ ! -f /usr/local/bin/truncate ]; then sudo ln -s /usr/local/opt/coreutils/bin/gtruncate /usr/local/bin/truncate; fi
+
+      - name: Check stdbuf
+        run: |
+          if [ ! -f /usr/local/bin/stdbuf ]; then sudo ln -s /usr/local/opt/coreutils/bin/gstdbuf /usr/local/bin/stdbuf; fi
+
+      - name: Build
+        run: |
+          ./autogen.sh
+          PKG_CONFIG_PATH=/usr/local/opt/curl/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig ./configure CXXFLAGS='-std=c++03 -DS3FS_PTHREAD_ERRORCHECK=1'
+          make
+
+      - name: Cppcheck
+        run: |
+          make cppcheck
+
+      - name: Test suite
+        run: |
+          make check -C src
+          echo "user_allow_other" | sudo tee -a /etc/fuse.conf >/dev/null
+          if [ -f /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ]; then /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs; elif [ -f /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ]; then /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse; else exit 1; fi
+          make check -C test || (test/filter-suite-log.sh test/test-suite.log; exit 1)
+
+#
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: expandtab sw=4 ts=4 fdm=marker
+# vim<600: expandtab sw=4 ts=4
+#

--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -1,0 +1,217 @@
+#!/bin/sh
+#
+# s3fs - FUSE-based file system backed by Amazon S3
+#
+# Copyright(C) 2007 Takeshi Nakatani <ggtakec.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+echo "${PRGNAME} [INFO] Start Linux helper for installing packages."
+
+#-----------------------------------------------------------
+# Common variables
+#-----------------------------------------------------------
+PRGNAME=`basename $0`
+
+#-----------------------------------------------------------
+# Parameter check
+#-----------------------------------------------------------
+#
+# Usage: ${PRGNAME} "OS:VERSION"
+#
+if [ $# -ne 1 ]; then
+    echo "${PRGNAME} [ERROR] No container name options specified."
+fi
+
+#-----------------------------------------------------------
+# Container OS variables
+#-----------------------------------------------------------
+CONTAINER_FULLNAME=$1
+CONTAINER_OSNAME=`echo ${CONTAINER_FULLNAME} | sed 's/:/ /g' | awk '{print $1}'`
+CONTAINER_OSVERSION=`echo ${CONTAINER_FULLNAME} | sed 's/:/ /g' | awk '{print $2}'`
+
+#-----------------------------------------------------------
+# Common variables for pip
+#-----------------------------------------------------------
+PIP_BIN="pip3"
+PIP_OPTIONS="--upgrade"
+INSTALL_AWSCLI_PACKAGES="awscli"
+
+#-----------------------------------------------------------
+# Parameters for configure(set environments)
+#-----------------------------------------------------------
+CONFIGURE_OPTIONS="CXXFLAGS='-std=c++11 -DS3FS_PTHREAD_ERRORCHECK=1' --prefix=/usr --with-openssl"
+
+#-----------------------------------------------------------
+# OS dependent variables
+#-----------------------------------------------------------
+if [ "${CONTAINER_FULLNAME}" = "ubuntu:20.04" ]; then
+    PACKAGE_MANAGER_BIN="apt-get"
+    PACKAGE_UPDATE_OPTIONS="update -y -qq"
+
+    INSTALL_PACKAGES="autoconf autotools-dev fuse libfuse-dev libcurl4-openssl-dev libxml2-dev mime-support libtool pkg-config libssl-dev attr wget python2 python3-pip"
+    INSTALL_CPPCHECK_OPTIONS=""
+    INSTALL_JDK_PACKAGES="openjdk-8-jdk"
+
+elif [ "${CONTAINER_FULLNAME}" = "ubuntu:18.04" ]; then
+    PACKAGE_MANAGER_BIN="apt-get"
+    PACKAGE_UPDATE_OPTIONS="update -y -qq"
+
+    INSTALL_PACKAGES="autoconf autotools-dev fuse libfuse-dev libcurl4-openssl-dev libxml2-dev mime-support libtool pkg-config libssl-dev attr wget python3-pip"
+    INSTALL_CPPCHECK_OPTIONS=""
+    INSTALL_JDK_PACKAGES="openjdk-8-jdk"
+
+elif [ "${CONTAINER_FULLNAME}" = "ubuntu:16.04" ]; then
+    PACKAGE_MANAGER_BIN="apt-get"
+    PACKAGE_UPDATE_OPTIONS="update -y -qq"
+
+    INSTALL_PACKAGES="autoconf autotools-dev fuse libfuse-dev libcurl4-openssl-dev libxml2-dev mime-support libtool pkg-config libssl-dev attr wget python3-pip"
+    INSTALL_CPPCHECK_OPTIONS=""
+    INSTALL_JDK_PACKAGES="openjdk-8-jdk"
+
+elif [ "${CONTAINER_FULLNAME}" = "debian:buster" ]; then
+    PACKAGE_MANAGER_BIN="apt-get"
+    PACKAGE_UPDATE_OPTIONS="update -y -qq"
+
+    INSTALL_PACKAGES="autoconf autotools-dev fuse libfuse-dev libcurl4-openssl-dev libxml2-dev mime-support libtool pkg-config libssl-dev attr wget python2 procps python3-pip"
+    INSTALL_CPPCHECK_OPTIONS=""
+    INSTALL_JDK_PACKAGES="adoptopenjdk-8-hotspot"
+
+elif [ "${CONTAINER_FULLNAME}" = "debian:stretch" ]; then
+    PACKAGE_MANAGER_BIN="apt-get"
+    PACKAGE_UPDATE_OPTIONS="update -y -qq"
+
+    INSTALL_PACKAGES="autoconf autotools-dev fuse libfuse-dev libcurl4-openssl-dev libxml2-dev mime-support libtool pkg-config libssl-dev attr wget procps python3-pip"
+    INSTALL_CPPCHECK_OPTIONS=""
+    INSTALL_JDK_PACKAGES="openjdk-8-jdk"
+
+elif [ "${CONTAINER_FULLNAME}" = "centos:centos8" ]; then
+    PACKAGE_MANAGER_BIN="dnf"
+    PACKAGE_UPDATE_OPTIONS="update -y -qq"
+
+    INSTALL_PACKAGES="gcc libstdc++-devel gcc-c++ fuse fuse-devel curl-devel libxml2-devel mailcap git automake make openssl-devel attr diffutils wget python2 python3"
+    INSTALL_CPPCHECK_OPTIONS="--enablerepo=PowerTools"
+    INSTALL_JDK_PACKAGES="java-1.8.0-openjdk"
+
+    # [NOTE]
+    # Add -O2 to prevent the warning '_FORTIFY_SOURCE requires compiling with optimization(-O)'.
+    #
+    CONFIGURE_OPTIONS="CXXFLAGS='-O2 -std=c++11 -DS3FS_PTHREAD_ERRORCHECK=1' --prefix=/usr --with-openssl"
+
+elif [ "${CONTAINER_FULLNAME}" = "centos:centos7" ]; then
+    PACKAGE_MANAGER_BIN="yum"
+    PACKAGE_UPDATE_OPTIONS="update -y"
+
+    INSTALL_PACKAGES="gcc libstdc++-devel gcc-c++ fuse fuse-devel curl-devel libxml2-devel mailcap git automake make openssl-devel attr wget python3 epel-release"
+    INSTALL_CPPCHECK_OPTIONS="--enablerepo=epel"
+    INSTALL_JDK_PACKAGES="java-1.8.0-openjdk"
+
+    # [NOTE]
+    # Add -O2 to prevent the warning '_FORTIFY_SOURCE requires compiling with optimization(-O)'.
+    #
+    CONFIGURE_OPTIONS="CXXFLAGS='-O2 -std=c++11 -DS3FS_PTHREAD_ERRORCHECK=1' --prefix=/usr --with-openssl"
+
+elif [ "${CONTAINER_FULLNAME}" = "fedora:32" ]; then
+    PACKAGE_MANAGER_BIN="dnf"
+    PACKAGE_UPDATE_OPTIONS="update -y -qq"
+
+    INSTALL_PACKAGES="gcc libstdc++-devel gcc-c++ fuse fuse-devel curl-devel libxml2-devel mailcap git automake make openssl-devel wget attr diffutils python2 procps python3-pip"
+    INSTALL_CPPCHECK_OPTIONS=""
+    INSTALL_JDK_PACKAGES="java-1.8.0-openjdk"
+
+elif [ "${CONTAINER_FULLNAME}" = "fedora:31" ]; then
+    PACKAGE_MANAGER_BIN="dnf"
+    PACKAGE_UPDATE_OPTIONS="update -y -qq"
+
+    INSTALL_PACKAGES="gcc libstdc++-devel gcc-c++ fuse fuse-devel curl-devel libxml2-devel mailcap git automake make openssl-devel wget attr python2 procps"
+    INSTALL_CPPCHECK_OPTIONS=""
+    INSTALL_JDK_PACKAGES="java-1.8.0-openjdk"
+
+elif [ "${CONTAINER_FULLNAME}" = "opensuse/leap:15" ]; then
+    PACKAGE_MANAGER_BIN="zypper"
+    PACKAGE_UPDATE_OPTIONS="refresh"
+
+    INSTALL_PACKAGES="automake curl-devel fuse fuse-devel gcc-c++ libxml2-devel make openssl-devel python3-pip wget attr"
+    INSTALL_CPPCHECK_OPTIONS=""
+    INSTALL_JDK_PACKAGES="java-1_8_0-openjdk"
+
+else
+    exit 1
+fi
+
+#-----------------------------------------------------------
+# Install
+#-----------------------------------------------------------
+#
+# Update packages (ex. apt-get update -y -qq)
+#
+echo "${PRGNAME} [INFO] Updates."
+${PACKAGE_MANAGER_BIN} ${PACKAGE_UPDATE_OPTIONS}
+
+#
+# Install pacakages ( with cppcheck )
+#
+echo "${PRGNAME} [INFO] Install packages."
+${PACKAGE_MANAGER_BIN} install -y ${INSTALL_PACKAGES}
+
+echo "${PRGNAME} [INFO] Install cppcheck package."
+${PACKAGE_MANAGER_BIN} ${INSTALL_CPPCHECK_OPTIONS} install -y cppcheck
+
+#
+# Install JDK 1.8
+#
+# [NOTE]
+# Now, the previous Java LTS version 8 is not available in the official Debian Buster repositories.
+# It'll enable the AdoptOpenJDK repository, which provides prebuilt OpenJDK packages.
+#
+echo "${PRGNAME} [INFO] Install JDK 1.8 package."
+if [ "${CONTAINER_FULLNAME}" != "debian:buster" ]; then
+    ${PACKAGE_MANAGER_BIN} install -y ${INSTALL_JDK_PACKAGES}
+else
+    # [NOTE]
+    # Debian Buster is special case for installing JDK.
+    #
+    ${PACKAGE_MANAGER_BIN} install -y apt-transport-https ca-certificates dirmngr gnupg software-properties-common
+    wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
+    add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+    ${PACKAGE_MANAGER_BIN} ${PACKAGE_UPDATE_OPTIONS}
+    ${PACKAGE_MANAGER_BIN} install -y ${INSTALL_JDK_PACKAGES}
+fi
+java -version
+
+#
+# Install awscli
+#
+echo "${PRGNAME} [INFO] Install awscli package."
+${PIP_BIN} install ${PIP_OPTIONS} ${INSTALL_AWSCLI_PACKAGES}
+
+#-----------------------------------------------------------
+# Set environment for configure
+#-----------------------------------------------------------
+echo "${PRGNAME} [INFO] Set environment for configure options"
+export CONFIGURE_OPTIONS
+
+echo "${PRGNAME} [INFO] Finish Linux helper for installing packages."
+exit 0
+
+#
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: expandtab sw=4 ts=4 fdm=marker
+# vim<600: expandtab sw=4 ts=4
+#


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1488 

### Details
This PR adds a Github Actions workflow for testing on 11 OS(version).

We have only 2 operating systems on TravisCI, but this PR(Github Actions) can build and test on the following operating systems.
- Ubuntu 20.04/18.04/16.04
- Debian 10(buster)/9(stretch)
- CentOS 8/9
- Fedora 32/31
- openSUSE Leap 15
- macos 10

### Notes
- macos11 is not supported as it requires a reboot after installing osx fuse.
- Added Debian/CentOS/Fedora/OpenSUSE.
- All test use JDK1.8.

@juliogonzalez If you can, please give me comments about OpenSUSE.
@gaul Please check about JDK.

This PR is only tested on Travis CI, not on Github Actions. It will be tested after being merged.
(This PR source code has passed the test on my repository's Github Actions)
