### PR TITLE
Prevents the etag string buffer from being destroyed during use

### DIFF
--- a/src/fdcache_fdinfo.h
+++ b/src/fdcache_fdinfo.h
@@ -22,22 +22,6 @@
 #define S3FS_FDCACHE_FDINFO_H_
 
 //------------------------------------------------
-// Structure
-//------------------------------------------------
-typedef struct _mppart_info
-{
-    off_t       start;
-    size_t      size;
-    bool        is_copy;
-    std::string etag;
-
-    _mppart_info(off_t part_start = -1, off_t part_size = 0, bool is_copy_part = false, const char* petag = NULL) : start(part_start), size(part_size), is_copy(is_copy_part), etag(NULL == petag ? "" : petag) {}
-
-}MPPART_INFO;
-
-typedef std::list<MPPART_INFO> mppart_list_t;
-
-//------------------------------------------------
 // Class PseudoFdInfo
 //------------------------------------------------
 class PseudoFdInfo
@@ -47,10 +31,10 @@ class PseudoFdInfo
         int             physical_fd;
         int             flags;              // flags at open
         std::string     upload_id;
-        mppart_list_t   upload_list;
+        filepart_list_t upload_list;
         off_t           untreated_start;    // untreated start position
         off_t           untreated_size;     // untreated size
-
+        etaglist_t      etag_entities;      // list of etag string entities(to maintain the etag entity even if MPPART_INFO is destroyed)
         bool            is_lock_init;
         pthread_mutex_t upload_list_lock;   // protects upload_id and upload_list
 

--- a/src/types.h
+++ b/src/types.h
@@ -185,9 +185,11 @@ struct filepart
     int          fd;          // base file(temporary full file) descriptor
     off_t        startpos;    // seek fd point for uploading
     off_t        size;        // uploading size
+    bool         is_copy;     // whether is copy multipart
     std::string* petag;       // use only parallel upload
 
-    filepart() : uploaded(false), fd(-1), startpos(0), size(-1), petag(NULL) {}
+    filepart(bool is_uploaded = false, int _fd = -1, off_t part_start = 0, off_t part_size = -1, bool is_copy_part = false, std::string* petag = NULL) : uploaded(false), fd(_fd), startpos(part_start), size(part_size), is_copy(is_copy_part), petag(petag) {}
+
     ~filepart()
     {
       clear();
@@ -200,6 +202,7 @@ struct filepart
         fd       = -1;
         startpos = 0;
         size     = -1;
+        is_copy  = false;
         petag    = NULL;
     }
 
@@ -214,6 +217,8 @@ struct filepart
         petag = petagobj;
     }
 };
+
+typedef std::list<filepart> filepart_list_t;
 
 //-------------------------------------------------------------------
 // mimes_t


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
There was a potential bug in the etag string saving process in parallel  multipart uploads.
Currently, it has not been realized, but it may be a problem in future function addition(planned now), so it has been fixed.

This bug is the part that saves etag string when CURL processing is completed in parallel multipart upload.
The object has an etag as a pointer, but it is possible that the entity does not exist in the future.
Therefore, I added an `etag_entities` member to the `PseudoFdInfo` class and modified it so that the etag entity always exists for the period when the `PseudoFdInfo` object exists.

And the `MPPART_INFO` structure has almost the same purpose and member variables as the `filepart` structure, so it is unified as `filepart`.

The `MPPART_INFO` changes are useless after this integration, so the above fix and this integration are combined into a single(this) PR.

