### PR TITLE
Output version and command parameters at startup

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4888,6 +4888,8 @@ int main(int argc, char* argv[])
                 exit(EXIT_FAILURE);
         }
     }
+    // print launch message
+    print_launch_message(argc, argv);
 
     // Load SSE environment
     if(!S3fsCurl::LoadEnvSse()){

--- a/src/s3fs_help.cpp
+++ b/src/s3fs_help.cpp
@@ -558,6 +558,12 @@ void show_version()
     VERSION, COMMIT_HASH_VAL, s3fs_crypt_lib_name());
 }
 
+const char* short_version()
+{
+    static const char short_ver[] = "s3fs version " VERSION "(" COMMIT_HASH_VAL ")";
+    return short_ver;
+}
+
 /*
 * Local variables:
 * tab-width: 4

--- a/src/s3fs_help.h
+++ b/src/s3fs_help.h
@@ -27,6 +27,7 @@
 void show_usage();
 void show_help();
 void show_version();
+const char* short_version();
 
 #endif // S3FS_S3FS_HELP_H_
 

--- a/src/s3fs_logger.h
+++ b/src/s3fs_logger.h
@@ -227,6 +227,17 @@ class S3fsLog
             } \
         }while(0)
 
+#define S3FS_PRN_LAUNCH_INFO(fmt, ...) \
+        do{ \
+            if(foreground || S3fsLog::IsSetLogFile()){ \
+                S3fsLog::SeekEnd(); \
+                fprintf(S3fsLog::GetOutputLogFile(), "%s%s" fmt "%s\n", S3fsLog::GetCurrentTime(), S3fsLog::GetLevelString(S3fsLog::LEVEL_INFO), __VA_ARGS__, ""); \
+                S3fsLog::Flush(); \
+            }else{ \
+                syslog(S3fsLog::GetSyslogLevel(S3fsLog::LEVEL_INFO), "%s" fmt "%s", instance_name.c_str(), __VA_ARGS__, ""); \
+            } \
+        }while(0)
+
 // Special macro for checking cache files
 #define S3FS_LOW_CACHE(fp, fmt, ...) \
         do{ \

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -36,6 +36,7 @@
 #include "s3fs.h"
 #include "s3fs_util.h"
 #include "string_util.h"
+#include "s3fs_help.h"
 
 //-------------------------------------------------------------------
 // Global variables
@@ -366,6 +367,29 @@ bool compare_sysname(const char* target)
         return false;
     }
     return true;
+}
+
+//-------------------------------------------------------------------
+// Utility for print message at launching
+//-------------------------------------------------------------------
+void print_launch_message(int argc, char** argv)
+{
+    std::string  message = short_version();
+
+    if(argv){
+        message += " :";
+        for(int cnt = 0; cnt < argc; ++cnt){
+            if(argv[cnt]){
+                message += " ";
+                if(0 == cnt){
+                    message += basename(argv[cnt]);
+                }else{
+                    message += argv[cnt];
+                }
+            }
+        }
+    }
+    S3FS_PRN_LAUNCH_INFO("%s", message.c_str());
 }
 
 /*

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -42,6 +42,8 @@ bool delete_files_in_dir(const char* dir, bool is_remove_own);
 
 bool compare_sysname(const char* target);
 
+void print_launch_message(int argc, char** argv);
+
 #endif // S3FS_S3FS_UTIL_H_
 
 /*


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1596 

### Details
The version and command parameters are always output at startup, and the output message is prefixed with [INF].
Below is a sample output.
```
2021-03-06T03:02:13.195Z [INF] s3fs version 1.89(8c58ba8) : s3fs -o allow_other,nonempty,enable_noobj_cache,multireq_max=50 <bucket> /mnt/s3
```