### PR TITLE
Return EACESS when lacking required executable bit

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -579,7 +579,7 @@ static int check_object_access(const char* path, int mask, struct stat* pstbuf)
 
     if(X_OK == (mask & X_OK)){
         if(0 == (mode & (S_IXUSR | S_IXGRP | S_IXOTH))){
-            return -EPERM;
+            return -EACCES;
         }
     }
     if(W_OK == (mask & W_OK)){


### PR DESCRIPTION
This makes the check consistent with read and write.  Found via
pjdfstests.  References #1551.  References #1589.