### PR TITLE
Fixed a bug that padded null bytes when changing xattr

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1581,7 +1581,7 @@ bool FdEntity::MergeOrgMeta(headers_t& updatemeta)
 }
 
 // global function in s3fs.cpp
-int put_headers(const char* path, headers_t& meta, bool is_copy, bool update_mtime);
+int put_headers(const char* path, headers_t& meta, bool is_copy);
 
 int FdEntity::UploadPendingMeta()
 {
@@ -1593,7 +1593,7 @@ int FdEntity::UploadPendingMeta()
     headers_t updatemeta = orgmeta;
     updatemeta["x-amz-copy-source"]        = urlEncode(service_path + bucket + get_realpath(path.c_str()));
     // put headers, no need to update mtime to avoid dead lock
-    int result = put_headers(path.c_str(), updatemeta, true, false);
+    int result = put_headers(path.c_str(), updatemeta, true);
     if(0 != result){
         S3FS_PRN_ERR("failed to put header after flushing file(%s) by(%d).", path.c_str(), result);
     }


### PR DESCRIPTION
### Relevant Issue (if applicable)
 #1579

### Details
In addition to the bug fix of #1579, the same bug was found in the `set`/`remove` operation of `xattr`, so it was fixed.
And I also added and modified the test case.
And, with #1579 and this PR change, the fourth argument(`update_mtime`) of the `put_header()` function is no longer needed, so I deleted it.
