### PR TITLE
Do not periodically flush with nomultipartupload

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -5056,6 +5056,7 @@ int main(int argc, char* argv[])
     // Check multipart / copy api for mix multipart uploading
     if(nomultipart || nocopyapi || norenameapi){
         FdEntity::SetNoMixMultipart();
+        max_dirty_data = -1;
     }
 
     // check free disk space


### PR DESCRIPTION
s3fs periodically flushes data to S3 and hole-punches the written
data, marking it as clean.  Without multipart copy, s3fs would write
the now-zeroed data along with any new data.  s3fs should not attempt
to periodically flush dirty data at all without multipart copy
support.  Fixes #1542.