### PR TITLE
Fixed 1710 - Added a flag for check in Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,7 @@ jobs:
 
       - name: Test suite
         run: |
-          make check -C test || (test/filter-suite-log.sh test/test-suite.log; exit 1)
-
+          make ALL_TESTS=1 check -C test || (test/filter-suite-log.sh test/test-suite.log; exit 1)
 
   # [NOTE]
   # A case of "runs-on: macos-11.0" does not work,


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1710 

### Details
The ALL_TESTS flag was missing from Linux tests.
