### PR TITLE
Loosen CheckBucket to check only the bucket

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3395,11 +3395,11 @@ int S3fsCurl::CheckBucket()
     }
     std::string resource;
     std::string turl;
-    MakeUrlResource(get_realpath("/").c_str(), resource, turl);
+    MakeUrlResource("/", resource, turl);
 
     turl           += urlargs;
     url             = prepare_url(turl.c_str());
-    path            = get_realpath("/");
+    path            = "/";  // Only check the presence of the bucket, not the entire virtual path.
     requestHeaders  = NULL;
     responseHeaders.clear();
     bodydata.Clear();


### PR DESCRIPTION
Previously it checked if there was an object present, assuming that
this was a directory object normally created for s3fs directories.
However most S3 clients do not create this object for virtual folders.
Fixes #1460.  Fixes #1687.