### PR TITLE
Add timestamps to debug log and cache integrity check

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -29,6 +29,7 @@
 #include "s3fs.h"
 #include "fdcache.h"
 #include "s3fs_util.h"
+#include "s3fs_logger.h"
 #include "string_util.h"
 #include "autolock.h"
 
@@ -50,14 +51,14 @@
 // The following symbols are used by FdManager::RawCheckAllCache().
 //
 #define CACHEDBG_FMT_DIR_PROB   "Directory: %s"
-#define CACHEDBG_FMT_HEAD       "------------------------------------------------------------\n" \
-                                "Check cache file and its stats file consistency\n" \
-                                "------------------------------------------------------------"
-#define CACHEDBG_FMT_FOOT       "------------------------------------------------------------\n" \
+#define CACHEDBG_FMT_HEAD       "---------------------------------------------------------------------------\n" \
+                                "Check cache file and its stats file consistency at %s\n"                       \
+                                "---------------------------------------------------------------------------"
+#define CACHEDBG_FMT_FOOT       "---------------------------------------------------------------------------\n" \
                                 "Summary - Total files:                %d\n" \
                                 "          Detected error files:       %d\n" \
                                 "          Detected error directories: %d\n" \
-                                "------------------------------------------------------------"
+                                "---------------------------------------------------------------------------"
 #define CACHEDBG_FMT_FILE_OK    "File:      %s%s    -> [OK] no problem"
 #define CACHEDBG_FMT_FILE_PROB  "File:      %s%s"
 #define CACHEDBG_FMT_DIR_PROB   "Directory: %s"
@@ -905,7 +906,7 @@ bool FdManager::CheckAllCache()
     }
 
     // print head message
-    S3FS_PRN_CACHE(fp, CACHEDBG_FMT_HEAD);
+    S3FS_PRN_CACHE(fp, CACHEDBG_FMT_HEAD, S3fsLog::GetCurrentTime());
 
     // Loop in directory of cache file's stats
     std::string top_path  = CacheFileStat::GetCacheFileStatTopDir();

--- a/src/s3fs_logger.cpp
+++ b/src/s3fs_logger.cpp
@@ -29,11 +29,12 @@
 //-------------------------------------------------------------------
 const int               S3fsLog::NEST_MAX;
 const char*             S3fsLog::nest_spaces[S3fsLog::NEST_MAX] = {"", "  ", "    ", "      "};
-const char*             S3fsLog::LOGFILEENV  = "S3FS_LOGFILE";
-S3fsLog*                S3fsLog::pSingleton  = NULL;
-S3fsLog::s3fs_log_level S3fsLog::debug_level = S3fsLog::LEVEL_CRIT;
-FILE*                   S3fsLog::logfp       = NULL;
-std::string*            S3fsLog::plogfile    = NULL;
+const char*             S3fsLog::LOGFILEENV       = "S3FS_LOGFILE";
+S3fsLog*                S3fsLog::pSingleton       = NULL;
+S3fsLog::s3fs_log_level S3fsLog::debug_level      = S3fsLog::LEVEL_CRIT;
+FILE*                   S3fsLog::logfp            = NULL;
+std::string*            S3fsLog::plogfile         = NULL;
+char                    S3fsLog::current_time[32] = "";
 
 //-------------------------------------------------------------------
 // S3fsLog class : class methods

--- a/src/s3fs_logger.h
+++ b/src/s3fs_logger.h
@@ -23,6 +23,7 @@
 
 #include <cstdio>
 #include <syslog.h>
+#include <sys/time.h>
 
 //-------------------------------------------------------------------
 // S3fsLog class
@@ -46,6 +47,7 @@ class S3fsLog
         static s3fs_log_level debug_level;
         static FILE*          logfp;
         static std::string*   plogfile;
+        static char           current_time[32];
 
     protected:
         bool LowLoadEnv();
@@ -68,6 +70,18 @@ class S3fsLog
                      LEVEL_WARN == (level & LEVEL_DBG) ? LOG_WARNING :
                      LEVEL_ERR  == (level & LEVEL_DBG) ? LOG_ERR     : LOG_CRIT );
         }
