### PR TITLE
Improve warning for terminated threads with non-zero return code

### DIFF
--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -133,7 +133,7 @@ int S3fsMultiCurl::MultiPerform()
                 } else {
                     int int_retval = (int)(intptr_t)(retval);
                     if (int_retval && !(int_retval == -ENOENT && isMultiHead)) {
-                        S3FS_PRN_WARN("thread failed - rc(%d)", int_retval);
+                        S3FS_PRN_WARN("thread terminated with non-zero return code: %d", int_retval);
                     }
                 }
             }
@@ -169,7 +169,7 @@ int S3fsMultiCurl::MultiPerform()
         } else {
             int int_retval = (int)(intptr_t)(retval);
             if (int_retval && !(int_retval == -ENOENT && isMultiHead)) {
-                S3FS_PRN_WARN("thread failed - rc(%d)", int_retval);
+                S3FS_PRN_WARN("thread terminated with non-zero return code: %d", int_retval);
             }
         }
     }


### PR DESCRIPTION
I struggled a little with the meaning of the previous warning. So I have improved the wording a little to be more precise.