### PR TITLE
Set decimal base for converting subseconds to int

### DIFF
--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -45,7 +45,7 @@ static struct timespec cvt_string_to_time(const char *str)
         strmtime = str;
         std::string::size_type pos = strmtime.find('.', 0);
         if(std::string::npos != pos){
-            nsec = cvt_strtoofft(strmtime.substr(pos + 1).c_str());
+            nsec = cvt_strtoofft(strmtime.substr(pos + 1).c_str(), 10);
             strmtime.erase(pos);
         }
     }


### PR DESCRIPTION
The leading 0 triggers an automatic conversion as an octal value. This fails because it is a decimal value.

Setting the base to 10 prevents this automatism and treats the value as a decimal value.

Fixes: 
```
[WAN] string_util.cpp:cvt_strtoofft(96): something error is occurred in convert std::string(017080564) to off_t, thus return 0 as default.
```

Related to #1676