### PR TITLE
Issue parallel requests in get_object_attribute

### DIFF
--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -99,7 +99,7 @@ function check_file_size() {
     size=$(get_size ${FILE_NAME})
     if [ $size -ne $EXPECTED_SIZE ]
     then
-        echo "error: expected ${FILE_NAME} to be zero length"
+        echo "error: expected ${FILE_NAME} to be $EXPECTED_SIZE length, got $size"
         return 1
     fi
 


### PR DESCRIPTION
s3fs must issue HEAD requests for path, path/, and the legacy
path_$folder$ to return an object's attributes.  Previously it issued
these serially which minimized costs but caused poor performance.
Instead issue these in parallel since HeadObject is cheap.  Reduces
getattr time of non-existent files from 732 ms to 369 ms.
References #1643.