### PR TITLE
Retry failed may load bad page

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -723,6 +723,12 @@ bool S3fsCurl::SetDnsCache(bool isCache)
     return old;
 }
 
+void S3fsCurl::ResetOffset(S3fsCurl* pCurl)
+{
+    pCurl->partdata.startpos = pCurl->b_partdata_startpos;
+    pCurl->partdata.size     = pCurl->b_partdata_size;
+}
+
 bool S3fsCurl::SetSslSessionCache(bool isCache)
 {
     bool old = S3fsCurl::is_ssl_session_cache;
@@ -1465,6 +1471,7 @@ S3fsCurl* S3fsCurl::ParallelGetObjectRetryCallback(S3fsCurl* s3fscurl)
 
     // duplicate request(setup new curl object)
     S3fsCurl* newcurl = new S3fsCurl(s3fscurl->IsUseAhbe());
+    
     if(0 != (result = newcurl->PreGetObjectRequest(s3fscurl->path.c_str(), s3fscurl->partdata.fd, s3fscurl->partdata.startpos, s3fscurl->partdata.size, s3fscurl->b_ssetype, s3fscurl->b_ssevalue))){
         S3FS_PRN_ERR("failed downloading part setup(%d)", result);
         delete newcurl;
@@ -2243,7 +2250,7 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
         curl_easy_setopt(hCurl, CURLOPT_HTTPHEADER, requestHeaders);
 
         // Requests
-        CURLcode curlCode = curl_easy_perform(hCurl);
+        curlCode = curl_easy_perform(hCurl);
 
         // Check result
         switch(curlCode){

--- a/src/curl.h
+++ b/src/curl.h
@@ -198,7 +198,8 @@ class S3fsCurl
         pthread_mutex_t      *completed_tids_lock;
         std::vector<pthread_t> *completed_tids;
         s3fscurl_lazy_setup  fpLazySetup;          // curl options for lazy setting function
-
+        CURLcode             curlCode;             // handle curl return
+    
     public:
         static const long S3FSCURL_RESPONSECODE_NOTSET      = -1;
         static const long S3FSCURL_RESPONSECODE_FATAL_ERROR = -2;
@@ -333,6 +334,7 @@ class S3fsCurl
         }
         static long SetSslVerifyHostname(long value);
         static long GetSslVerifyHostname() { return S3fsCurl::ssl_verify_hostname; }
+        static void ResetOffset(S3fsCurl* pCurl);
         // maximum parallel GET and PUT requests
         static int SetMaxParallelCount(int value);
         static int GetMaxParallelCount() { return S3fsCurl::max_parallel_cnt; }
@@ -398,6 +400,7 @@ class S3fsCurl
         headers_t* GetResponseHeaders() { return &responseHeaders; }
         BodyData* GetBodyData() { return &bodydata; }
         BodyData* GetHeadData() { return &headdata; }
+        CURLcode GetCurlCode() const { return curlCode; }
         long GetLastResponseCode() const { return LastResponseCode; }
         bool SetUseAhbe(bool ahbe);
         bool EnableUseAhbe() { return SetUseAhbe(true); }


### PR DESCRIPTION
### Relevant Issue (if applicable)
In MultRead, If Any retry failed. And curl return no OK(such like WRITE ERROR eg.), MultiRead may return 0 and fd may load this page.
But this page is bad. if request include 403、5xx、Partical File(Read Timeout?Connection loss), And next retry is not CURLE_OK, The 403 data may insert into part head and be set loaded(I think we need overwrite it but not loaded).

### Details

### Another issue?
1. Multi retry may more large. default is 5(MultiRead) x 5(RequestPerfrom) = 25 count.
2. If offset and size is 0, may request all file without range.