### PR TITLE
Require explicit base parameter in cvt_strtoofft

### DIFF
--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -45,11 +45,11 @@ static struct timespec cvt_string_to_time(const char *str)
         strmtime = str;
         std::string::size_type pos = strmtime.find('.', 0);
         if(std::string::npos != pos){
-            nsec = cvt_strtoofft(strmtime.substr(pos + 1).c_str(), 10);
+            nsec = cvt_strtoofft(strmtime.substr(pos + 1).c_str(), /*base=*/ 10);
             strmtime.erase(pos);
         }
     }
-    return {static_cast<time_t>(cvt_strtoofft(strmtime.c_str())), nsec};
+    return {static_cast<time_t>(cvt_strtoofft(strmtime.c_str(), /*base=*/ 10)), nsec};
 }
 
 static struct timespec get_time(const headers_t& meta, const char *header)
@@ -103,7 +103,7 @@ struct timespec get_atime(const headers_t& meta, bool overcheck)
 
 off_t get_size(const char *s)
 {
-    return cvt_strtoofft(s);
+    return cvt_strtoofft(s, /*base=*/ 10);
 }
 
 off_t get_size(const headers_t& meta)
@@ -202,7 +202,7 @@ mode_t get_mode(const headers_t& meta, const char* path, bool checkdir, bool for
 
 uid_t get_uid(const char *s)
 {
-    return static_cast<uid_t>(cvt_strtoofft(s));
+    return static_cast<uid_t>(cvt_strtoofft(s, /*base=*/ 0));
 }
 
 uid_t get_uid(const headers_t& meta)
@@ -221,7 +221,7 @@ uid_t get_uid(const headers_t& meta)
 
 gid_t get_gid(const char *s)
 {
-    return static_cast<gid_t>(cvt_strtoofft(s));
+    return static_cast<gid_t>(cvt_strtoofft(s, /*base=*/ 0));
 }
 
 gid_t get_gid(const headers_t& meta)

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4242,7 +4242,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "retries=")){
-            off_t retries = cvt_strtoofft(strchr(arg, '=') + sizeof(char));
+            off_t retries = cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10);
             if(retries == 0){
                 S3FS_PRN_EXIT("retries must be greater than zero");
                 return -1;
@@ -4267,7 +4267,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "multireq_max=")){
-            int maxreq = static_cast<int>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
+            int maxreq = static_cast<int>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10));
             S3fsCurl::SetMaxMultiRequest(maxreq);
             return 0;
         }
@@ -4284,7 +4284,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             off_t rrs = 1;
             // for an old format.
             if(is_prefix(arg, "use_rrs=")){
-                rrs = cvt_strtoofft(strchr(arg, '=') + sizeof(char));
+                rrs = cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10);
             }
             if(0 == rrs){
                 S3fsCurl::SetStorageClass("STANDARD");
@@ -4411,7 +4411,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "ssl_verify_hostname=")){
-            long sslvh = static_cast<long>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
+            long sslvh = static_cast<long>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10));
             if(-1 == S3fsCurl::SetSslVerifyHostname(sslvh)){
                 S3FS_PRN_EXIT("poorly formed argument to option: ssl_verify_hostname.");
                 return -1;
@@ -4487,7 +4487,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "public_bucket=")){
-            off_t pubbucket = cvt_strtoofft(strchr(arg, '=') + sizeof(char));
+            off_t pubbucket = cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10);
             if(1 == pubbucket){
                 S3fsCurl::SetPublicBucket(true);
                 // [NOTE]
@@ -4515,17 +4515,17 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "connect_timeout=")){
-            long contimeout = static_cast<long>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
+            long contimeout = static_cast<long>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10));
             S3fsCurl::SetConnectTimeout(contimeout);
             return 0;
         }
         if(is_prefix(arg, "readwrite_timeout=")){
-            time_t rwtimeout = static_cast<time_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
+            time_t rwtimeout = static_cast<time_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10));
             S3fsCurl::SetReadwriteTimeout(rwtimeout);
             return 0;
         }
         if(is_prefix(arg, "list_object_max_keys=")){
-            int max_keys = static_cast<int>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
+            int max_keys = static_cast<int>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10));
             if(max_keys < 1000){
                 S3FS_PRN_EXIT("argument should be over 1000: list_object_max_keys");
                 return -1;
@@ -4534,19 +4534,19 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "max_stat_cache_size=")){
-            unsigned long cache_size = static_cast<unsigned long>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
+            unsigned long cache_size = static_cast<unsigned long>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), 10));
             StatCache::getStatCacheData()->SetCacheSize(cache_size);
             return 0;
         }
         if(is_prefix(arg, "stat_cache_expire=")){
-            time_t expr_time = static_cast<time_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
+            time_t expr_time = static_cast<time_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), 10));
             StatCache::getStatCacheData()->SetExpireTime(expr_time);
             return 0;
         }
         // [NOTE]
         // This option is for compatibility old version.
         if(is_prefix(arg, "stat_cache_interval_expire=")){
-            time_t expr_time = static_cast<time_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
+            time_t expr_time = static_cast<time_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10));
             StatCache::getStatCacheData()->SetExpireTime(expr_time, true);
             return 0;
         }
