### PR TITLE
Enhanced parallel processing for list_bucket and multihead request

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -25,7 +25,6 @@
 
 #include "curl_handlerpool.h"
 #include "bodydata.h"
-#include "psemaphore.h"
 #include "metaheader.h"
 #include "fdcache_page.h"
 
@@ -115,6 +114,7 @@ class S3fsCurl
             pthread_mutex_t dns;
             pthread_mutex_t ssl_session;
         } callback_locks;
+        static pthread_mutex_t  cryptfunc_lock;       // [NOTE] exclusive control of cryption libraries(for openssl)
         static bool             is_initglobal_done;
         static CurlHandlerPool* sCurlPool;
         static int              sCurlPoolSize;
@@ -195,12 +195,9 @@ class S3fsCurl
         headers_t            b_meta;               // backup for retrying(for copy request)
         std::string          op;                   // the HTTP verb of the request ("PUT", "GET", etc.)
         std::string          query_string;         // request query string
-        Semaphore            *sem;
-        pthread_mutex_t      *completed_tids_lock;
-        std::vector<pthread_t> *completed_tids;
         s3fscurl_lazy_setup  fpLazySetup;          // curl options for lazy setting function
-        CURLcode             curlCode;             // handle curl return
-    
+        volatile CURLcode    curlCode;             // handle curl return
+
     public:
         static const long S3FSCURL_RESPONSECODE_NOTSET      = -1;
         static const long S3FSCURL_RESPONSECODE_FATAL_ERROR = -2;

--- a/src/curl.h
+++ b/src/curl.h
@@ -114,7 +114,6 @@ class S3fsCurl
             pthread_mutex_t dns;
             pthread_mutex_t ssl_session;
         } callback_locks;
-        static pthread_mutex_t  cryptfunc_lock;       // [NOTE] exclusive control of cryption libraries(for openssl)
         static bool             is_initglobal_done;
         static CurlHandlerPool* sCurlPool;
         static int              sCurlPoolSize;

--- a/src/curl_multi.h
+++ b/src/curl_multi.h
@@ -21,14 +21,29 @@
 #ifndef S3FS_CURL_MULTI_H_
 #define S3FS_CURL_MULTI_H_
 
+#include "psemaphore.h"
+
 //----------------------------------------------
 // Typedef
 //----------------------------------------------
 class S3fsCurl;
+class S3fsMultiCurl;
 
-typedef std::vector<S3fsCurl*>       s3fscurllist_t;
+typedef std::list<S3fsCurl*>   s3fscurllist_t;
+typedef std::vector<pthread_t> s3fsthreadlist_t;
+
+typedef bool (*S3fsMultiPrecheckCallback)(S3fsCurl* s3fscurl);   // callback for pre-check to start
 typedef bool (*S3fsMultiSuccessCallback)(S3fsCurl* s3fscurl);    // callback for succeed multi request
 typedef S3fsCurl* (*S3fsMultiRetryCallback)(S3fsCurl* s3fscurl); // callback for failure and retrying
+
+typedef struct mcurl_thread_param
+{
+    S3fsMultiCurl*  s3fsmulticurl;
+    S3fsCurl*       s3fscurl;
+    Semaphore*      sem;
+
+    mcurl_thread_param(S3fsMultiCurl* ps3fsmulticurl = NULL, S3fsCurl* ps3fscurl = NULL, Semaphore* psem = NULL) : s3fsmulticurl(ps3fsmulticurl), s3fscurl(ps3fscurl), sem(psem) {}
+}MCTH_PARAM;
 
 //----------------------------------------------
 // class S3fsMultiCurl
@@ -36,23 +51,31 @@ typedef S3fsCurl* (*S3fsMultiRetryCallback)(S3fsCurl* s3fscurl); // callback for
 class S3fsMultiCurl
 {
     private:
-        const int maxParallelism;
+        const int                   maxParallelism;
+        volatile bool               exit_thread;
 
-        s3fscurllist_t clist_all;  // all of curl requests
-        s3fscurllist_t clist_req;  // curl requests are sent
+        S3fsMultiPrecheckCallback   PrecheckCallback;
+        S3fsMultiSuccessCallback    SuccessCallback;
+        S3fsMultiRetryCallback      RetryCallback;
 
-        S3fsMultiSuccessCallback SuccessCallback;
-        S3fsMultiRetryCallback   RetryCallback;
-
-        pthread_mutex_t completed_tids_lock;
-        std::vector<pthread_t> completed_tids;
+        s3fscurllist_t              clist_all;           // all of curl requests
+        s3fscurllist_t              clist_req;           // curl requests are sent
+        s3fscurllist_t              clist_res;           // list of responses received
+        pthread_mutex_t             clist_lock;          // for clist_all, clist_req and clist_res
+        long                        running_threads;     // running thread count
+        s3fsthreadlist_t            completed_tids;      // waiting list for pthread_join
+        pthread_mutex_t             completed_tids_lock; // for completed_tids and running_threads
+        pthread_t                   parallel_thread;
 
     private:
         bool ClearEx(bool is_all);
+        int MultiPrePerform(Semaphore& sem, bool& has_headreq, bool trywait);
+        int MultiPostPerform(bool has_headreq);
         int MultiPerform();
-        int MultiRead();
+        int MultiRead(bool is_parallel);
 
         static void* RequestPerformWrapper(void* arg);
+        static void* ParallelProcessingWorker(void* arg);
 
     public:
         explicit S3fsMultiCurl(int maxParallelism);
@@ -60,10 +83,14 @@ class S3fsMultiCurl
 
         int GetMaxParallelism() { return maxParallelism; }
 
+        S3fsMultiPrecheckCallback SetPrecheckCallback(S3fsMultiPrecheckCallback function);
         S3fsMultiSuccessCallback SetSuccessCallback(S3fsMultiSuccessCallback function);
         S3fsMultiRetryCallback SetRetryCallback(S3fsMultiRetryCallback function);
+
         bool Clear() { return ClearEx(true); }
         bool SetS3fsCurlObject(S3fsCurl* s3fscurl);
+        bool StartParallelThread();
+        int WaitParallelThread();
         int Request();
 };
 

