### PR TITLE
fix 404 error message

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3486,7 +3486,7 @@ static int s3fs_check_service()
                 S3FS_PRN_CRIT("invalid credentials(host=%s) - result of checking service.", s3host.c_str());
 
             }else if(responseCode == 404){
-                S3FS_PRN_CRIT("bucket not found(host=%s) - result of checking service.", s3host.c_str());
+                S3FS_PRN_CRIT("bucket or key not found(host=%s) - result of checking service.", s3host.c_str());
 
             }else{
                 // another error


### PR DESCRIPTION
### Relevant Issue
* #1377

### Details
AWS can return an explicit 404 message that says that the key doesn't exist:

```
[INF]       curl.cpp:RequestPerform(2441): HTTP response code 404 was returned, returning ENOENT
[ERR] curl.cpp:CheckBucket(3439): Check bucket failed, S3 response: <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>my-key/</Key><RequestId>F571C209C9ACA4FC</RequestId><HostId>SBKSxWs3ULB8R8ev....</HostId></Error>
[CRT] s3fs.cpp:s3fs_check_service(3901): bucket not found(host=https://s3.amazonaws.com) - result of checking service.
[
```

It would be great if the message provided by AWS could be printed to the user as well, but I've no idea about how to that in C++.