### PR TITLE
Changed etaglist_t from string list to new structure etagpairs list

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -399,7 +399,7 @@ class S3fsCurl
         int MultipartListRequest(std::string& body);
         int AbortMultipartUpload(const char* tpath, const std::string& upload_id);
         int MultipartHeadRequest(const char* tpath, off_t size, headers_t& meta, bool is_copy);
-        int MultipartUploadRequest(const std::string& upload_id, const char* tpath, int fd, off_t offset, off_t size, int part_num, std::string* petag);
+        int MultipartUploadRequest(const std::string& upload_id, const char* tpath, int fd, off_t offset, off_t size, etagpair* petagpair);
         int MultipartRenameRequest(const char* from, const char* to, headers_t& meta, off_t size);
 
         // methods(variables)

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1265,14 +1265,13 @@ int FdEntity::NoCacheMultipartPost(PseudoFdInfo* pseudo_obj, int tgfd, off_t sta
     }
 
     // append new part and get it's etag string pointer
-    int          partnum = 0;
-    std::string* petag   = NULL;
-    if(!pseudo_obj->AppendUploadPart(start, size, false, &partnum, &petag)){
+    etagpair* petagpair = NULL;
+    if(!pseudo_obj->AppendUploadPart(start, size, false, &petagpair)){
         return -EIO;
     }
 
     S3fsCurl s3fscurl(true);
-    return s3fscurl.MultipartUploadRequest(upload_id, path.c_str(), tgfd, start, size, partnum, petag);
+    return s3fscurl.MultipartUploadRequest(upload_id, path.c_str(), tgfd, start, size, petagpair);
 }
 
 // [NOTE]

--- a/src/fdcache_fdinfo.cpp
+++ b/src/fdcache_fdinfo.cpp
@@ -177,7 +177,7 @@ bool PseudoFdInfo::GetEtaglist(etaglist_t& list)
 // An error will occur if it is discontinuous or if it overlaps with an
 // existing area.
 //
-bool PseudoFdInfo::AppendUploadPart(off_t start, off_t size, bool is_copy, int* ppartnum, std::string** ppetag)
+bool PseudoFdInfo::AppendUploadPart(off_t start, off_t size, bool is_copy, etagpair** ppetag)
 {
     if(IsUploading()){
         S3FS_PRN_ERR("Multipart Upload has not started yet.");
@@ -194,21 +194,20 @@ bool PseudoFdInfo::AppendUploadPart(off_t start, off_t size, bool is_copy, int* 
         return false;
     }
 
-    // add new part
-    etag_entities.push_back(std::string(""));                   // [NOTE] Create the etag entity and register it in the list.
-    std::string&    etag_entity = etag_entities.back();
-    filepart        newpart(false, physical_fd, start, size, is_copy, &etag_entity);
-    upload_list.push_back(newpart);
+    // make part number
+    int partnumber = static_cast<int>(upload_list.size()) + 1;
 
-    // set part number
-    if(ppartnum){
-        *ppartnum = static_cast<int>(upload_list.size());
-    }
+    // add new part
+    etag_entities.push_back(etagpair(NULL, partnumber));        // [NOTE] Create the etag entity and register it in the list.
+    etagpair&   etag_entity = etag_entities.back();
+    filepart    newpart(false, physical_fd, start, size, is_copy, &etag_entity);
+    upload_list.push_back(newpart);
 
     // set etag pointer
     if(ppetag){
         *ppetag = &etag_entity;
     }
+
     return true;
 }
 

--- a/src/fdcache_fdinfo.h
+++ b/src/fdcache_fdinfo.h
@@ -35,7 +35,7 @@ class PseudoFdInfo
         std::string     upload_id;
         filepart_list_t upload_list;
         UntreatedParts  untreated_list;     // list of untreated parts that have been written and not yet uploaded(for streamupload)
-        etaglist_t      etag_entities;      // list of etag string entities(to maintain the etag entity even if MPPART_INFO is destroyed)
+        etaglist_t      etag_entities;      // list of etag string and part number entities(to maintain the etag entity even if MPPART_INFO is destroyed)
 
         bool            is_lock_init;
         pthread_mutex_t upload_list_lock;   // protects upload_id and upload_list
@@ -61,7 +61,7 @@ class PseudoFdInfo
         bool GetUploadId(std::string& id) const;
         bool GetEtaglist(etaglist_t& list);
 
-        bool AppendUploadPart(off_t start, off_t size, bool is_copy = false, int* ppartnum = NULL, std::string** ppetag = NULL);
+        bool AppendUploadPart(off_t start, off_t size, bool is_copy = false, etagpair** ppetag = NULL);
 
         void ClearUntreated(bool lock_already_held = false);
         bool ClearUntreated(off_t start, off_t size);


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Changed the etaglist_t element that stores a list of `ETag` values for multipart uploads.

The etaglist_t was a list of `std::string`, but I changed it to a list of newly added structure `etagpair`.

For multipart uploads, the `ETag` and `part number` must be a pair.
Currently, these are managed separately, but that has no problem.
That's because each part of the multipart is a sequential number and matches the position of the string `list etaglist_t`.

In this PR, we have added a new structure `etagpair` with `ETag` and `part number` as members.
And I changed `etaglist_t` to a list of structs `etagpair`.

This PR is a related modification.
