### PR TITLE
Add configuration for Chaos HTTP Proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ default_commit_hash
 src/s3fs
 src/test_curl_util
 src/test_string_util
+test/chaos-http-proxy-*
 test/s3proxy-*
 
 #

--- a/test/chaos-http-proxy.conf
+++ b/test/chaos-http-proxy.conf
@@ -1,0 +1,2 @@
+com.bouncestorage.chaoshttpproxy.http_503=1
+com.bouncestorage.chaoshttpproxy.success=9

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -319,6 +319,19 @@ function aws_cli() {
     aws $* --endpoint-url "${S3_URL}" --no-verify-ssl $FLAGS
 }
 
+function wait_for_port() {
+    PORT=$1
+    for i in $(seq 30); do
+        if exec 3<>"/dev/tcp/127.0.0.1/${PORT}";
+        then
+            exec 3<&-  # Close for read
+            exec 3>&-  # Close for write
+            break
+        fi
+        sleep 1
+    done
+}
+
 #
 # Local variables:
 # tab-width: 4


### PR DESCRIPTION
This can find errors in retry logic.  Chaos HTTP Proxy does not
support SSL bouncestorage/chaos-http-proxy#1 so users must set
`s3proxy.endpoint` and run via:

```
CHAOS_HTTP_PROXY=1 S3_URL=http://127.0.0.1:8080 make check -C test
```

It can also be helpful to increase retries and reduce sleep times.
References #1504.