### PR TITLE
Updated to clearly output message about the file descriptor type(pseudo/physical)

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -452,7 +452,7 @@ FdManager::~FdManager()
 
 FdEntity* FdManager::GetFdEntity(const char* path, int& existfd, bool newfd, bool lock_already_held)
 {
-    S3FS_PRN_INFO3("[path=%s][fd=%d]", SAFESTRPTR(path), existfd);
+    S3FS_PRN_INFO3("[path=%s][pseudo_fd=%d]", SAFESTRPTR(path), existfd);
 
     if(!path || '\0' == path[0]){
         return NULL;
@@ -590,7 +590,7 @@ FdEntity* FdManager::Open(int& fd, const char* path, headers_t* pmeta, off_t siz
 //
 FdEntity* FdManager::GetExistFdEntity(const char* path, int existfd)
 {
-    S3FS_PRN_DBG("[path=%s][existfd=%d]", SAFESTRPTR(path), existfd);
+    S3FS_PRN_DBG("[path=%s][pseudo_fd=%d]", SAFESTRPTR(path), existfd);
 
     AutoLock auto_lock(&FdManager::fd_manager_lock);
 

--- a/src/fdcache_auto.cpp
+++ b/src/fdcache_auto.cpp
@@ -91,7 +91,7 @@ bool AutoFdEntity::Attach(const char* path, int existfd)
     Close();
 
     if(NULL == (pFdEntity = FdManager::get()->GetFdEntity(path, existfd, false))){
-        S3FS_PRN_DBG("Could not find fd entity object(file=%s, existfd=%d)", path, existfd);
+        S3FS_PRN_DBG("Could not find fd entity object(file=%s, pseudo_fd=%d)", path, existfd);
         return false;
     }
     pseudo_fd = existfd;

--- a/src/fdcache_page.cpp
+++ b/src/fdcache_page.cpp
@@ -186,7 +186,7 @@ bool PageList::GetSparseFilePages(int fd, size_t file_size, fdpage_list_t& spars
     off_t hole_pos = lseek(fd, 0, SEEK_HOLE);
     off_t data_pos = lseek(fd, 0, SEEK_DATA);
     if(-1 == hole_pos && -1 == data_pos){
-        S3FS_PRN_ERR("Could not find the first position both HOLE and DATA in the file(fd=%d).", fd);
+        S3FS_PRN_ERR("Could not find the first position both HOLE and DATA in the file(physical_fd=%d).", fd);
         return false;
     }else if(-1 == hole_pos){
         is_hole   = false;
@@ -231,7 +231,7 @@ bool PageList::CheckZeroAreaInFile(int fd, off_t start, size_t bytes)
         bool    found_bad_data = false;
         ssize_t read_bytes;
         if(-1 == (read_bytes = pread(fd, readbuff, check_bytes, (start + comp_bytes)))){
-            S3FS_PRN_ERR("Something error is occurred in reading %zu bytes at %lld from file(%d).", check_bytes, static_cast<long long int>(start + comp_bytes), fd);
+            S3FS_PRN_ERR("Something error is occurred in reading %zu bytes at %lld from file(physical_fd=%d).", check_bytes, static_cast<long long int>(start + comp_bytes), fd);
             found_bad_data = true;
         }else{
             check_bytes = static_cast<size_t>(read_bytes);
@@ -941,7 +941,7 @@ bool PageList::CompareSparseFile(int fd, size_t file_size, fdpage_list_t& err_ar
     // are assigned to any holes.
     fdpage_list_t sparse_list;
     if(!PageList::GetSparseFilePages(fd, file_size, sparse_list)){
-        S3FS_PRN_ERR("Something error is occurred in parsing hole/data of the cache file(%d).", fd);
+        S3FS_PRN_ERR("Something error is occurred in parsing hole/data of the cache file(physical_fd=%d).", fd);
 
         fdpage page(0, static_cast<off_t>(file_size), false, false);
         err_area_list.push_back(page);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2312,12 +2312,12 @@ static int s3fs_read(const char* _path, char* buf, size_t size, off_t offset, st
     WTF8_ENCODE(path)
     ssize_t res;
 
-    S3FS_PRN_DBG("[path=%s][size=%zu][offset=%lld][fd=%llu]", path, size, static_cast<long long>(offset), (unsigned long long)(fi->fh));
+    S3FS_PRN_DBG("[path=%s][size=%zu][offset=%lld][pseudo_fd=%llu]", path, size, static_cast<long long>(offset), (unsigned long long)(fi->fh));
 
     AutoFdEntity autoent;
     FdEntity*    ent;
     if(NULL == (ent = autoent.GetExistFdEntity(path, static_cast<int>(fi->fh)))){
-        S3FS_PRN_ERR("could not find opened fd(%s)", path);
+        S3FS_PRN_ERR("could not find opened pseudo_fd(=%llu) for path(%s)", (unsigned long long)(fi->fh), path);
         return -EIO;
     }
 
@@ -2340,12 +2340,12 @@ static int s3fs_write(const char* _path, const char* buf, size_t size, off_t off
     WTF8_ENCODE(path)
     ssize_t res;
 
-    S3FS_PRN_DBG("[path=%s][size=%zu][offset=%lld][fd=%llu]", path, size, static_cast<long long int>(offset), (unsigned long long)(fi->fh));
+    S3FS_PRN_DBG("[path=%s][size=%zu][offset=%lld][pseudo_fd=%llu]", path, size, static_cast<long long int>(offset), (unsigned long long)(fi->fh));
 
     AutoFdEntity autoent;
     FdEntity*    ent;
     if(NULL == (ent = autoent.GetExistFdEntity(path, static_cast<int>(fi->fh)))){
-        S3FS_PRN_ERR("could not find opened fd(%s)", path);
+        S3FS_PRN_ERR("could not find opened pseudo_fd(%llu) for path(%s)", (unsigned long long)(fi->fh), path);
         return -EIO;
     }
 
@@ -2386,7 +2386,7 @@ static int s3fs_flush(const char* _path, struct fuse_file_info* fi)
     WTF8_ENCODE(path)
     int result;
 
-    S3FS_PRN_INFO("[path=%s][fd=%llu]", path, (unsigned long long)(fi->fh));
+    S3FS_PRN_INFO("[path=%s][pseudo_fd=%llu]", path, (unsigned long long)(fi->fh));
 
     int mask = (O_RDONLY != (fi->flags & O_ACCMODE) ? W_OK : R_OK);
     if(0 != (result = check_parent_object_access(path, X_OK))){
@@ -2422,7 +2422,7 @@ static int s3fs_fsync(const char* _path, int datasync, struct fuse_file_info* fi
     WTF8_ENCODE(path)
     int result = 0;
 
-    S3FS_PRN_INFO("[path=%s][fd=%llu]", path, (unsigned long long)(fi->fh));
+    S3FS_PRN_INFO("[path=%s][pseudo_fd=%llu]", path, (unsigned long long)(fi->fh));
 
     AutoFdEntity autoent;
     FdEntity*    ent;
@@ -2444,7 +2444,7 @@ static int s3fs_fsync(const char* _path, int datasync, struct fuse_file_info* fi
 static int s3fs_release(const char* _path, struct fuse_file_info* fi)
 {
     WTF8_ENCODE(path)
-    S3FS_PRN_INFO("[path=%s][fd=%llu]", path, (unsigned long long)(fi->fh));
+    S3FS_PRN_INFO("[path=%s][pseudo_fd=%llu]", path, (unsigned long long)(fi->fh));
 
     // [NOTE]
     // All opened file's stats is cached with no truncate flag.
@@ -2469,7 +2469,7 @@ static int s3fs_release(const char* _path, struct fuse_file_info* fi)
         // destroyed here.
         //
         if(!autoent.Attach(path, static_cast<int>(fi->fh))){
-            S3FS_PRN_ERR("could not find pseudo fd(file=%s, fd=%d)", path, static_cast<int>(fi->fh));
+            S3FS_PRN_ERR("could not find pseudo_fd(%llu) for path(%s)", (unsigned long long)(fi->fh), path);
             return -EIO;
         }
     }


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1666 

### Details
With the fix of #1666, the file descriptor returned from s3fs to FUSE has been changed from physical fd to pseudo fd.
Changed to clearly output the type of file descriptor included in the (debug)message output of s3fs.
This is more useful when debugging and when investigating bugs.
This is a message-only update, not a logic change.
