### PR TITLE
Remove authorization header when remaking handle

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2065,6 +2065,7 @@ bool S3fsCurl::RemakeHandle()
     }
 
     // reinitialize internal data
+    requestHeaders = curl_slist_remove(requestHeaders, "Authorization");
     responseHeaders.clear();
     bodydata.Clear();
     headdata.Clear();

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -100,6 +100,33 @@ struct curl_slist* curl_slist_sort_insert(struct curl_slist* list, const char* k
     return list;
 }
 
+struct curl_slist* curl_slist_remove(struct curl_slist* list, const char* key)
+{
+    if(!key){
+        return list;
+    }
+
+    std::string strkey = trim(std::string(key));
+    struct curl_slist **p = &list;
+    for(;*p; p = &(*p)->next){
+        std::string strcur = (*p)->data;
+        size_t pos;
+        if(std::string::npos != (pos = strcur.find(':', 0))){
+            strcur = strcur.substr(0, pos);
+        }
+
+        int result = strcasecmp(strkey.c_str(), strcur.c_str());
+        if(0 == result){
+            free((*p)->data);
+            struct curl_slist *tmp = *p;
+            *p = (*p)->next;
+            free(tmp);
+        }
+    }
+
+    return list;
+}
+
 std::string get_sorted_header_keys(const struct curl_slist* list)
 {
     std::string sorted_headers;

--- a/src/curl_util.h
+++ b/src/curl_util.h
@@ -31,6 +31,7 @@ struct sse_type_t;
 std::string GetContentMD5(int fd);
 struct curl_slist* curl_slist_sort_insert(struct curl_slist* list, const char* data);
 struct curl_slist* curl_slist_sort_insert(struct curl_slist* list, const char* key, const char* value);
+struct curl_slist* curl_slist_remove(struct curl_slist* list, const char* key);
 std::string get_sorted_header_keys(const struct curl_slist* list);
 std::string get_canonical_headers(const struct curl_slist* list, bool only_amz = false);
 std::string get_header_value(const struct curl_slist* list, const std::string &key);


### PR DESCRIPTION
This avoids including Authorization in `SignedHeaders`.  s3fs will
recreate the Authorization header before sending the request.