### PR TITLE
Fixed a bug in disk free space calculation

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1557,7 +1557,7 @@ int FdEntity::RowFlushMixMultipart(PseudoFdInfo* pseudo_obj, const char* tpath)
         // Start uploading
 
         // If there is no loading all of the area, loading all area.
-        off_t restsize = pagelist.GetTotalUnloadedPageSize();
+        off_t restsize = pagelist.GetTotalUnloadedPageSize(/* start */ 0, /* size = all */ 0, MIN_MULTIPART_SIZE);
 
         // Check rest size and free disk space
         if(0 < restsize && !ReserveDiskSpace(restsize)){
@@ -1974,7 +1974,7 @@ ssize_t FdEntity::WriteMixMultipart(PseudoFdInfo* pseudo_obj, const char* bytes,
 
     if(!pseudo_obj->IsUploading()){
         // check disk space
-        off_t restsize = pagelist.GetTotalUnloadedPageSize(0, start) + size;
+        off_t restsize = pagelist.GetTotalUnloadedPageSize(0, start, MIN_MULTIPART_SIZE) + size;
         if(ReserveDiskSpace(restsize)){
             // enough disk space
             FdManager::FreeReservedDiskSpace(restsize);

--- a/src/fdcache_page.cpp
+++ b/src/fdcache_page.cpp
@@ -509,10 +509,20 @@ bool PageList::FindUnloadedPage(off_t start, off_t& resstart, off_t& ressize) co
     return false;
 }
 
-off_t PageList::GetTotalUnloadedPageSize(off_t start, off_t size) const
+// [NOTE]
+// Accumulates the range of unload that is smaller than the Limit size.
+// If you want to integrate all unload ranges, set the limit size to 0.
+//
+off_t PageList::GetTotalUnloadedPageSize(off_t start, off_t size, off_t limit_size) const
 {
-    off_t restsize = 0;
+    // If size is 0, it means loading to end.
+    if(0 == size){
+        if(start < Size()){
+            size = Size() - start;
+        }
+    }
     off_t next     = start + size;
+    off_t restsize = 0;
     for(fdpage_list_t::const_iterator iter = pages.begin(); iter != pages.end(); ++iter){
         if(iter->next() <= start){
             continue;
@@ -537,7 +547,9 @@ off_t PageList::GetTotalUnloadedPageSize(off_t start, off_t size) const
                 tmpsize = next - iter->offset;
             }
         }
-        restsize += tmpsize;
+        if(0 == limit_size || tmpsize < limit_size){
+            restsize += tmpsize;
+        }
     }
     return restsize;
 }

--- a/src/fdcache_page.h
+++ b/src/fdcache_page.h
@@ -106,7 +106,7 @@ class PageList
         bool IsPageLoaded(off_t start = 0, off_t size = 0) const;                  // size=0 is checking to end of list
         bool SetPageLoadedStatus(off_t start, off_t size, PageList::page_status pstatus = PAGE_LOADED, bool is_compress = true);
         bool FindUnloadedPage(off_t start, off_t& resstart, off_t& ressize) const;
-        off_t GetTotalUnloadedPageSize(off_t start = 0, off_t size = 0) const;    // size=0 is checking to end of list
+        off_t GetTotalUnloadedPageSize(off_t start = 0, off_t size = 0, off_t limit_size = 0) const;   // size=0 is checking to end of list
         size_t GetUnloadedPages(fdpage_list_t& unloaded_list, off_t start = 0, off_t size = 0) const;  // size=0 is checking to end of list
         bool GetPageListsForMultipartUpload(fdpage_list_t& dlpages, fdpage_list_t& mixuppages, off_t max_partsize);
         bool GetNoDataPageLists(fdpage_list_t& nodata_pages, off_t start = 0, size_t size = 0);


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
There were two problems with the calculation of free disk space.

### (1) Call PageList::GetTotalUnloadedPageSize method with size=0
The `PageList::GetTotalUnloadedPageSize` method should check the entire area when `size=0`, but It wasn't able to do this.
Fixed this bug by doing the same process as the `PageList::GetUnloadedPages` method.

### (2) Calculation of free space in Mix MultipartUpload
Before #1714, I didn't notice it because I used the same method in all upload modes.
The calculation of free space in the case of Mix MultipartUpload is different from normal Multipart and No Multipart, and it has the feature that the object is not needed to download.
Therefore, the calculation of free space is different, but it was not able to distinguish in same function.
Thus, added an argument to the `GetTotalUnloadedPageSize` method and modified it so that it does not accumulate if it is larger than the minimum size(for multipart upload).

### NOTES
Free space testing needs to be enhanced, but I think it can only be achieved by giving s3fs a special debug test mode.
(We should think about it in the future)
