### PR TITLE
Fix implicit narrowing conversions

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -180,16 +180,16 @@ class S3fsCurl
         BodyData             headdata;             // header data by WriteMemoryCallback
         volatile long        LastResponseCode;
         const unsigned char* postdata;             // use by post method and read callback function.
-        int                  postdata_remaining;   // use by post method and read callback function.
+        off_t                postdata_remaining;   // use by post method and read callback function.
         filepart             partdata;             // use by multipart upload/get object callback
         bool                 is_use_ahbe;          // additional header by extension
         int                  retry_count;          // retry count for multipart
         FILE*                b_infile;             // backup for retrying
         const unsigned char* b_postdata;           // backup for retrying
-        int                  b_postdata_remaining; // backup for retrying
+        off_t                b_postdata_remaining; // backup for retrying
         off_t                b_partdata_startpos;  // backup for retrying
         off_t                b_partdata_size;      // backup for retrying
-        int                  b_ssekey_pos;         // backup for retrying
+        size_t               b_ssekey_pos;         // backup for retrying
         std::string          b_ssevalue;           // backup for retrying
         sse_type_t           b_ssetype;            // backup for retrying
         std::string          b_from;               // backup for retrying(for copy request)
@@ -318,8 +318,8 @@ class S3fsCurl
         static bool IsSetSseKmsId() { return !S3fsCurl::ssekmsid.empty(); }
         static const char* GetSseKmsId() { return S3fsCurl::ssekmsid.c_str(); }
         static bool GetSseKey(std::string& md5, std::string& ssekey);
-        static bool GetSseKeyMd5(int pos, std::string& md5);
-        static int GetSseKeyCount();
+        static bool GetSseKeyMd5(size_t pos, std::string& md5);
+        static size_t GetSseKeyCount();
         static bool SetContentMd5(bool flag);
         static bool SetVerbose(bool flag);
         static bool GetVerbose() { return S3fsCurl::is_verbose; }
@@ -376,8 +376,8 @@ class S3fsCurl
         bool GetResponseCode(long& responseCode, bool from_curl_handle = true);
         int RequestPerform(bool dontAddAuthHeaders=false);
         int DeleteRequest(const char* tpath);
-        bool PreHeadRequest(const char* tpath, const char* bpath = NULL, const char* savedpath = NULL, int ssekey_pos = -1);
-        bool PreHeadRequest(const std::string& tpath, const std::string& bpath, const std::string& savedpath, int ssekey_pos = -1) {
+        bool PreHeadRequest(const char* tpath, const char* bpath = NULL, const char* savedpath = NULL, size_t ssekey_pos = -1);
+        bool PreHeadRequest(const std::string& tpath, const std::string& bpath, const std::string& savedpath, size_t ssekey_pos = -1) {
           return PreHeadRequest(tpath.c_str(), bpath.c_str(), savedpath.c_str(), ssekey_pos);
         }
         int HeadRequest(const char* tpath, headers_t& meta);
@@ -415,7 +415,7 @@ class S3fsCurl
         int GetMultipartRetryCount() const { return retry_count; }
         void SetMultipartRetryCount(int retrycnt) { retry_count = retrycnt; }
         bool IsOverMultipartRetryCount() const { return (retry_count >= S3fsCurl::retries); }
-        int GetLastPreHeadSeecKeyPos() const { return b_ssekey_pos; }
+        size_t GetLastPreHeadSeecKeyPos() const { return b_ssekey_pos; }
 };
 
 #endif // S3FS_CURL_H_

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -258,9 +258,9 @@ std::string prepare_url(const char* url)
     std::string path;
     std::string url_str = std::string(url);
     std::string token = std::string("/") + bucket;
