### PR TITLE
Correct usage of istringstream

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -424,12 +424,8 @@ bool S3fsCurl::InitMimeType(const std::string& strFile)
             std::istringstream tmp(line);
             std::string mimeType;
             tmp >> mimeType;
-            while(tmp){
-                std::string ext;
-                tmp >> ext;
-                if(ext.empty()){
-                    continue;
-                }
+            std::string ext;
+            while(tmp >> ext){
                 S3fsCurl::mimeTypes[ext] = mimeType;
             }
         }


### PR DESCRIPTION
Previously this looped one more time than necessary due to the `eof`
check:

https://isocpp.org/wiki/faq/input-output#istream-and-eof

Remove now redundant `empty` check.