### PR TITLE
Added fake_diskfree option to deceive free disk space for test

### DIFF
--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -36,7 +36,8 @@ class FdManager
       static bool            is_lock_init;
       static std::string     cache_dir;
       static bool            check_cache_dir_exist;
-      static off_t           free_disk_space; // limit free disk space
+      static off_t           free_disk_space;       // limit free disk space
+      static off_t           fake_used_disk_space;  // difference between fake free disk space and actual at startup(for test/debug)
       static std::string     check_cache_output;
       static bool            checked_lseek;
       static bool            have_lseek_hole;
@@ -72,6 +73,7 @@ class FdManager
       static bool HasOpenEntityFd(const char* path);
       static off_t GetEnsureFreeDiskSpace();
       static off_t SetEnsureFreeDiskSpace(off_t size);
+      static bool InitFakeUsedDiskSize(off_t fake_freesize);
       static bool IsSafeDiskSpace(const char* path, off_t size);
       static void FreeReservedDiskSpace(off_t size);
       static bool ReserveDiskSpace(off_t size);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -98,6 +98,7 @@ static bool support_compat_dir    = true;// default supports compatibility direc
 static int max_keys_list_object   = 1000;// default is 1000
 static off_t max_dirty_data       = 5LL * 1024LL * 1024LL * 1024LL;
 static bool use_wtf8              = false;
+static off_t fake_diskfree_size   = -1; // default is not set(-1)
 
 static const std::string allbucket_fields_type;              // special key for mapping(This name is absolutely not used as a bucket name)
 static const std::string keyval_fields_type    = "\t";       // special key for mapping(This name is absolutely not used as a bucket name)
@@ -4619,6 +4620,13 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             FdManager::SetEnsureFreeDiskSpace(dfsize);
             return 0;
         }
+        if(is_prefix(arg, "fake_diskfree=")){
+            S3FS_PRN_WARN("The fake_diskfree option was specified. Use this option for testing or debugging.");
+
+            // [NOTE] This value is used for initializing to FdManager after parsing all options.
+            fake_diskfree_size = cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10) * 1024 * 1024;
+            return 0;
+        }
         if(is_prefix(arg, "multipart_threshold=")){
             multipart_threshold = static_cast<int64_t>(cvt_strtoofft(strchr(arg, '=') + sizeof(char), /*base=*/ 10)) * 1024 * 1024;
             if(multipart_threshold <= MIN_MULTIPART_SIZE){
@@ -5125,6 +5133,11 @@ int main(int argc, char* argv[])
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
         exit(EXIT_FAILURE);
+    }
+
+    // set fake free disk space
+    if(-1 != fake_diskfree_size){
+        FdManager::InitFakeUsedDiskSize(fake_diskfree_size);
     }
 
     // check IBM IAM requirements

--- a/test/small-integration-test.sh
+++ b/test/small-integration-test.sh
@@ -38,25 +38,14 @@ mkdir "${CACHE_DIR}"
 
 #reserve 200MB for data cache
 source test-utils.sh
-CACHE_DISK_AVAIL_SIZE=`get_disk_avail_size $CACHE_DIR`
-if [ `uname` = "Darwin" ]; then
-    # [FIXME]
-    # Only on MacOS, there are cases where process or system
-    # other than the s3fs cache uses disk space.
-    # We can imagine that this is caused by Timemachine, but
-    # there is no workaround, so s3fs cache size is set +1gb
-    # for error bypass.
-    #
-    ENSURE_DISKFREE_SIZE=$((CACHE_DISK_AVAIL_SIZE - 1200))
-else
-    ENSURE_DISKFREE_SIZE=$((CACHE_DISK_AVAIL_SIZE - 200))
-fi
+FAKE_FREE_DISK_SIZE=200
+ENSURE_DISKFREE_SIZE=10
 
 export CACHE_DIR
 export ENSURE_DISKFREE_SIZE 
 if [ -n "${ALL_TESTS}" ]; then
     FLAGS=(
-        "use_cache=${CACHE_DIR} -o ensure_diskfree=${ENSURE_DISKFREE_SIZE}"
+        "use_cache=${CACHE_DIR} -o ensure_diskfree=${ENSURE_DISKFREE_SIZE} -o fake_diskfree=${FAKE_FREE_DISK_SIZE}"
         enable_content_md5
         enable_noobj_cache
         max_stat_cache_size=100


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1722 

### Details
The `ensure_diskfree` option is an option to protect the free disk space.
The reason for not checking the disk usage of s3fs is that it causes performance degradation. (like the `du` command)
So that s3fs is using disk stat information will improve performance.
That's why we provide the `ensure_diskfree` option.

However, there are some issues that are very difficult to test, such as Github Actions.
This is because the Runner(VM, HOST, etc) have different capacities, so the same value cannot be used for the `ensure_diskfree` option.

To avoid this situation, we have added the option `fake_diskfree` to deceive free disk space.
The value of this option is stored as free disk space when s3fs is started, and after that, this value(difference from the actual free disk space) will be used.
