### PR TITLE
Remove unneeded volatile qualifiers

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -178,7 +178,7 @@ class S3fsCurl
         headers_t            responseHeaders;      // header data by HeaderCallback
         BodyData             bodydata;             // body data by WriteMemoryCallback
         BodyData             headdata;             // header data by WriteMemoryCallback
-        volatile long        LastResponseCode;
+        long                 LastResponseCode;
         const unsigned char* postdata;             // use by post method and read callback function.
         off_t                postdata_remaining;   // use by post method and read callback function.
         filepart             partdata;             // use by multipart upload/get object callback

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1755,11 +1755,12 @@ int put_headers(const char* path, headers_t& meta, bool is_copy, bool use_st_siz
 
 int FdEntity::UploadPendingMeta()
 {
+    AutoLock auto_lock(&fdent_lock);
+
     if(!is_meta_pending) {
        return 0;
     }
 
-    AutoLock auto_lock(&fdent_lock);
     headers_t updatemeta = orgmeta;
     updatemeta["x-amz-copy-source"]        = urlEncode(service_path + bucket + get_realpath(path.c_str()));
     // put headers, no need to update mtime to avoid dead lock

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -49,7 +49,7 @@ class FdEntity
         std::string     cachepath;      // local cache file path
                                         // (if this is empty, does not load/save pagelist.)
         std::string     mirrorpath;     // mirror file path to local cache file path
-        volatile bool   is_meta_pending;
+        bool            is_meta_pending;
         struct timespec holding_mtime;  // if mtime is updated while the file is open, it is set time_t value
 
     private:


### PR DESCRIPTION
We should use proper locking instead.  Specifically for
`is_meta_pending` this does not do what was intended due to the
read-modify-write of the member.