### PR TITLE
Add support for AWS-style environment variables

### DIFF
--- a/doc/man/s3fs.1
+++ b/doc/man/s3fs.1
@@ -40,7 +40,7 @@ Password files can be stored in two locations:
  \fB$HOME/.passwd-s3fs\fP   [0600]
 .RE
 .PP
-s3fs also recognizes the \fBAWSACCESSKEYID\fP and \fBAWSSECRETACCESSKEY\fP environment variables.
+s3fs also recognizes the \fBAWS_ACCESS_KEY_ID\fP and \fBAWS_SECRET_ACCESS_KEY\fP environment variables.
 .SH OPTIONS
 .SS "general options"
 .TP
@@ -274,7 +274,7 @@ AWS instance metadata service, used with IAM role authentication,
 supports the use of an API token.  If you're using an IAM role in an
 environment that does not support IMDSv2, setting this flag will skip
 retrieval and usage of the API token when retrieving IAM credentials.
-
+.TP
 \fB\-o\fR ibm_iam_auth (default is not using IBM IAM authentication)
 This option instructs s3fs to use IBM IAM authentication. In this mode, the AWSAccessKey and AWSSecretKey will be used as IBM's Service-Instance-ID and APIKey, respectively.
 .TP
@@ -350,7 +350,7 @@ Useful on clients not using UTF-8 as their file system encoding.
 .TP
 \fB\-o\fR use_session_token - indicate that session token should be provided.
 If credentials are provided by environment variables this switch
-forces presence check of AWSSESSIONTOKEN variable.
+forces presence check of AWS_SESSION_TOKEN variable.
 Otherwise an error is returned.
 .TP
 \fB\-o\fR requester_pays (default is disable)

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3990,13 +3990,14 @@ static int get_access_keys()
     }
 
     // 3  - environment variables
-    char* AWSACCESSKEYID     = getenv("AWSACCESSKEYID");
-    char* AWSSECRETACCESSKEY = getenv("AWSSECRETACCESSKEY");
-    char* AWSSESSIONTOKEN    = getenv("AWSSESSIONTOKEN");
+    char* AWSACCESSKEYID     = getenv("AWS_ACCESS_KEY_ID") ? getenv("AWS_ACCESS_KEY_ID") : getenv("AWSACCESSKEYID");
+    char* AWSSECRETACCESSKEY = getenv("AWS_SECRET_ACCESS_KEY") ? getenv("AWS_SECRET_ACCESS_KEY") : getenv("AWSSECRETACCESSKEY");
+    char* AWSSESSIONTOKEN    = getenv("AWS_SESSION_TOKEN") ? getenv("AWS_SESSION_TOKEN") : getenv("AWSSESSIONTOKEN");
+
     if(AWSACCESSKEYID != NULL || AWSSECRETACCESSKEY != NULL){
         if( (AWSACCESSKEYID == NULL && AWSSECRETACCESSKEY != NULL) ||
             (AWSACCESSKEYID != NULL && AWSSECRETACCESSKEY == NULL) ){
-            S3FS_PRN_EXIT("if environment variable AWSACCESSKEYID is set then AWSSECRETACCESSKEY must be set too.");
+            S3FS_PRN_EXIT("both environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set together.");
             return EXIT_FAILURE;
         }
         S3FS_PRN_INFO2("access key from env variables");
@@ -4009,7 +4010,7 @@ static int get_access_keys()
         } else {
             S3FS_PRN_INFO2("session token is not available");
             if (is_use_session_token) {
-                S3FS_PRN_EXIT("environment variable AWSSESSIONTOKEN is expected to be set.");
+                S3FS_PRN_EXIT("environment variable AWS_SESSION_TOKEN is expected to be set.");
                 return EXIT_FAILURE;
             }
         }


### PR DESCRIPTION
Support AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN
in addition to the AWSACCESSKEYID, AWSSECRETACCESSKEY and
AWSSESSIONTOKEN.

The old environment variables are still supported, but they are deprecated and no longer documented.

I would add a deprecation warning for the original environment variables if suggested. Users would 

Close #1708