### PR TITLE
set IsExpireTime to true by default

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -150,7 +150,7 @@ pthread_mutex_t StatCache::stat_cache_lock;
 //-------------------------------------------------------------------
 // Constructor/Destructor
 //-------------------------------------------------------------------
-StatCache::StatCache() : IsExpireTime(false), IsExpireIntervalType(false), ExpireTime(15 * 60), CacheSize(100000), IsCacheNoObject(false)
+StatCache::StatCache() : IsExpireTime(true), IsExpireIntervalType(false), ExpireTime(15 * 60), CacheSize(100000), IsCacheNoObject(false)
 {
     if(this == StatCache::getStatCacheData()){
         stat_cache.clear();


### PR DESCRIPTION
fixes #1563

### Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._
#1563

### Details
_Please describe the details of PullRequest._
Sets the stat cache `IsExpireTime` to `true` by default, so that the default `ExpireTime` actually takes effect.

Tested using:
1. Run s3fs: `s3fs -f bucket /mountpoint ...` *without* the `-o stat_cache_expire` option
2. Create a file in S3: `echo | aws cp - s3://bucket/test-file`
3. Run: `ls -l /mountpoint/test-file`
4. Remove the file from S3: `aws rm s3://bucket/test-file`
5. Wait for more than 15min. (During this time, s3fs will still report the file as existing)
6. Run: `ls -l /mountpoint/test-file` . This should print `No such file or directory`