### PR TITLE
Protect orgmeta with fdent_lock

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1323,9 +1323,9 @@ int FdEntity::RowFlush(int fd, const char* tpath, bool force_sync)
     }
     int         result     = 0;
     std::string tmppath    = path;
-    headers_t   tmporgmeta = orgmeta;
 
     AutoLock auto_lock(&fdent_lock);
+    headers_t tmporgmeta = orgmeta;
 
     // check pseudo fd and its flag
     fdinfo_map_t::iterator miter = pseudo_fd_map.find(fd);


### PR DESCRIPTION
Fixes a crash seen with the CentOS 7 builder and when running with
AddressSanitizer.  Regression introduced by
ac578d188e811ed6bdc7a29fa3b0c810fc29d739.  Fixes #1677.