### PR TITLE
Add initiator pid, uid and gid to a debug log

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -535,6 +535,8 @@ static int check_object_access(const char* path, int mask, struct stat* pstbuf)
     if(NULL == (pcxt = fuse_get_context())){
         return -EIO;
     }
+    S3FS_PRN_DBG("[pid=%u,uid=%u,gid=%u]", (unsigned int)(pcxt->pid), (unsigned int)(pcxt->uid), (unsigned int)(pcxt->gid));
+
     if(0 != (result = get_object_attribute(path, pst))){
         // If there is not the target file(object), result is -ENOENT.
         return result;


### PR DESCRIPTION
### Details
I've discovered a lot of requests to my Minio installation from one of servers with s3fs installed.
After changing the log level to debug I saw a lot of log items that some process is recursively fetching file attributes. But I was not able to find any information about the process which made these requests - `lsof` could return only the information about opened files, but it does not handle `get_attr` kernel calls.

So I've added a debug info in the s3fs process itself. This is a really useful feature.
