### PR TITLE
Fixed make_random_string test code being slow on macos

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -1460,14 +1460,7 @@ function add_all_tests {
     add_tests test_external_modification
     add_tests test_read_external_object
     add_tests test_update_metadata_external_small_object
-    if ! uname | grep -q Darwin; then
-        # [NOTE]
-        # This test is very time consuming on OSX and will not run.
-        # And this test should be no different between OSX and
-        # other OSs. so skip this test on OSX.
-        #
-        add_tests test_update_metadata_external_large_object
-    fi
+    add_tests test_update_metadata_external_large_object
     add_tests test_rename_before_close
     add_tests test_multipart_upload
     add_tests test_multipart_copy

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -50,10 +50,12 @@ if [ `uname` = "Darwin" ]; then
     export STDBUF_BIN="gstdbuf"
     export TRUNCATE_BIN="gtruncate"
     export SED_BIN="gsed"
+    export BASE64_BIN="gbase64"
 else
     export STDBUF_BIN="stdbuf"
     export TRUNCATE_BIN="truncate"
     export SED_BIN="sed"
+    export BASE64_BIN="base64"
 fi
 export SED_BUFFER_FLAG="--unbuffered"
 
@@ -343,8 +345,10 @@ function make_random_string() {
     else
         END_POS=8
     fi
-    RANDOM_STR=`cat /dev/urandom | base64 | sed 's#[/|+]##g' | head -1 | cut -c 1-${END_POS}`
-    echo "${RANDOM_STR}"
+
+    ${BASE64_BIN} --wrap=0 < /dev/urandom | tr -d /+ | head -c ${END_POS}
+
+    return 0
 }
 
 #


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1586

### Details
I noticed that the make_random_string function in my test code is very slow on macos.
When I executed `cat / dev / urandom | base64.....`, it used a lot of CPU and memory, and it took a lot of execution time.
This was also the reason why #1586 bypassed the test_update_metadata_external_large_object test.
With this fix, even if you re-add the bypassed test, the test time will be shorter.
