### PR TITLE
Fixed a bug utimens is calling before flush

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1745,7 +1745,7 @@ bool FdEntity::MergeOrgMeta(headers_t& updatemeta)
     if(0 <= atime.tv_sec){
         SetAtime(atime, true);
     }
-    is_meta_pending |= IsUploading(true);
+    is_meta_pending |= (IsUploading(true) || pagelist.IsModified());
 
     return is_meta_pending;
 }

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -624,6 +624,20 @@ function test_multipart_mix {
     rm_test_file "${BIG_FILE}-mix"
 }
 
+function test_utimens_during_multipart {
+    describe "Testing utimens calling during multipart copy ..."
+
+    dd if=/dev/urandom of="${TEMP_DIR}/${BIG_FILE}" bs=$BIG_FILE_BLOCK_SIZE count=$BIG_FILE_COUNT
+
+    cp ${TEMP_DIR}/${BIG_FILE} ${BIG_FILE}
+
+    # The second copy of the "-p" option calls utimens during multipart upload.
+    cp -p ${TEMP_DIR}/${BIG_FILE} ${BIG_FILE}
+
+    rm -f "${TEMP_DIR}/${BIG_FILE}"
+    rm_test_file "${BIG_FILE}"
+}
+
 function test_special_characters {
     describe "Testing special characters ..."
 
@@ -1465,6 +1479,7 @@ function add_all_tests {
     add_tests test_multipart_upload
     add_tests test_multipart_copy
     add_tests test_multipart_mix
+    add_tests test_utimens_during_multipart
     add_tests test_special_characters
     add_tests test_hardlink
     add_tests test_symlink


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1685

### Details
In the case where utimens was called before flush after updating the file was called, it was wrong to determine that it was being updated.
(It seems to have existed for a long time, but it may have become apparent with the modification of #1666.)
There was a file fix that required the meta data to be updated, and I was getting an error because I was doing an upload with utimens before uploading that meta information.