@@ -4563,7 +4563,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "parallel_count=") || is_prefix(arg, "parallel_upload=")){
-            int maxpara = static_cast<int>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
+            int maxpara = static_cast<int>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10));
             if(0 >= maxpara){
                 S3FS_PRN_EXIT("argument should be over 1: parallel_count");
                 return -1;
@@ -4576,7 +4576,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "multipart_size=")){
-            off_t size = static_cast<off_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
+            off_t size = static_cast<off_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10));
             if(!S3fsCurl::SetMultipartSize(size)){
                 S3FS_PRN_EXIT("multipart_size option must be at least 5 MB.");
                 return -1;
@@ -4584,7 +4584,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "multipart_copy_size=")){
-            off_t size = static_cast<off_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
+            off_t size = static_cast<off_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10));
             if(!S3fsCurl::SetMultipartCopySize(size)){
                 S3FS_PRN_EXIT("multipart_copy_size option must be at least 5 MB.");
                 return -1;
@@ -4592,7 +4592,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "max_dirty_data=")){
-            off_t size = static_cast<off_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char)));
+            off_t size = static_cast<off_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10));
             if(size >= 50){
                 size *= 1024 * 1024;
             }else if(size != -1){
@@ -4603,7 +4603,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "ensure_diskfree=")){
-            off_t dfsize = cvt_strtoofft(strchr(arg, '=') + sizeof(char)) * 1024 * 1024;
+            off_t dfsize = cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10) * 1024 * 1024;
             if(dfsize < S3fsCurl::GetMultipartSize()){
                 S3FS_PRN_WARN("specified size to ensure disk free space is smaller than multipart size, so set multipart size to it.");
                 dfsize = S3fsCurl::GetMultipartSize();
@@ -4612,7 +4612,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "multipart_threshold=")){
-            multipart_threshold = static_cast<int64_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char))) * 1024 * 1024;
+            multipart_threshold = static_cast<int64_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10)) * 1024 * 1024;
             if(multipart_threshold <= MIN_MULTIPART_SIZE){
                 S3FS_PRN_EXIT("multipart_threshold must be at least %lld, was: %lld", static_cast<long long>(MIN_MULTIPART_SIZE), static_cast<long long>(multipart_threshold));
                 return -1;
@@ -4620,7 +4620,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         if(is_prefix(arg, "singlepart_copy_limit=")){
-            singlepart_copy_limit = static_cast<int64_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char))) * 1024 * 1024;
+            singlepart_copy_limit = static_cast<int64_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10)) * 1024 * 1024;
             return 0;
         }
         if(is_prefix(arg, "ahbe_conf=")){

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -63,7 +63,7 @@ bool s3fs_strtoofft(off_t* value, const char* str, int base = 0);
 // This function returns 0 if a value that cannot be converted is specified.
 // Only call if 0 is considered an error and the operation can continue.
 //
-off_t cvt_strtoofft(const char* str, int base = 0);
+off_t cvt_strtoofft(const char* str, int base);
 
 //
 // String Manipulation


### PR DESCRIPTION
Also convert most callers of `cvt_strtoofft` to base 10 which avoid the
magical behavior of interpreting a leading 0 as octal.
References #1682.