### PR TITLE
Fixed a bug that filling NULL bytes when changing the attribute after renaming

### DIFF
--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -337,6 +337,16 @@ function wait_for_port() {
     done
 }
 
+function make_random_string() {
+    if [ -n "$1" ]; then
+        END_POS=$1
+    else
+        END_POS=8
+    fi
+    RANDOM_STR=`cat /dev/urandom | base64 | sed 's#[/|+]##g' | head -1 | cut -c 1-${END_POS}`
+    echo "${RANDOM_STR}"
+}
+
 #
 # Local variables:
 # tab-width: 4


### PR DESCRIPTION
## Relevant Issue (if applicable)
#1453 

### Details
The rename logic internally copies the file and deletes the original file.
The cause of the #1453 was that s3fs was updating mtime immediately after this copy, at which time a new cache file was created and the contents of the file were null.

In this PR, updates such as mtime are added to the cache file before copying.
And leave the cache file open and copy (put_header).
After copying, rename the cache file and delete the original file.

Keeping the cache file open is necessary because fdcache cannot be renamed unless it is open and new cache files are not created.

And, although it was also the cause of the problem, I accidentally deleted the cache of the destination file.
This is also fixed. (Prevents unnecessary downloads and improves efficiency)

