### PR TITLE
Update README for change in brew arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Many systems provide pre-built packages:
 * macOS via [Homebrew](https://brew.sh/):
 
   ```
-  brew cask install osxfuse
+  brew install --cask osxfuse
   brew install s3fs
   ```
 


### PR DESCRIPTION
Homebrew changed the arguments required to install casks. 

* Previously, `brew cask install <package>` was the correct syntax, 
* But now it's `brew install --cask <package>`. 

This small commit updates the README for installing `osxfuse` to reflect this change.

This is the output when following the README in the current master:

```
$ brew cask install osxfuse
Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
```

### Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

### Details
_Please describe the details of PullRequest._
