### PR TITLE
Fixed osx mistype declaration and typo warnings

### DIFF
--- a/src/curl_util.h
+++ b/src/curl_util.h
@@ -23,7 +23,7 @@
 
 #include <curl/curl.h>
 
-struct sse_type_t;
+class sse_type_t;
 
 //----------------------------------------------
 // Functions

--- a/src/s3fs_logger.h
+++ b/src/s3fs_logger.h
@@ -32,6 +32,12 @@
 #define S3FS_CLOCK_MONOTONIC    CLOCK_MONOTONIC
 #endif
 
+#if defined(__APPLE__)
+#define S3FSLOG_TIME_FMT        "%s.%03dZ"
+#else
+#define S3FSLOG_TIME_FMT        "%s.%03ldZ"
+#endif
+
 //-------------------------------------------------------------------
 // S3fsLog class
 //-------------------------------------------------------------------
@@ -91,7 +97,7 @@ class S3fsLog
                 gettimeofday(&now, NULL);
             }
             strftime(tmp, sizeof(tmp), "%Y-%m-%dT%H:%M:%S", gmtime_r(&now.tv_sec, &res));
-            snprintf(current_time, sizeof(current_time), "%s.%03ldZ", tmp, (now.tv_usec / 1000));
+            snprintf(current_time, sizeof(current_time), S3FSLOG_TIME_FMT, tmp, (now.tv_usec / 1000));
             return current_time;
         }
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
There was a part where `sse_type_t` was incorrectly declared in the struct.
Also, the `tv_usec` member of `struct timeval` is different between OSX and Linux, so I fixed it.
