### PR TITLE
Prefer std::string::rbegin over operator[]

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -249,7 +249,7 @@ bool StatCache::GetStat(const std::string& key, struct stat* pst, headers_t* met
     AutoLock lock(&StatCache::stat_cache_lock);
 
     stat_cache_t::iterator iter = stat_cache.end();
-    if(overcheck && '/' != strpath[strpath.length() - 1]){
+    if(overcheck && '/' != *strpath.rbegin()){
         strpath += "/";
         iter = stat_cache.find(strpath);
     }
@@ -335,7 +335,7 @@ bool StatCache::IsNoObjectCache(const std::string& key, bool overcheck)
     AutoLock lock(&StatCache::stat_cache_lock);
 
     stat_cache_t::iterator iter = stat_cache.end();
-    if(overcheck && '/' != strpath[strpath.length() - 1]){
+    if(overcheck && '/' != *strpath.rbegin()){
         strpath += "/";
         iter     = stat_cache.find(strpath);
     }
@@ -628,7 +628,7 @@ bool StatCache::DelStat(const char* key, bool lock_already_held)
     }
     if(0 < strlen(key) && 0 != strcmp(key, "/")){
         std::string strpath = key;
-        if('/' == strpath[strpath.length() - 1]){
+        if('/' == *strpath.rbegin()){
             // If there is "path" cache, delete it.
             strpath.erase(strpath.length() - 1);
         }else{

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -387,11 +387,11 @@ const char* getCurlDebugHead(curl_infotype type)
 //
 bool etag_equals(std::string s1, std::string s2)
 {
-    if(s1.length() > 1 && s1[0] == '\"' && s1[s1.length() - 1] == '\"'){
+    if(s1.length() > 1 && s1[0] == '\"' && *s1.rbegin() == '\"'){
         s1.erase(s1.size() - 1);
         s1.erase(0, 1);
     }
-    if(s2.length() > 1 && s2[0] == '\"' && s2[s2.length() - 1] == '\"'){
+    if(s2.length() > 1 && s2[0] == '\"' && *s2.rbegin() == '\"'){
         s2.erase(s2.size() - 1);
         s2.erase(0, 1);
     }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -219,7 +219,7 @@ static bool is_special_name_folder_object(const char* path)
     headers_t header;
 
     if(std::string::npos == strpath.find("_$folder$", 0)){
-        if('/' == strpath[strpath.length() - 1]){
+        if('/' == *strpath.rbegin()){
             strpath.erase(strpath.length() - 1);
         }
         strpath += "_$folder$";
@@ -254,7 +254,7 @@ static int chk_dir_object_type(const char* path, std::string& newpath, std::stri
 
     // Normalize new path.
     newpath = path;
-    if('/' != newpath[newpath.length() - 1]){
+    if('/' != *newpath.rbegin()){
         std::string::size_type Pos;
         if(std::string::npos != (Pos = newpath.find("_$folder$", 0))){
             newpath.erase(Pos);
@@ -277,7 +277,7 @@ static int chk_dir_object_type(const char* path, std::string& newpath, std::stri
             nowpath  = "";
         }else{
             nowpath = newpath;
-            if(0 < nowpath.length() && '/' == nowpath[nowpath.length() - 1]){
+            if(0 < nowpath.length() && '/' == *nowpath.rbegin()){
                 // "dir/" type
                 (*pType) = DIRTYPE_NEW;
             }else{
@@ -420,7 +420,7 @@ static int get_object_attribute(const char* path, struct stat* pstbuf, headers_t
     }else if(0 != result){
         if(overcheck){
             // when support_compat_dir is disabled, strpath maybe have "_$folder$".
-            if('/' != strpath[strpath.length() - 1] && std::string::npos == strpath.find("_$folder$", 0)){
+            if('/' != *strpath.rbegin() && std::string::npos == strpath.find("_$folder$", 0)){
                 // now path is "object", do check "object/" for over checking
                 strpath    += "/";
                 result      = s3fscurl.HeadRequest(strpath.c_str(), (*pheader));
@@ -443,7 +443,7 @@ static int get_object_attribute(const char* path, struct stat* pstbuf, headers_t
         }
         if(support_compat_dir && 0 != result && std::string::npos == strpath.find("_$folder$", 0)){
             // now path is "object" or "object/", do check "no dir object" which is not object but has only children.
-            if('/' == strpath[strpath.length() - 1]){
+            if('/' == *strpath.rbegin()){
                 strpath.erase(strpath.length() - 1);
             }
             if(-ENOTEMPTY == directory_empty(strpath.c_str())){
@@ -454,7 +454,7 @@ static int get_object_attribute(const char* path, struct stat* pstbuf, headers_t
             }
         }
     }else{
-        if(support_compat_dir && '/' != strpath[strpath.length() - 1] && std::string::npos == strpath.find("_$folder$", 0) && is_need_check_obj_detail(*pheader)){
+        if(support_compat_dir && '/' != *strpath.rbegin() && std::string::npos == strpath.find("_$folder$", 0) && is_need_check_obj_detail(*pheader)){
             // check a case of that "object" does not have attribute and "object" is possible to be directory.
             if(-ENOTEMPTY == directory_empty(strpath.c_str())){
                 // found "no dir object".
@@ -1014,7 +1014,7 @@ static int create_directory_object(const char* path, mode_t mode, time_t atime, 
         return -EINVAL;
     }
     std::string tpath = path;
-    if('/' != tpath[tpath.length() - 1]){
+    if('/' != *tpath.rbegin()){
         tpath += "/";
     }
 
@@ -1115,7 +1115,7 @@ static int s3fs_rmdir(const char* _path)
     }
 
     strpath = path;
-    if('/' != strpath[strpath.length() - 1]){
+    if('/' != *strpath.rbegin()){
         strpath += "/";
     }
     S3fsCurl s3fscurl;
@@ -1128,7 +1128,7 @@ static int s3fs_rmdir(const char* _path)
     // A case, there is only "dir", the first removing object is "dir/".
     // Then "dir/" is not exists, but curl_delete returns 0.
     // So need to check "dir" and should be removed it.
-    if('/' == strpath[strpath.length() - 1]){
+    if('/' == *strpath.rbegin()){
         strpath.erase(strpath.length() - 1);
     }
     if(0 == get_object_attribute(strpath.c_str(), &stbuf, NULL, false)){
@@ -2574,7 +2574,7 @@ static int readdir_multi_head(const char* path, const S3ObjList& head, void* buf
         std::string etag     = head.GetETag((*iter).c_str());
 
         std::string fillpath = disppath;
-        if('/' == disppath[disppath.length() - 1]){
+        if('/' == *disppath.rbegin()){
             fillpath.erase(fillpath.length() -1);
         }
         fillerlist.push_back(fillpath);
@@ -2694,7 +2694,7 @@ static int list_bucket(const char* path, S3ObjList& head, const char* delimiter,
 
     query_prefix += "&prefix=";
     s3_realpath = get_realpath(path);
-    if(0 == s3_realpath.length() || '/' != s3_realpath[s3_realpath.length() - 1]){
+    if(0 == s3_realpath.length() || '/' != *s3_realpath.rbegin()){
         // last word must be "/"
         query_prefix += urlEncode(s3_realpath.substr(1) + "/");
     }else{
@@ -2764,7 +2764,7 @@ static int list_bucket(const char* path, S3ObjList& head, const char* delimiter,
                     truncated = false;
                 }else{
                     next_marker = s3_realpath.substr(1);
-                    if(0 == s3_realpath.length() || '/' != s3_realpath[s3_realpath.length() - 1]){
+                    if(0 == s3_realpath.length() || '/' != *s3_realpath.rbegin()){
                         next_marker += "/";
                     }
                     next_marker += lastname;

--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -175,7 +175,7 @@ static char* get_object_name(xmlDocPtr doc, xmlNodePtr node, const char* path)
                 if(strlen(dirpath) > strlen(basepath)){
                     withdirname = &dirpath[strlen(basepath)];
                 }
-                if(0 < withdirname.length() && '/' != withdirname[withdirname.length() - 1]){
+                if(0 < withdirname.length() && '/' != *withdirname.rbegin()){
                     withdirname += "/";
                 }
                 withdirname += mybname;

--- a/src/s3objlist.cpp
+++ b/src/s3objlist.cpp
@@ -54,11 +54,11 @@ bool S3ObjList::insert(const char* name, const char* etag, bool is_dir)
         newname = orgname;
     }
     if(is_dir){
-        if('/' != newname[newname.length() - 1]){
+        if('/' != *newname.rbegin()){
             newname += "/";
         }
     }else{
-        if('/' == newname[newname.length() - 1]){
+        if('/' == *newname.rbegin()){
             is_dir = true;
         }
     }
@@ -223,7 +223,7 @@ bool S3ObjList::GetNameList(s3obj_list_t& list, bool OnlyNormalized, bool CutSla
             continue;
         }
         std::string name = (*iter).first;
-        if(CutSlash && 1 < name.length() && '/' == name[name.length() - 1]){
+        if(CutSlash && 1 < name.length() && '/' == *name.rbegin()){
             // only "/" std::string is skipped this.
             name.erase(name.length() - 1);
         }
@@ -242,7 +242,7 @@ bool S3ObjList::MakeHierarchizedList(s3obj_list_t& list, bool haveSlash)
 
     for(liter = list.begin(); list.end() != liter; ++liter){
         std::string strtmp = (*liter);
-        if(1 < strtmp.length() && '/' == strtmp[strtmp.length() - 1]){
+        if(1 < strtmp.length() && '/' == *strtmp.rbegin()){
             strtmp.erase(strtmp.length() - 1);
         }
         h_map[strtmp] = true;


### PR DESCRIPTION
This is more concise and safer due to not repeating the variable name.
We cannot use `std::string::back` since it is not available in C++03.