### PR TITLE
Fixed aws command error by rsa on ubuntu16.04

### DIFF
--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -197,6 +197,7 @@ java -version
 #
 echo "${PRGNAME} [INFO] Install awscli package."
 ${PIP_BIN} install ${PIP_OPTIONS} ${INSTALL_AWSCLI_PACKAGES}
+${PIP_BIN} install ${PIP_OPTIONS} rsa
 
 #-----------------------------------------------------------
 # Set environment for configure


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Since last night, the aws command has been errored in the rsa related package in the Github Actions build of Ubuntu 16.04.
Changed to upgrade rsa after installing the awscli package.
(Because the release schedule is near)
```
Traceback (most recent call last):
  File "/usr/local/bin/aws", line 27, in <module>
    sys.exit(main())
  File "/usr/local/bin/aws", line 23, in main
    return awscli.clidriver.main()
  File "/usr/local/lib/python3.5/dist-packages/awscli/clidriver.py", line 68, in main
    driver = create_clidriver()
  File "/usr/local/lib/python3.5/dist-packages/awscli/clidriver.py", line 78, in create_clidriver
    event_hooks=session.get_component('event_emitter'))
  File "/usr/local/lib/python3.5/dist-packages/awscli/plugin.py", line 44, in load_plugins
    modules = _import_plugins(plugin_mapping)
  File "/usr/local/lib/python3.5/dist-packages/awscli/plugin.py", line 61, in _import_plugins
    module = __import__(path, fromlist=[module])
  File "/usr/local/lib/python3.5/dist-packages/awscli/handlers.py", line 28, in <module>
    from awscli.customizations.cloudfront import register as register_cloudfront
  File "/usr/local/lib/python3.5/dist-packages/awscli/customizations/cloudfront.py", line 17, in <module>
    import rsa
ImportError: No module named 'rsa'
```
@gaul I'll merge when the build passes.