### PR TITLE
Fix a few nits

### DIFF
--- a/src/bodydata.cpp
+++ b/src/bodydata.cpp
@@ -106,7 +106,7 @@ bool BodyData::Append(void* ptr, size_t bytes)
 const char* BodyData::str() const
 {
     if(!text){
-        static const char* strnull = "";
+        static const char strnull[] = "";
         return strnull;
     }
     return text;

--- a/src/common.h
+++ b/src/common.h
@@ -29,8 +29,9 @@
 // Global variables
 //-------------------------------------------------------------------
 // TODO: namespace these
-extern int64_t        FIVE_GB;
-extern off_t          MIN_MULTIPART_SIZE;
+static const int64_t  FIVE_GB            = 5LL * 1024LL * 1024LL * 1024LL;
+static const off_t    MIN_MULTIPART_SIZE = 5 * 1024 * 1024;
+
 extern bool           foreground;
 extern bool           nomultipart;
 extern bool           pathrequeststyle;

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -64,8 +64,8 @@ static const std::string IAMCRED_ROLEARN            = "RoleArn";
 // If the mime.types file is not found, s3fs will exit with an
 // error.
 //
-static const char* DEFAULT_MIME_FILE                = "/etc/mime.types";
-static const char* SPECIAL_DARWIN_MIME_FILE         = "/etc/apache2/mime.types";
+static const char DEFAULT_MIME_FILE[]               = "/etc/mime.types";
+static const char SPECIAL_DARWIN_MIME_FILE[]        = "/etc/apache2/mime.types";
 
 // [NOTICE]
 // This symbol is for libcurl under 7.23.0
@@ -1910,7 +1910,7 @@ S3fsCurl::S3fsCurl(bool ahbe) :
     LastResponseCode(S3FSCURL_RESPONSECODE_NOTSET), postdata(NULL), postdata_remaining(0), is_use_ahbe(ahbe),
     retry_count(0), b_infile(NULL), b_postdata(NULL), b_postdata_remaining(0), b_partdata_startpos(0), b_partdata_size(0),
     b_ssekey_pos(-1), b_ssetype(sse_type_t::SSE_DISABLE),
-    sem(NULL), completed_tids_lock(NULL), completed_tids(NULL), fpLazySetup(NULL)
+    sem(NULL), completed_tids_lock(NULL), completed_tids(NULL), fpLazySetup(NULL), curlCode(CURLE_OK)
 {
 }
 

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -41,6 +41,7 @@ S3fsMultiCurl::S3fsMultiCurl(int maxParallelism) : maxParallelism(maxParallelism
 #endif
     if (0 != (result = pthread_mutex_init(&completed_tids_lock, &attr))) {
         S3FS_PRN_ERR("could not initialize completed_tids_lock: %i", result);
+        abort();
     }
 }
 

--- a/src/s3fs_global.cpp
+++ b/src/s3fs_global.cpp
@@ -24,9 +24,6 @@
 //-------------------------------------------------------------------
 // Global variables
 //-------------------------------------------------------------------
-int64_t FIVE_GB                   = 5LL * 1024LL * 1024LL * 1024LL;
-off_t MIN_MULTIPART_SIZE          = 5 * 1024 * 1024;
-
 bool foreground                   = false;
 bool nomultipart                  = false;
 bool pathrequeststyle             = false;

--- a/src/s3fs_logger.cpp
+++ b/src/s3fs_logger.cpp
@@ -28,9 +28,9 @@
 // S3fsLog class : variables
 //-------------------------------------------------------------------
 const int               S3fsLog::NEST_MAX;
-const char*             S3fsLog::nest_spaces[S3fsLog::NEST_MAX] = {"", "  ", "    ", "      "};
-const char*             S3fsLog::LOGFILEENV       = "S3FS_LOGFILE";
-const char*             S3fsLog::MSGTIMESTAMP     = "S3FS_MSGTIMESTAMP";
+const char* const       S3fsLog::nest_spaces[S3fsLog::NEST_MAX] = {"", "  ", "    ", "      "};
+const char              S3fsLog::LOGFILEENV[]     = "S3FS_LOGFILE";
+const char              S3fsLog::MSGTIMESTAMP[]   = "S3FS_MSGTIMESTAMP";
 S3fsLog*                S3fsLog::pSingleton       = NULL;
 S3fsLog::s3fs_log_level S3fsLog::debug_level      = S3fsLog::LEVEL_CRIT;
 FILE*                   S3fsLog::logfp            = NULL;

--- a/src/s3fs_logger.h
+++ b/src/s3fs_logger.h
@@ -53,10 +53,11 @@ class S3fsLog
         };
 
     protected:
-        static const int      NEST_MAX = 4;
-        static const char*    nest_spaces[NEST_MAX];
-        static const char*    LOGFILEENV;
-        static const char*    MSGTIMESTAMP;
+        static const int         NEST_MAX = 4;
+        static const char* const nest_spaces[NEST_MAX];
+        static const char        LOGFILEENV[];
+        static const char        MSGTIMESTAMP[];
+
         static S3fsLog*       pSingleton;
         static s3fs_log_level debug_level;
         static FILE*          logfp;

--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -29,7 +29,7 @@
 //-------------------------------------------------------------------
 // Variables
 //-------------------------------------------------------------------
-static const char* c_strErrorObjectName = "FILE or SUBDIR in DIR";
+static const char c_strErrorObjectName[] = "FILE or SUBDIR in DIR";
 
 //-------------------------------------------------------------------
 // Functions

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -379,7 +379,7 @@ std::string s3fs_hex(const unsigned char* input, size_t length, bool lower)
 
 char* s3fs_base64(const unsigned char* input, size_t length)
 {
-    static const char* base = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+    static const char base[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
     char* result;
 
     if(!input || 0 == length){


### PR DESCRIPTION
Make some strings more const, initialize members, and abort if lock
initialization fails.  Partially found via clang-tidy.