+
+    static const char* GetCurrentTime()
+    {
+        struct timeval now;
+        struct tm res;
+        char tmp[32];
+
+        gettimeofday(&now, NULL);
+        strftime(tmp, sizeof(tmp), "%Y-%m-%dT%H:%M:%S", gmtime_r(&now.tv_sec, &res));
+        snprintf(current_time, sizeof(current_time), "%s.%03ldZ", tmp, (now.tv_usec / 1000));
+        return current_time;
+    }
 
         static const char* GetLevelString(s3fs_log_level level)
         {
@@ -132,7 +146,7 @@ class S3fsLog
             if(S3fsLog::IsS3fsLogLevel(level)){ \
                 if(foreground || S3fsLog::IsSetLogFile()){ \
                     S3fsLog::SeekEnd(); \
-                    fprintf(S3fsLog::GetOutputLogFile(), "%s%s:%s(%d): " fmt "%s\n", S3fsLog::GetLevelString(level), __FILE__, __func__, __LINE__, __VA_ARGS__); \
+                    fprintf(S3fsLog::GetOutputLogFile(), "%s %s%s:%s(%d): " fmt "%s\n", S3fsLog::GetCurrentTime(), S3fsLog::GetLevelString(level), __FILE__, __func__, __LINE__, __VA_ARGS__); \
                     S3fsLog::Flush(); \
                 }else{ \
                     syslog(S3fsLog::GetSyslogLevel(level), "%s%s:%s(%d): " fmt "%s", instance_name.c_str(), __FILE__, __func__, __LINE__, __VA_ARGS__); \
@@ -145,7 +159,7 @@ class S3fsLog
             if(S3fsLog::IsS3fsLogLevel(level)){ \
                 if(foreground || S3fsLog::IsSetLogFile()){ \
                     S3fsLog::SeekEnd(); \
-                    fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s:%s(%d): " fmt "%s\n", S3fsLog::GetLevelString(level), S3fsLog::GetS3fsLogNest(nest), __FILE__, __func__, __LINE__, __VA_ARGS__); \
+                    fprintf(S3fsLog::GetOutputLogFile(), "%s %s%s%s:%s(%d): " fmt "%s\n", S3fsLog::GetCurrentTime(), S3fsLog::GetLevelString(level), S3fsLog::GetS3fsLogNest(nest), __FILE__, __func__, __LINE__, __VA_ARGS__); \
                     S3fsLog::Flush(); \
                 }else{ \
                     syslog(S3fsLog::GetSyslogLevel(level), "%s%s" fmt "%s", instance_name.c_str(), S3fsLog::GetS3fsLogNest(nest), __VA_ARGS__); \
@@ -157,7 +171,7 @@ class S3fsLog
         do{ \
             if(foreground || S3fsLog::IsSetLogFile()){ \
                 S3fsLog::SeekEnd(); \
-                fprintf(S3fsLog::GetOutputLogFile(), "[CURL DBG] " fmt "%s\n", __VA_ARGS__); \
+                fprintf(S3fsLog::GetOutputLogFile(), "%s [CURL DBG] " fmt "%s\n", S3fsLog::GetCurrentTime(), __VA_ARGS__); \
                 S3fsLog::Flush(); \
             }else{ \
                 syslog(S3fsLog::GetSyslogLevel(S3fsLog::LEVEL_CRIT), "%s" fmt "%s", instance_name.c_str(), __VA_ARGS__); \
@@ -181,7 +195,7 @@ class S3fsLog
         do{ \
             if(foreground || S3fsLog::IsSetLogFile()){ \
                 S3fsLog::SeekEnd(); \
-                fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s:%s(%d): " fmt "%s\n", S3fsLog::GetLevelString(S3fsLog::LEVEL_INFO), S3fsLog::GetS3fsLogNest(0), __FILE__, __func__, __LINE__, __VA_ARGS__, ""); \
+                fprintf(S3fsLog::GetOutputLogFile(), "%s %s%s%s:%s(%d): " fmt "%s\n", S3fsLog::GetCurrentTime(), S3fsLog::GetLevelString(S3fsLog::LEVEL_INFO), S3fsLog::GetS3fsLogNest(0), __FILE__, __func__, __LINE__, __VA_ARGS__, ""); \
                 S3fsLog::Flush(); \
             }else{ \
                 syslog(S3fsLog::GetSyslogLevel(S3fsLog::LEVEL_INFO), "%s%s" fmt "%s", instance_name.c_str(), S3fsLog::GetS3fsLogNest(0), __VA_ARGS__, ""); \

--- a/src/s3fs_logger.h
+++ b/src/s3fs_logger.h
@@ -71,17 +71,17 @@ class S3fsLog
                      LEVEL_ERR  == (level & LEVEL_DBG) ? LOG_ERR     : LOG_CRIT );
         }
 
-    static const char* GetCurrentTime()
-    {
-        struct timeval now;
-        struct tm res;
-        char tmp[32];
+        static const char* GetCurrentTime()
+        {
+            struct timeval now;
+            struct tm res;
+            char tmp[32];
 
-        gettimeofday(&now, NULL);
-        strftime(tmp, sizeof(tmp), "%Y-%m-%dT%H:%M:%S", gmtime_r(&now.tv_sec, &res));
-        snprintf(current_time, sizeof(current_time), "%s.%03ldZ", tmp, (now.tv_usec / 1000));
-        return current_time;
-    }
+            gettimeofday(&now, NULL);
+            strftime(tmp, sizeof(tmp), "%Y-%m-%dT%H:%M:%S", gmtime_r(&now.tv_sec, &res));
+            snprintf(current_time, sizeof(current_time), "%s.%03ldZ", tmp, (now.tv_usec / 1000));
+            return current_time;
+        }
 
         static const char* GetLevelString(s3fs_log_level level)
         {


### PR DESCRIPTION
This PR adds timestamps to the debug output as well as to the cache integrity check output.

The new function `S3fsLog::GetCurrentTime()` isn't thread safe.

Closes #1528