### PR TITLE
Do not create zero-byte object when creating file

### DIFF
--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -118,6 +118,12 @@ class FdEntity
 
         bool ReserveDiskSpace(off_t size);
         bool PunchHole(off_t start = 0, size_t size = 0);
+
+        // Indicate that a new file's is dirty.  This ensures that both metadata and data are synced during flush.
+        void MarkDirtyNewFile() {
+            pagelist.SetPageLoadedStatus(0, 1, PageList::PAGE_LOAD_MODIFIED);
+            is_meta_pending = true;
+        }
 };
 
 typedef std::map<std::string, class FdEntity*> fdent_map_t;   // key=path, value=FdEntity*

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -24,6 +24,20 @@ set -o pipefail
 
 source test-utils.sh
 
+function test_create_empty_file {
+    describe "Testing creating an empty file ..."
+
+    OBJECT_NAME="$(basename $PWD)/${TEST_TEXT_FILE}"
+
+    touch ${TEST_TEXT_FILE}
+
+    check_file_size "${TEST_TEXT_FILE}" 0
+
+    aws_cli s3api head-object --bucket "${TEST_BUCKET_1}" --key "${OBJECT_NAME}"
+
+    rm_test_file
+}
+
 function test_append_file {
     describe "Testing append to file ..."
     TEST_INPUT="echo ${TEST_TEXT} to ${TEST_TEXT_FILE}"
@@ -1425,6 +1439,7 @@ function add_all_tests {
     if ! ps u $S3FS_PID | grep -q ensure_diskfree && ! uname | grep -q Darwin; then
         add_tests test_clean_up_cache
     fi
+    add_tests test_create_empty_file
     add_tests test_append_file
     add_tests test_truncate_file
     add_tests test_truncate_upload


### PR DESCRIPTION
Previously s3fs created this object to store metadata and overwrote it
when flushing.  This prevented use with object stores which do not
allow overwrites like HDS.  Instead only create an in-memory
representation which reduces the time to create small files.
Fixes #1013.