### PR TITLE
Replace snprintf with string and ostringstream

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2784,11 +2784,9 @@ int S3fsCurl::GetIAMv2ApiToken()
     responseHeaders.clear();
     bodydata.Clear();
 
-    // maximum allowed value is 21600, so 6 bytes for the C string
-    char ttlstr[6];
-    snprintf(ttlstr, sizeof(ttlstr), "%d", S3fsCurl::IAMv2_token_ttl);
+    std::string ttlstr = str(S3fsCurl::IAMv2_token_ttl);
     requestHeaders = curl_slist_sort_insert(requestHeaders, S3fsCurl::IAMv2_token_ttl_hdr.c_str(),
-                                            ttlstr);
+                                            ttlstr.c_str());
     curl_easy_setopt(hCurl, CURLOPT_PUT, true);
     curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata);

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -909,7 +909,7 @@ bool FdManager::CheckAllCache()
     }
 
     // print head message
-    S3FS_PRN_CACHE(fp, CACHEDBG_FMT_HEAD, S3fsLog::GetCurrentTime());
+    S3FS_PRN_CACHE(fp, CACHEDBG_FMT_HEAD, S3fsLog::GetCurrentTime().c_str());
 
     // Loop in directory of cache file's stats
     std::string top_path  = CacheFileStat::GetCacheFileStatTopDir();

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <cerrno>
 #include <climits>
+#include <iomanip>
 
 #include <stdexcept>
 #include <sstream>
@@ -59,9 +60,7 @@ template<> std::string str(struct timespec value) {
     std::ostringstream s;
     s << value.tv_sec;
     if(value.tv_nsec != 0){
-        char buf[16];
-        snprintf(buf, sizeof(buf), "%09lld", static_cast<long long>(value.tv_nsec));
-        s << "." << buf;
+        s << "." << std::setfill('0') << std::setw(9) << value.tv_nsec;
     }
     return s.str();
 }


### PR DESCRIPTION
These uses are probably safe from a buffer overflow perspective but
can cause data race issues in logging due to static buffers.