### PR TITLE
update brew install command to install macfuse

### DIFF
--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -21,6 +21,7 @@ Keep in mind using the pre-built packages when available.
 	* s3fs exits with an error if these files are not exist
 	* Alternatively, you can set mime.types file path with `mime` option without detecting these default files
 * pkg-config (or your OS equivalent)
+	* If macOS throws an error on configure `No package 'libcrypto' found` try exporting the following variable and running configure again `export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"` 
 
 2. Then compile from master via the following commands:
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Many systems provide pre-built packages:
 * macOS via [Homebrew](https://brew.sh/):
 
   ```
-  brew install --cask osxfuse
+  brew install --cask macfuse
   brew install s3fs
   ```
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4024,13 +4024,11 @@ static int get_access_keys()
     if(AWS_CREDENTIAL_FILE != NULL){
         passwd_file = AWS_CREDENTIAL_FILE;
         if(!passwd_file.empty()){
-            std::ifstream PF(passwd_file.c_str());
-            if(PF.good()){
-                 PF.close();
-                 return read_passwd_file();
-            }else{
-                S3FS_PRN_EXIT("AWS_CREDENTIAL_FILE: \"%s\" is not readable.", passwd_file.c_str());
-                return EXIT_FAILURE;
+            if(read_aws_credentials_file(passwd_file) == EXIT_SUCCESS) {
+                return EXIT_SUCCESS;
+            }else if(aws_profile != "default"){
+                S3FS_PRN_EXIT("Could not find profile: %s in file: %s", aws_profile.c_str(), passwd_file.c_str());
+            return EXIT_FAILURE;
             }
         }
     }


### PR DESCRIPTION
osxfuse now redirects to macfuse.  Current releases are released as macfuse.  updating the brew install command accordingly.

### Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

### Details
_Please describe the details of PullRequest._