--- a/src/psemaphore.h
+++ b/src/psemaphore.h
@@ -42,6 +42,7 @@ class Semaphore
             dispatch_release(sem);
         }
         void wait() { dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER); }
+        bool trywait() { return (0 == dispatch_semaphore_wait(sem, DISPATCH_TIME_NOW)); }
         void post() { dispatch_semaphore_signal(sem); }
         int get_value() const { return value; }
 
@@ -67,6 +68,7 @@ class Semaphore
                 r = sem_wait(&mutex);
             } while (r == -1 && errno == EINTR);
         }
+        bool trywait() { return (0 == sem_trywait(&mutex)); }
         void post() { sem_post(&mutex); }
         int get_value() const { return value; }
 

--- a/src/s3objlist.cpp
+++ b/src/s3objlist.cpp
@@ -31,6 +31,12 @@
 // New class S3ObjList is base on old s3_object struct.
 // This class is for S3 compatible clients.
 //
+void S3ObjList::clear()
+{
+    objects.clear();
+}
+
+//
 // If name is terminated by "/", it is forced dir type.
 // If name is terminated by "_$folder$", it is forced dir type.
 // If is_dir is true and name is not terminated by "/", the name is added "/".
@@ -101,6 +107,15 @@ bool S3ObjList::insert(const char* name, const char* etag, bool is_dir)
 
     // add normalization
     return insert_normalized(orgname.c_str(), newname.c_str(), is_dir);
+}
+
+bool S3ObjList::append(const S3ObjList& other)
+{
+    for(s3obj_t::const_iterator iter = other.objects.begin(); iter != other.objects.end(); ++iter){
+        // If it exists, it will be overwritten.
+        objects[iter->first] = iter->second;
+    }
+    return true;
 }
 
 bool S3ObjList::insert_normalized(const char* name, const char* normalized, bool is_dir)

--- a/src/s3objlist.h
+++ b/src/s3objlist.h
@@ -55,8 +55,10 @@ class S3ObjList
         S3ObjList() {}
         ~S3ObjList() {}
 
+        void clear(void);
         bool IsEmpty() const { return objects.empty(); }
         bool insert(const char* name, const char* etag = NULL, bool is_dir = false);
+        bool append(const S3ObjList& other);
         std::string GetOrgName(const char* name) const;
         std::string GetNormalizedName(const char* name) const;
         std::string GetETag(const char* name) const;


### PR DESCRIPTION
## Relevant Issue (if applicable)
#1541 

## Details
### Current
The process of readdir is to first create a list of files(objects) in the directory with the list_bucket function.(ListBucket Request)
The maximum value of ListBucket Request is 1000 files, and the list is created in units of 1000 files.
For directories with over 1000 files, list them all.
After making list, s3fs sends HEAD requests for all the files to get the Stats information.(readdir_multi_head)
Finally, after all the Stats information is complete, it returns the file list to FUSE, and it will also be registered in the Stats cache.

### Change
I changed the above process.
First, calling the list_bucket function is the same.
ListBucket Request lists files in units of 1000 as before.

Changed to start sending HEAD requests after listing 1000 instead of waiting for all listings.
This process is done in a separate thread, and also the HEAD request itself runs in a separate thread.
This has changed to list up files and executing HEAD requests in parallel.

It also registers the Stats  information in the Stats cache as soon as each HEAD request is completed.
This means updating the Stats cache while processing other HEAD requests and listing files.
If the Stats cache is updated while waiting for a HEAD request and its file information becomes hit, the HEAD request will not be sent.
(It's not clear if this situation exists, but it would be beneficial if the Stats cache was updated by another process.)

### About perfomance
After all, due to the large number of individual HEAD requests, the processing time of HEAD requests is longer than the processing time of ListBucket.
Therefore, I think the performance will not change much.
(There was not much difference in my results.)
However, I think that this PR should be merged for future changes.
(Because the multi-request logic can be used for other than HEAD request)

### Others
#### 400 HTTP response code
In the HEAD request, I noticed that accessing the HEAD request to an object such as SSE returns an error 400 from S3.
In the processing of S3fsMultiCurl, when this number 400 was received, it was retrying.
Changed this retry process so that it is not performed in the case of HEAD request.
I think this issue was previously pointed out in the Issue. (I couldn't find which issue it was.)

~~#### About libcrypt and multi-threading~~
~~When using openssl(libcrypt) from multithreading, it may get a `double free` error on OSX.~~
~~To avoid this, the insertV4(2)Headers function was changed exclusively controlled by mutex.~~
~~I wrote a little more information on gist at https://gist.github.com/ggtakec/a743affecf153e78f6b5d74e2bb1fcd5.~~

