### PR TITLE
Make pseudo fd for each file opening and each pseudo fd has own upload info

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,6 +47,8 @@ s3fs_SOURCES = \
     fdcache_page.cpp \
     fdcache_stat.cpp \
     fdcache_auto.cpp \
+    fdcache_fdinfo.cpp \
+    fdcache_pseudofd.cpp \
     addhead.cpp \
     sighandlers.cpp \
     autolock.cpp \

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3984,7 +3984,7 @@ int S3fsCurl::MultipartHeadRequest(const char* tpath, off_t size, headers_t& met
     return 0;
 }
 
-int S3fsCurl::MultipartUploadRequest(const std::string& upload_id, const char* tpath, int fd, off_t offset, off_t size, etaglist_t& list)
+int S3fsCurl::MultipartUploadRequest(const std::string& upload_id, const char* tpath, int fd, off_t offset, off_t size, int part_num, std::string* petag)
 {
     S3FS_PRN_INFO3("[upload_id=%s][tpath=%s][fd=%d][offset=%lld][size=%lld]", upload_id.c_str(), SAFESTRPTR(tpath), fd, static_cast<long long int>(offset), static_cast<long long int>(size));
 
@@ -4004,12 +4004,12 @@ int S3fsCurl::MultipartUploadRequest(const std::string& upload_id, const char* t
     partdata.size       = size;
     b_partdata_startpos = partdata.startpos;
     b_partdata_size     = partdata.size;
-    partdata.add_etag_list(&list);
+    partdata.add_etag(petag);
 
     // upload part
     int   result;
-    if(0 != (result = UploadMultipartPostRequest(tpath, list.size(), upload_id))){
-        S3FS_PRN_ERR("failed uploading part(%d)", result);
+    if(0 != (result = UploadMultipartPostRequest(tpath, part_num, upload_id))){
+        S3FS_PRN_ERR("failed uploading %d part by error(%d)", part_num, result);
         close(fd2);
         return result;
     }

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3984,67 +3984,6 @@ int S3fsCurl::MultipartHeadRequest(const char* tpath, off_t size, headers_t& met
     return 0;
 }
 
-int S3fsCurl::MultipartUploadRequest(const char* tpath, headers_t& meta, int fd, bool is_copy)
-{
-    int            result;
-    std::string    upload_id;
-    struct stat    st;
-    int            fd2;
-    etaglist_t     list;
-    off_t          remaining_bytes;
-    off_t          chunk;
-
-    S3FS_PRN_INFO3("[tpath=%s][fd=%d]", SAFESTRPTR(tpath), fd);
-
-    // duplicate fd
-    if(-1 == (fd2 = dup(fd)) || 0 != lseek(fd2, 0, SEEK_SET)){
-        S3FS_PRN_ERR("Could not duplicate file descriptor(errno=%d)", errno);
-        if(-1 != fd2){
-            close(fd2);
-        }
-        return -errno;
-    }
-    if(-1 == fstat(fd2, &st)){
-        S3FS_PRN_ERR("Invalid file descriptor(errno=%d)", errno);
-        close(fd2);
-        return -errno;
-    }
-
-    if(0 != (result = PreMultipartPostRequest(tpath, meta, upload_id, is_copy))){
-        close(fd2);
-        return result;
-    }
-    DestroyCurlHandle();
-
-    // cycle through open fd, pulling off 10MB chunks at a time
-    for(remaining_bytes = st.st_size; 0 < remaining_bytes; remaining_bytes -= chunk){
-        // chunk size
-        chunk = remaining_bytes > S3fsCurl::multipart_size ? S3fsCurl::multipart_size : remaining_bytes;
-
-        // set
-        partdata.fd         = fd2;
-        partdata.startpos   = st.st_size - remaining_bytes;
-        partdata.size       = chunk;
-        b_partdata_startpos = partdata.startpos;
-        b_partdata_size     = partdata.size;
-        partdata.add_etag_list(&list);
-
-        // upload part
-        if(0 != (result = UploadMultipartPostRequest(tpath, list.size(), upload_id))){
-            S3FS_PRN_ERR("failed uploading part(%d)", result);
-            close(fd2);
-            return result;
-        }
-        DestroyCurlHandle();
-    }
-    close(fd2);
-
-    if(0 != (result = CompleteMultipartPostRequest(tpath, upload_id, list))){
-        return result;
-    }
-    return 0;
-}
-
 int S3fsCurl::MultipartUploadRequest(const std::string& upload_id, const char* tpath, int fd, off_t offset, off_t size, etaglist_t& list)
 {
     S3FS_PRN_INFO3("[upload_id=%s][tpath=%s][fd=%d][offset=%lld][size=%lld]", upload_id.c_str(), SAFESTRPTR(tpath), fd, static_cast<long long int>(offset), static_cast<long long int>(size));

--- a/src/curl.h
+++ b/src/curl.h
@@ -393,7 +393,6 @@ class S3fsCurl
         int MultipartListRequest(std::string& body);
         int AbortMultipartUpload(const char* tpath, const std::string& upload_id);
         int MultipartHeadRequest(const char* tpath, off_t size, headers_t& meta, bool is_copy);
-        int MultipartUploadRequest(const char* tpath, headers_t& meta, int fd, bool is_copy);
         int MultipartUploadRequest(const std::string& upload_id, const char* tpath, int fd, off_t offset, off_t size, etaglist_t& list);
         int MultipartRenameRequest(const char* from, const char* to, headers_t& meta, off_t size);
 

--- a/src/curl.h
+++ b/src/curl.h
@@ -393,7 +393,7 @@ class S3fsCurl
         int MultipartListRequest(std::string& body);
         int AbortMultipartUpload(const char* tpath, const std::string& upload_id);
         int MultipartHeadRequest(const char* tpath, off_t size, headers_t& meta, bool is_copy);
-        int MultipartUploadRequest(const std::string& upload_id, const char* tpath, int fd, off_t offset, off_t size, etaglist_t& list);
+        int MultipartUploadRequest(const std::string& upload_id, const char* tpath, int fd, off_t offset, off_t size, int part_num, std::string* petag);
         int MultipartRenameRequest(const char* from, const char* to, headers_t& meta, off_t size);
 
         // methods(variables)

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -76,9 +76,9 @@ class FdManager
       static bool HaveLseekHole();
 
       // Return FdEntity associated with path, returning NULL on error.  This operation increments the reference count; callers must decrement via Close after use.
-      FdEntity* GetFdEntity(const char* path, int& existfd, bool newfd = true);
+      FdEntity* GetFdEntity(const char* path, int& existfd, bool newfd = true, bool lock_already_held = false);
       FdEntity* Open(int& fd, const char* path, headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, int flags = O_RDONLY, bool force_tmpfile = false, bool is_create = true, bool no_fd_lock_wait = false);
-      FdEntity* GetExistFdEntiy(const char* path, int existfd = -1);
+      FdEntity* GetExistFdEntity(const char* path, int existfd = -1);
       FdEntity* OpenExistFdEntiy(const char* path, int& fd, int flags = O_RDONLY);
       void Rename(const std::string &from, const std::string &to);
       bool Close(FdEntity* ent, int fd);

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -67,7 +67,7 @@ class FdManager
       static bool MakeRandomTempPath(const char* path, std::string& tmppath);
       static bool SetCheckCacheDirExist(bool is_check);
       static bool CheckCacheDirExist();
-
+      static bool HasOpenEntityFd(const char* path);
       static off_t GetEnsureFreeDiskSpace();
       static off_t SetEnsureFreeDiskSpace(off_t size);
       static bool IsSafeDiskSpace(const char* path, off_t size);
@@ -76,11 +76,12 @@ class FdManager
       static bool HaveLseekHole();
 
       // Return FdEntity associated with path, returning NULL on error.  This operation increments the reference count; callers must decrement via Close after use.
-      FdEntity* GetFdEntity(const char* path, int existfd = -1, bool increase_ref = true);
-      FdEntity* Open(const char* path, headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, bool force_tmpfile = false, bool is_create = true, bool no_fd_lock_wait = false);
-      FdEntity* ExistOpen(const char* path, int existfd = -1, bool ignore_existfd = false);
+      FdEntity* GetFdEntity(const char* path, int& existfd, bool newfd = true);
+      FdEntity* Open(int& fd, const char* path, headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, int flags = O_RDONLY, bool force_tmpfile = false, bool is_create = true, bool no_fd_lock_wait = false);
+      FdEntity* GetExistFdEntiy(const char* path, int existfd = -1);
+      FdEntity* OpenExistFdEntiy(const char* path, int& fd, int flags = O_RDONLY);
       void Rename(const std::string &from, const std::string &to);
-      bool Close(FdEntity* ent);
+      bool Close(FdEntity* ent, int fd);
       bool ChangeEntityToTempPath(FdEntity* ent, const char* path);
       void CleanupCacheDir();
 

--- a/src/fdcache_auto.cpp
+++ b/src/fdcache_auto.cpp
@@ -112,12 +112,12 @@ FdEntity* AutoFdEntity::Open(const char* path, headers_t* pmeta, off_t size, tim
 // [NOTE]
 // the fd obtained by this method is not a newly created pseudo fd.
 //
-FdEntity* AutoFdEntity::GetExistFdEntiy(const char* path, int existfd)
+FdEntity* AutoFdEntity::GetExistFdEntity(const char* path, int existfd)
 {
     Close();
 
     FdEntity* ent;
-    if(NULL == (ent = FdManager::get()->GetExistFdEntiy(path, existfd))){
+    if(NULL == (ent = FdManager::get()->GetExistFdEntity(path, existfd))){
         return NULL;
     }
     return ent;

--- a/src/fdcache_auto.h
+++ b/src/fdcache_auto.h
@@ -51,7 +51,7 @@ class AutoFdEntity
       int GetPseudoFd() const { return pseudo_fd; }
 
       FdEntity* Open(const char* path, headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, int flags = O_RDONLY, bool force_tmpfile = false, bool is_create = true, bool no_fd_lock_wait = false);
-      FdEntity* GetExistFdEntiy(const char* path, int existfd = -1);
+      FdEntity* GetExistFdEntity(const char* path, int existfd = -1);
       FdEntity* OpenExistFdEntiy(const char* path, int flags = O_RDONLY);
 };
 

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1594,7 +1594,7 @@ ssize_t FdEntity::Write(int fd, const char* bytes, off_t start, size_t size)
     S3FS_PRN_DBG("[path=%s][pseudo_fd=%d][physical_fd=%d][offset=%lld][size=%zu]", path.c_str(), fd, physical_fd, static_cast<long long int>(start), size);
 
     PseudoFdInfo* pseudo_obj = NULL;
-    if(-1 == physical_fd || NULL == (pseudo_obj = CheckPseudoFdFlags(fd, true))){
+    if(-1 == physical_fd || NULL == (pseudo_obj = CheckPseudoFdFlags(fd, false))){
         S3FS_PRN_DBG("pseudo_fd(%d) to physical_fd(%d) for path(%s) is not opened or not writable", fd, physical_fd, path.c_str());
         return -EBADF;
     }

--- a/src/fdcache_fdinfo.cpp
+++ b/src/fdcache_fdinfo.cpp
@@ -33,6 +33,18 @@
 //------------------------------------------------
 PseudoFdInfo::PseudoFdInfo(int fd, int open_flags) : pseudo_fd(-1), physical_fd(fd), flags(0) //, is_lock_init(false)
 {
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+#if S3FS_PTHREAD_ERRORCHECK
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+#endif
+    int result;
+    if(0 != (result = pthread_mutex_init(&upload_list_lock, &attr))){
+        S3FS_PRN_CRIT("failed to init upload_list_lock: %d", result);
+        abort();
+    }
+    is_lock_init = true;
+
     if(-1 != physical_fd){
         pseudo_fd = PseudoFdManager::Get();
         flags     = open_flags;
@@ -41,6 +53,14 @@ PseudoFdInfo::PseudoFdInfo(int fd, int open_flags) : pseudo_fd(-1), physical_fd(
 
 PseudoFdInfo::~PseudoFdInfo()
 {
+    if(is_lock_init){
+      int result;
+      if(0 != (result = pthread_mutex_destroy(&upload_list_lock))){
+          S3FS_PRN_CRIT("failed to destroy upload_list_lock: %d", result);
+          abort();
+      }
+      is_lock_init = false;
+    }
     Clear();
 }
 
@@ -85,6 +105,131 @@ bool PseudoFdInfo::Readable() const
         return false;
     }
     // O_RDONLY is 0x00, it means any pattern is readable.
+    return true;
+}
+
+bool PseudoFdInfo::ClearUploadInfo(bool is_cancel_mp, bool lock_already_held)
+{
+    AutoLock auto_lock(&upload_list_lock, lock_already_held ? AutoLock::ALREADY_LOCKED : AutoLock::NONE);
+
+    if(is_cancel_mp){
+        // [TODO]
+        // If we have any uploaded parts, we should delete them here.
+        // We haven't implemented it yet, but it will be implemented in the future.
+        // (User can delete them in the utility mode of s3fs.)
+        //
+        S3FS_PRN_INFO("Implementation of cancellation process for multipart upload is awaited.");
+    }
+
+    upload_id.erase();
+    upload_list.clear();
+    ClearUntreated(true);
+
+    return true;
+}
+
+bool PseudoFdInfo::InitialUploadInfo(const std::string& id)
+{
+    AutoLock auto_lock(&upload_list_lock);
+
+    if(!ClearUploadInfo(true, true)){
+        return false;
+    }
+    upload_id = id;
+    return true;
+}
+
+bool PseudoFdInfo::GetUploadId(std::string& id) const
+{
+    if(IsUploading()){
+        S3FS_PRN_ERR("Multipart Upload has not started yet.");
+        return false;
+    }
+    id = upload_id;
+    return true;
+}
+
+bool PseudoFdInfo::GetEtaglist(etaglist_t& list)
+{
+    if(IsUploading()){
+        S3FS_PRN_ERR("Multipart Upload has not started yet.");
+        return false;
+    }
+
+    AutoLock auto_lock(&upload_list_lock);
+
+    list.clear();
+    for(mppart_list_t::const_iterator iter = upload_list.begin(); iter != upload_list.end(); ++iter){
+        list.push_back(iter->etag);
+    }
+    return !list.empty();
+}
+
+// [NOTE]
+// This method adds a part for a multipart upload.
+// The added new part must be an area that is exactly continuous with the
+// immediately preceding part.
+// An error will occur if it is discontinuous or if it overlaps with an
+// existing area.
+//
+bool PseudoFdInfo::AppendUploadPart(off_t start, off_t size, bool is_copy, int* ppartnum, std::string** ppetag)
+{
+    if(IsUploading()){
+        S3FS_PRN_ERR("Multipart Upload has not started yet.");
+        return false;
+    }
+
+    AutoLock auto_lock(&upload_list_lock);
+    off_t    next_start_pos = 0;
+    if(!upload_list.empty()){
+        next_start_pos = upload_list.back().start + upload_list.back().size;
+    }
+    if(start != next_start_pos){
+        S3FS_PRN_ERR("The expected starting position for the next part is %lld, but %lld was specified.", static_cast<long long int>(next_start_pos), static_cast<long long int>(start));
+        return false;
+    }
+
+    // add new part
+    MPPART_INFO newpart(start, size, is_copy, NULL);
+    upload_list.push_back(newpart);
+
+    // set part number
+    if(ppartnum){
+        *ppartnum = upload_list.size();
+    }
+
+    // set etag pointer
+    if(ppetag){
+        *ppetag = &(upload_list.back().etag);
+    }
+    return true;
+}
+
+void PseudoFdInfo::ClearUntreated(bool lock_already_held)
+{
+    AutoLock auto_lock(&upload_list_lock, lock_already_held ? AutoLock::ALREADY_LOCKED : AutoLock::NONE);
+
+    untreated_start = 0;
+    untreated_size  = 0;
+}
+
+bool PseudoFdInfo::GetUntreated(off_t& start, off_t& size)
+{
+    AutoLock auto_lock(&upload_list_lock);
+
+    start = untreated_start;
+    size  = untreated_size;
+
+    return true;
+}
+
+bool PseudoFdInfo::SetUntreated(off_t start, off_t size)
+{
+    AutoLock auto_lock(&upload_list_lock);
+
+    untreated_start = start;
+    untreated_size  = size;
+
     return true;
 }
 

--- a/src/fdcache_fdinfo.cpp
+++ b/src/fdcache_fdinfo.cpp
@@ -1,0 +1,98 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2007 Takeshi Nakatani <ggtakec.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <algorithm>
+
+#include "common.h"
+#include "s3fs.h"
+#include "fdcache_fdinfo.h"
+#include "fdcache_pseudofd.h"
+#include "autolock.h"
+
+//------------------------------------------------
+// PseudoFdInfo methods
+//------------------------------------------------
+PseudoFdInfo::PseudoFdInfo(int fd, int open_flags) : pseudo_fd(-1), physical_fd(fd), flags(0) //, is_lock_init(false)
+{
+    if(-1 != physical_fd){
+        pseudo_fd = PseudoFdManager::Get();
+        flags     = open_flags;
+    }
+}
+
+PseudoFdInfo::~PseudoFdInfo()
+{
+    Clear();
+}
+
+bool PseudoFdInfo::Clear()
+{
+    if(-1 != pseudo_fd){
+        PseudoFdManager::Release(pseudo_fd);
+    }
+    pseudo_fd   = -1;
+    physical_fd = -1;
+
+    return true;
+}
+
+bool PseudoFdInfo::Set(int fd, int open_flags)
+{
+    if(-1 == fd){
+        return false;
+    }
+    Clear();
+    physical_fd = fd;
+    pseudo_fd   = PseudoFdManager::Get();
+    flags       = open_flags;
+
+    return true;
+}
+
+bool PseudoFdInfo::Writable() const
+{
+    if(-1 == pseudo_fd){
+        return false;
+    }
+    if(0 == (flags & (O_WRONLY | O_RDWR))){
+        return false;
+    }
+    return true;
+}
+
+bool PseudoFdInfo::Readable() const
+{
+    if(-1 == pseudo_fd){
+        return false;
+    }
+    // O_RDONLY is 0x00, it means any pattern is readable.
+    return true;
+}
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/

--- a/src/fdcache_fdinfo.h
+++ b/src/fdcache_fdinfo.h
@@ -18,44 +18,38 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#ifndef S3FS_FDCACHE_AUTO_H_
-#define S3FS_FDCACHE_AUTO_H_
-
-#include "fdcache_entity.h"
+#ifndef S3FS_FDCACHE_FDINFO_H_
+#define S3FS_FDCACHE_FDINFO_H_
 
 //------------------------------------------------
-// class AutoFdEntity
+// Class PseudoFdInfo
 //------------------------------------------------
-// A class that opens fdentiry and closes it automatically.
-// This class object is used to prevent inconsistencies in
-// the number of references in fdentiry.
-// The methods are wrappers to the method of the FdManager class.
-//
-class AutoFdEntity
+class PseudoFdInfo
 {
-  private:
-      FdEntity* pFdEntity;
-      int       pseudo_fd;
+    private:
+        int             pseudo_fd;
+        int             physical_fd;
+        int             flags;              // flags at open
 
-  private:
-      AutoFdEntity(AutoFdEntity& other);
-      bool operator=(AutoFdEntity& other);
+    private:
+        bool Clear();
 
-  public:
-      AutoFdEntity();
-      ~AutoFdEntity();
+    public:
+        PseudoFdInfo(int fd = -1, int open_flags = 0);
+        ~PseudoFdInfo();
 
-      bool Close();
-      int Detach();
-      bool Attach(const char* path, int existfd);
-      int GetPseudoFd() const { return pseudo_fd; }
+        int GetPhysicalFd() const { return physical_fd; }
+        int GetPseudoFd() const { return pseudo_fd; }
+        int GetFlags() const { return flags; }
+        bool Writable() const;
+        bool Readable() const;
 
-      FdEntity* Open(const char* path, headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, int flags = O_RDONLY, bool force_tmpfile = false, bool is_create = true, bool no_fd_lock_wait = false);
-      FdEntity* GetExistFdEntiy(const char* path, int existfd = -1);
-      FdEntity* OpenExistFdEntiy(const char* path, int flags = O_RDONLY);
+        bool Set(int fd, int open_flags);
 };
 
-#endif // S3FS_FDCACHE_AUTO_H_
+typedef std::map<int, class PseudoFdInfo*> fdinfo_map_t;
+
+#endif // S3FS_FDCACHE_FDINFO_H_
 
 /*
 * Local variables:

--- a/src/fdcache_pseudofd.cpp
+++ b/src/fdcache_pseudofd.cpp
@@ -1,0 +1,134 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2007 Takeshi Nakatani <ggtakec.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <algorithm>
+
+#include "common.h"
+#include "s3fs.h"
+#include "fdcache_pseudofd.h"
+#include "autolock.h"
+
+//------------------------------------------------
+// Symbols
+//------------------------------------------------
+// [NOTE]
+// The minimum pseudo fd value starts 2.
+// This is to avoid mistakes for 0(stdout) and 1(stderr), which are usually used.
+//
+#define MIN_PSEUDOFD_NUMBER     2
+
+//------------------------------------------------
+// PseudoFdManager class methods
+//------------------------------------------------
+PseudoFdManager& PseudoFdManager::GetManager()
+{
+    static PseudoFdManager singleton;
+    return singleton;
+}
+
+int PseudoFdManager::Get()
+{
+    return (PseudoFdManager::GetManager()).CreatePseudoFd();
+}
+
+bool PseudoFdManager::Release(int fd)
+{
+    return (PseudoFdManager::GetManager()).ReleasePseudoFd(fd);
+}
+
+//------------------------------------------------
+// PseudoFdManager methods
+//------------------------------------------------
+PseudoFdManager::PseudoFdManager() : is_lock_init(false)
+{
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+#if S3FS_PTHREAD_ERRORCHECK
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+#endif
+    int result;
+    if(0 != (result = pthread_mutex_init(&pseudofd_list_lock, &attr))){
+        S3FS_PRN_CRIT("failed to init pseudofd_list_lock: %d", result);
+        abort();
+    }
+    is_lock_init = true;
+}
+
+PseudoFdManager::~PseudoFdManager()
+{
+    if(is_lock_init){
+      int result;
+      if(0 != (result = pthread_mutex_destroy(&pseudofd_list_lock))){
+          S3FS_PRN_CRIT("failed to destroy pseudofd_list_lock: %d", result);
+          abort();
+      }
+      is_lock_init = false;
+    }
+}
+
+int PseudoFdManager::GetUnusedMinPseudoFd() const
+{
+    int min_fd = MIN_PSEUDOFD_NUMBER;
+
+    // Look for the first discontinuous value.
+    for(pseudofd_list_t::const_iterator iter = pseudofd_list.begin(); iter != pseudofd_list.end(); ++iter){
+        if(min_fd == (*iter)){
+            ++min_fd;
+        }else if(min_fd < (*iter)){
+            break;
+        }
+    }
+    return min_fd;
+}
+
+int PseudoFdManager::CreatePseudoFd()
+{
+    AutoLock auto_lock(&pseudofd_list_lock);
+
+    int new_fd = PseudoFdManager::GetUnusedMinPseudoFd();
+    pseudofd_list.push_back(new_fd);
+    std::sort(pseudofd_list.begin(), pseudofd_list.end());
+
+    return new_fd;
+}
+
+bool PseudoFdManager::ReleasePseudoFd(int fd)
+{
+    AutoLock auto_lock(&pseudofd_list_lock);
+
+    for(pseudofd_list_t::iterator iter = pseudofd_list.begin(); iter != pseudofd_list.end(); ++iter){
+        if(fd == (*iter)){
+            pseudofd_list.erase(iter);
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/

--- a/src/fdcache_pseudofd.h
+++ b/src/fdcache_pseudofd.h
@@ -18,44 +18,42 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#ifndef S3FS_FDCACHE_AUTO_H_
-#define S3FS_FDCACHE_AUTO_H_
-
-#include "fdcache_entity.h"
+#ifndef S3FS_FDCACHE_PSEUDOFD_H_
+#define S3FS_FDCACHE_PSEUDOFD_H_
 
 //------------------------------------------------
-// class AutoFdEntity
+// Typdefs
 //------------------------------------------------
-// A class that opens fdentiry and closes it automatically.
-// This class object is used to prevent inconsistencies in
-// the number of references in fdentiry.
-// The methods are wrappers to the method of the FdManager class.
+// List of pseudo fd in use
 //
-class AutoFdEntity
+typedef std::vector<int>    pseudofd_list_t;
+
+//------------------------------------------------
+// Class PseudoFdManager
+//------------------------------------------------
+class PseudoFdManager
 {
-  private:
-      FdEntity* pFdEntity;
-      int       pseudo_fd;
+    private:
+        pseudofd_list_t pseudofd_list;
+        bool            is_lock_init;
+        pthread_mutex_t pseudofd_list_lock;    // protects pseudofd_list
 
-  private:
-      AutoFdEntity(AutoFdEntity& other);
-      bool operator=(AutoFdEntity& other);
+    private:
+        static PseudoFdManager& GetManager();
 
-  public:
-      AutoFdEntity();
-      ~AutoFdEntity();
+        PseudoFdManager();
+        ~PseudoFdManager();
 
-      bool Close();
-      int Detach();
-      bool Attach(const char* path, int existfd);
-      int GetPseudoFd() const { return pseudo_fd; }
+        int GetUnusedMinPseudoFd() const;
+        int CreatePseudoFd();
+        bool ReleasePseudoFd(int fd);
 
-      FdEntity* Open(const char* path, headers_t* pmeta = NULL, off_t size = -1, time_t time = -1, int flags = O_RDONLY, bool force_tmpfile = false, bool is_create = true, bool no_fd_lock_wait = false);
-      FdEntity* GetExistFdEntiy(const char* path, int existfd = -1);
-      FdEntity* OpenExistFdEntiy(const char* path, int flags = O_RDONLY);
+    public:
+        static int Get();
+        static bool Release(int fd);
 };
 
-#endif // S3FS_FDCACHE_AUTO_H_
+#endif // S3FS_FDCACHE_PSEUDOFD_H_
 
 /*
 * Local variables:

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2316,7 +2316,7 @@ static int s3fs_read(const char* _path, char* buf, size_t size, off_t offset, st
 
     AutoFdEntity autoent;
     FdEntity*    ent;
-    if(NULL == (ent = autoent.GetExistFdEntiy(path, static_cast<int>(fi->fh)))){
+    if(NULL == (ent = autoent.GetExistFdEntity(path, static_cast<int>(fi->fh)))){
         S3FS_PRN_ERR("could not find opened fd(%s)", path);
         return -EIO;
     }
@@ -2344,7 +2344,7 @@ static int s3fs_write(const char* _path, const char* buf, size_t size, off_t off
 
     AutoFdEntity autoent;
     FdEntity*    ent;
-    if(NULL == (ent = autoent.GetExistFdEntiy(path, static_cast<int>(fi->fh)))){
+    if(NULL == (ent = autoent.GetExistFdEntity(path, static_cast<int>(fi->fh)))){
         S3FS_PRN_ERR("could not find opened fd(%s)", path);
         return -EIO;
     }
@@ -2403,7 +2403,7 @@ static int s3fs_flush(const char* _path, struct fuse_file_info* fi)
 
     AutoFdEntity autoent;
     FdEntity*    ent;
-    if(NULL != (ent = autoent.GetExistFdEntiy(path, static_cast<int>(fi->fh)))){
+    if(NULL != (ent = autoent.GetExistFdEntity(path, static_cast<int>(fi->fh)))){
         ent->UpdateMtime(true);         // clear the flag not to update mtime.
         ent->UpdateCtime();
         result = ent->Flush(static_cast<int>(fi->fh), false);
@@ -2426,7 +2426,7 @@ static int s3fs_fsync(const char* _path, int datasync, struct fuse_file_info* fi
 
     AutoFdEntity autoent;
     FdEntity*    ent;
-    if(NULL != (ent = autoent.GetExistFdEntiy(path, static_cast<int>(fi->fh)))){
+    if(NULL != (ent = autoent.GetExistFdEntity(path, static_cast<int>(fi->fh)))){
         if(0 == datasync){
             ent->UpdateMtime();
             ent->UpdateCtime();

--- a/src/types.h
+++ b/src/types.h
@@ -208,6 +208,11 @@ struct filepart
         list->push_back(std::string());
         petag = &list->back();
     }
+
+    void add_etag(std::string* petagobj)
+    {
+        petag = petagobj;
+    }
 };
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
This PR is a fix for managing file descriptors that will be needed for future fixes in s3fs.
_I'm improving the performance of s3fs and want to update the correction part in small pieces, so first I will post the code without upload logic change._

### NOTE
This PR has a lot of modified code, but it is separated into the following two commits and put together as one PR.
The reason for posting them together is that if these are posted two separately, we may not understand the purpose of the PR.
Please do not squash when merging.

### Current code
When a file(S3 object) is opened, the file descriptor(issued by the system(os)) to the local file of the cache file(or temporary file) managed by s3fs is returned to FUSE.
s3fs always returns the same file descriptor, even if the file is opened at the same time.
(However, the number of open is kept as the number of references)
And s3fs cannot distinguish system calls(and callers) using fd for the same file.


### [Commit] Introduced pseudo fd and separated fd for each file opening
Changed s3fs to return a different pseudo file descriptor each time a file is opened at the same time.
This allows s3fs to recognize between callers, and system calls with fd can be processed depending on the caller.
Also, it has been fixed so that the file open flag(read/write, etc.) can be retained.

Note that there is only one cache file(and temporary file), even if the files are opened at the same time and different pseudo fd are issued.
In other words, pseuto fd is issued as a reference to one physical file.

### [Commit] Added info object about multipart uploading for each pseudo fd
The multi-part upload id and etag managed by the FdEntity object have been changed to be managed in units of pseudo fd.
I changed the information of multipart upload to be managed individually, but please note that there is only one cache file(or temporary file) for one file.
