### PR TITLE
Splited some methods of FdEntity class by uploading mode

### DIFF
--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -67,6 +67,12 @@ class FdEntity
         int NoCachePreMultipartPost(PseudoFdInfo* pseudo_obj);
         int NoCacheMultipartPost(PseudoFdInfo* pseudo_obj, int tgfd, off_t start, off_t size);
         int NoCacheCompleteMultipartPost(PseudoFdInfo* pseudo_obj);
+        int RowFlushNoMultipart(PseudoFdInfo* pseudo_obj, const char* tpath);
+        int RowFlushMultipart(PseudoFdInfo* pseudo_obj, const char* tpath);
+        int RowFlushMixMultipart(PseudoFdInfo* pseudo_obj, const char* tpath);
+        ssize_t WriteNoMultipart(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size);
+        ssize_t WriteMultipart(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size);
+        ssize_t WriteMixMultipart(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size);
         int UploadPendingMeta();
 
     public:


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a 

### Details
This is not a bug or a fix for a logic change.

The `FdEntity::RowFlush` and `FdEntity::Write` methods are common method for all uploading options(`nomultipart`, `multipart`, `mixmaultipart`).

Depending on the upload mode, the processing of these methods is roughly similar logic, but slightly different.
For this reason, we should be aware of the impact on other modes when modifying or changing methods.

I've split these methods in consideration of adding more modes in the future.
The processing of `multipart` and `mixmultipart` is very similar and seems verbose, but I focused on mode specific independence.

@gaul Please give me your opinion.
I thought it would be better to split it when adding a new mode(ex.  adding new mode which is uploading file as a stream).