### PR TITLE
Propagate errno instead of EIO

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -335,7 +335,7 @@ int FdEntity::Open(headers_t* pmeta, off_t size, time_t time, bool no_fd_lock_wa
                 if(0 < refcnt){
                     refcnt--;
                 }
-                return -EIO;
+                return -errno;
             }
             // resize page list
             if(!pagelist.Resize(size, false, true)){      // Areas with increased size are modified
@@ -1426,7 +1426,7 @@ ssize_t FdEntity::Read(char* bytes, off_t start, size_t size, bool force_load)
 
         if(0 != result){
             S3FS_PRN_ERR("could not download. start(%lld), size(%zu), errno(%d)", static_cast<long long int>(start), size, result);
-            return -EIO;
+            return result;
         }
     }
 
@@ -1456,7 +1456,7 @@ ssize_t FdEntity::Write(const char* bytes, off_t start, size_t size)
         // grow file size
         if(-1 == ftruncate(fd, start)){
             S3FS_PRN_ERR("failed to truncate temporary file(%d).", fd);
-            return -EIO;
+            return -errno;
         }
         // add new area
         pagelist.SetPageLoadedStatus(pagelist.Size(), start - pagelist.Size(), PageList::PAGE_MODIFIED);
@@ -1540,7 +1540,7 @@ ssize_t FdEntity::Write(const char* bytes, off_t start, size_t size)
             //
             if(-1 == ftruncate(fd, 0) || -1 == ftruncate(fd, (mp_start + mp_size))){
                 S3FS_PRN_ERR("failed to truncate file(%d).", fd);
-                return -EIO;
+                return -errno;
             }
             mp_start += mp_size;
             mp_size   = 0;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2332,7 +2332,7 @@ static int s3fs_write(const char* _path, const char* buf, size_t size, off_t off
         if(0 != (flushres = ent->RowFlush(path, true))){
             S3FS_PRN_ERR("could not upload file(%s): result=%d", path, flushres);
             StatCache::getStatCacheData()->DelStat(path);
-            return -EIO;
+            return flushres;
         }
         // Punch a hole in the file to recover disk space.
         if(!ent->PunchHole()){


### PR DESCRIPTION
This improves error fidelity.  Follows on to
b70f8db037415821822d7ab2644978086d3df303.  References #1523.