-    int bucket_pos;
-    int bucket_length = token.size();
-    int uri_length = 0;
+    size_t bucket_pos;
+    size_t bucket_length = token.size();
+    size_t uri_length = 0;
 
     if(!strncasecmp(url_str.c_str(), "https://", 8)){
         uri_length = 8;

--- a/src/fdcache_fdinfo.cpp
+++ b/src/fdcache_fdinfo.cpp
@@ -195,7 +195,7 @@ bool PseudoFdInfo::AppendUploadPart(off_t start, off_t size, bool is_copy, int* 
 
     // set part number
     if(ppartnum){
-        *ppartnum = upload_list.size();
+        *ppartnum = static_cast<int>(upload_list.size());
     }
 
     // set etag pointer

--- a/src/fdcache_page.cpp
+++ b/src/fdcache_page.cpp
@@ -542,7 +542,7 @@ off_t PageList::GetTotalUnloadedPageSize(off_t start, off_t size) const
     return restsize;
 }
 
-int PageList::GetUnloadedPages(fdpage_list_t& unloaded_list, off_t start, off_t size) const
+size_t PageList::GetUnloadedPages(fdpage_list_t& unloaded_list, off_t start, off_t size) const
 {
     // If size is 0, it means loading to end.
     if(0 == size){
@@ -801,7 +801,7 @@ bool PageList::Serialize(CacheFileStat& file, bool is_output, ino_t inode)
             return true;
         }
         char* ptmp = new char[st.st_size + 1];
-        int result;
+        ssize_t result;
         // read from file
         if(0 >= (result = pread(file.GetFd(), ptmp, st.st_size, 0))){
             S3FS_PRN_ERR("failed to read stats(%d)", errno);

--- a/src/fdcache_page.h
+++ b/src/fdcache_page.h
@@ -107,7 +107,7 @@ class PageList
         bool SetPageLoadedStatus(off_t start, off_t size, PageList::page_status pstatus = PAGE_LOADED, bool is_compress = true);
         bool FindUnloadedPage(off_t start, off_t& resstart, off_t& ressize) const;
         off_t GetTotalUnloadedPageSize(off_t start = 0, off_t size = 0) const;    // size=0 is checking to end of list
-        int GetUnloadedPages(fdpage_list_t& unloaded_list, off_t start = 0, off_t size = 0) const;  // size=0 is checking to end of list
+        size_t GetUnloadedPages(fdpage_list_t& unloaded_list, off_t start = 0, off_t size = 0) const;  // size=0 is checking to end of list
         bool GetPageListsForMultipartUpload(fdpage_list_t& dlpages, fdpage_list_t& mixuppages, off_t max_partsize);
         bool GetNoDataPageLists(fdpage_list_t& nodata_pages, off_t start = 0, size_t size = 0);
 

--- a/src/gnutls_auth.cpp
+++ b/src/gnutls_auth.cpp
@@ -281,7 +281,7 @@ size_t get_sha256_digest_length()
 }
 
 #ifdef USE_GNUTLS_NETTLE
-bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char** digest, unsigned int* digestlen)
+bool s3fs_sha256(const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen)
 {
     (*digestlen) = static_cast<unsigned int>(get_sha256_digest_length());
     *digest = new unsigned char[*digestlen];
@@ -325,7 +325,7 @@ unsigned char* s3fs_sha256_fd(int fd, off_t start, off_t size)
 
 #else // USE_GNUTLS_NETTLE
 
-bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char** digest, unsigned int* digestlen)
+bool s3fs_sha256(const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen)
 {
     size_t len = (*digestlen) = static_cast<unsigned int>(get_sha256_digest_length());
     *digest = new unsigned char[len];

--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -49,7 +49,7 @@ static struct timespec cvt_string_to_time(const char *str)
             strmtime.erase(pos);
         }
     }
-    return {cvt_strtoofft(strmtime.c_str()), nsec};
+    return {static_cast<time_t>(cvt_strtoofft(strmtime.c_str())), nsec};
 }
 
 static struct timespec get_time(const headers_t& meta, const char *header)

--- a/src/nss_auth.cpp
+++ b/src/nss_auth.cpp
@@ -198,7 +198,7 @@ size_t get_sha256_digest_length()
     return SHA256_LENGTH;
 }
 
-bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char** digest, unsigned int* digestlen)
+bool s3fs_sha256(const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen)
 {
     (*digestlen) = static_cast<unsigned int>(get_sha256_digest_length());
     *digest      = new unsigned char[*digestlen];

--- a/src/openssl_auth.cpp
+++ b/src/openssl_auth.cpp
@@ -227,9 +227,9 @@ static bool s3fs_HMAC_RAW(const void* key, size_t keylen, const unsigned char* d
     (*digestlen) = EVP_MAX_MD_SIZE * sizeof(unsigned char);
     *digest      = new unsigned char[*digestlen];
     if(is_sha256){
-        HMAC(EVP_sha256(), key, keylen, data, datalen, *digest, digestlen);
+        HMAC(EVP_sha256(), key, static_cast<int>(keylen), data, datalen, *digest, digestlen);
     }else{
-        HMAC(EVP_sha1(), key, keylen, data, datalen, *digest, digestlen);
+        HMAC(EVP_sha1(), key, static_cast<int>(keylen), data, datalen, *digest, digestlen);
     }
 
     return true;
@@ -299,7 +299,7 @@ size_t get_sha256_digest_length()
     return SHA256_DIGEST_LENGTH;
 }
 
-bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char** digest, unsigned int* digestlen)
+bool s3fs_sha256(const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen)
 {
     (*digestlen) = EVP_MAX_MD_SIZE * sizeof(unsigned char);
     *digest      = new unsigned char[*digestlen];

--- a/src/s3fs_auth.h
+++ b/src/s3fs_auth.h
@@ -45,7 +45,7 @@ bool s3fs_HMAC(const void* key, size_t keylen, const unsigned char* data, size_t
 bool s3fs_HMAC256(const void* key, size_t keylen, const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen);
 size_t get_md5_digest_length();
 unsigned char* s3fs_md5_fd(int fd, off_t start, off_t size);
-bool s3fs_sha256(const unsigned char* data, unsigned int datalen, unsigned char** digest, unsigned int* digestlen);
+bool s3fs_sha256(const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen);
 size_t get_sha256_digest_length();
 unsigned char* s3fs_sha256_fd(int fd, off_t start, off_t size);
 

--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -458,7 +458,7 @@ bool simple_parse_xml(const char* data, size_t len, const char* key, std::string
     value.clear();
 
     xmlDocPtr doc;
-    if(NULL == (doc = xmlReadMemory(data, len, "", NULL, 0))){
+    if(NULL == (doc = xmlReadMemory(data, static_cast<int>(len), "", NULL, 0))){
         return false;
     }
 


### PR DESCRIPTION
These do not appear to be problematic but rather just clean up warnings.
Found via clang `-Wshorten-64-to-32`.