### PR TITLE
Add warning for failing metadata updates of large files

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -729,6 +729,7 @@ int put_headers(const char* path, headers_t& meta, bool is_copy, bool update_mti
     if(buf.st_size >= FIVE_GB){
         // multipart
         if(nocopyapi || nomultipart){
+            S3FS_PRN_WARN("Metadata update failed because the file is larger than 5GB and the options nocopyapi or nomultipart are set: [path=%s]", path);
             return -EFBIG;    // File too large
         }
         if(0 != (result = s3fscurl.MultipartHeadRequest(path, buf.st_size, meta, is_copy))){


### PR DESCRIPTION
Metadata updates fail for large files if "-o nocopyapi" or "-o nomultipart" is set.

This change is related to #1528

### Example
```
# ll bigfile
-rw-r--r-- 1 tcpdump tcpdump 7486832640 Jan 27 11:20 bigfile

# cp -p bigfile /grid/
cp: failed to preserve ownership for "/grid/bigfile": Input/output error
```

### Old debug output w/o warning
```
unique: 114254, opcode: SETATTR (4), nodeid: 2, insize: 128, pid: 26341
chown /bigfile 72 72
[INF] s3fs.cpp:s3fs_chown(1741): [path=/bigfile][uid=72][gid=72]
[...]
[DBG] s3fs.cpp:get_object_attribute(362): [path=/bigfile]
[DBG] cache.cpp:GetStat(293): stat cache hit [path=/bigfile][time=1128915.515422614][hit count=3]
[DBG] fdcache.cpp:Close(592): [ent->file=/bigfile][ent->fd=7]
[DBG] fdcache_entity.cpp:Close(200): [path=/bigfile][fd=7][refcnt=1]
   unique: 114254, error: -5 (Input/output error), outsize: 16
```

### New debug output w/ warning
```
unique: 114249, opcode: SETATTR (4), nodeid: 2, insize: 128, pid: 28319
chown /bigfile 72 72
[INF] s3fs.cpp:s3fs_chown(1742): [path=/bigfile][uid=72][gid=72]
[...]
[DBG] s3fs.cpp:get_object_attribute(362): [path=/bigfile]
[DBG] cache.cpp:GetStat(293): stat cache hit [path=/bigfile][time=1130681.479403969][hit count=3]
[WAN] s3fs.cpp:put_headers(729): Metadata update failed because the file is larger than 5GB and the options nocopyapi or nomultipart are set: [path=/bigfile]
[DBG] fdcache.cpp:Close(592): [ent->file=/bigfile][ent->fd=7]
[DBG] fdcache_entity.cpp:Close(200): [path=/bigfile][fd=7][refcnt=1]
   unique: 114249, error: -5 (Input/output error), outsize: 16
unique: 114250, opcode: FLUSH (25), nodeid: 2, insize: 64, pid: 28319
```