### PR TITLE
Fixed brew install with cask in github actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Install osxfuse
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew cask install osxfuse
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install osxfuse
 
       - name: Install brew other packages
         run: |


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
When building Github Actions on macOS, the following error may be reported and it may fail.
```
Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
Error: Process completed with exit code 1.
```
If it is reported as a warning, the build is successful.

Then fixed not to specify `cask`.
