### PR TITLE
Convert storage class values to uppercase

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -775,6 +775,8 @@ std::string S3fsCurl::SetStorageClass(const std::string& storage_class)
 {
     std::string old = S3fsCurl::storage_class;
     S3fsCurl::storage_class = storage_class;
+    // AWS requires uppercase storage class values
+    transform(S3fsCurl::storage_class.begin(), S3fsCurl::storage_class.end(), S3fsCurl::storage_class.begin(), ::toupper);
     return old;
 }
 


### PR DESCRIPTION
AWS requires uppercase values.  Fixes a regression from
bbcccd6e9816ebb16ca33d2003d563b24625a053.  References #1613.