### PR TITLE
Re-fix retry logic

### DIFF
--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -106,7 +106,7 @@ function retry {
     status=0
     for i in $(seq $N); do
         echo "Trying: $*"
-        "$@"
+        eval $@
         status=$?
         if [ $status == 0 ]; then
             break
@@ -296,7 +296,7 @@ function stop_s3fs {
     # Retry in case file system is in use
     if [ `uname` = "Darwin" ]; then
         if df | grep -q $TEST_BUCKET_MOUNT_POINT_1; then
-            retry 10 df | grep -q $TEST_BUCKET_MOUNT_POINT_1 && umount $TEST_BUCKET_MOUNT_POINT_1
+            retry 10 df "|" grep -q $TEST_BUCKET_MOUNT_POINT_1 "&&" umount $TEST_BUCKET_MOUNT_POINT_1
         fi
     else
         if grep -q $TEST_BUCKET_MOUNT_POINT_1 /proc/mounts; then 


### PR DESCRIPTION
This logic has always been broken but happened to try one time due to
&& operator precedence.  7158e50ee2b2d48ee2e3724e2f299b4644321aeb
broke this further when quoting && since the command was not
evaluated.