### PR TITLE
Require explicit length in s3fs_decode64

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -802,7 +802,7 @@ bool S3fsCurl::PushbackSseKeys(const std::string& input)
         char* p_key;
         size_t keylength;
 
-        if(NULL != (p_key = (char *)s3fs_decode64(onekey.c_str(), &keylength))) {
+        if(NULL != (p_key = (char *)s3fs_decode64(onekey.c_str(), onekey.size(), &keylength))) {
             raw_key = std::string(p_key, keylength);
             base64_key = onekey;
             delete[] p_key;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2839,7 +2839,7 @@ static bool parse_xattr_keyval(const std::string& xattrpair, std::string& key, P
 
     pval = new XATTRVAL;
     pval->length = 0;
-    pval->pvalue = s3fs_decode64(tmpval.c_str(), &pval->length);
+    pval->pvalue = s3fs_decode64(tmpval.c_str(), tmpval.size(), &pval->length);
 
     return true;
 }

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -432,16 +432,15 @@ inline unsigned char char_decode64(const char ch)
     return by;
 }
 
-unsigned char* s3fs_decode64(const char* input, size_t* plength)
+unsigned char* s3fs_decode64(const char* input, size_t input_len, size_t* plength)
 {
     unsigned char* result;
-    if(!input || 0 == strlen(input) || !plength){
+    if(!input || 0 == input_len || !plength){
         return NULL;
     }
-    result = new unsigned char[strlen(input) / 4 * 3];
+    result = new unsigned char[input_len / 4 * 3];
 
     unsigned char parts[4];
-    size_t input_len = strlen(input);
     size_t rpos;
     size_t wpos;
     for(rpos = 0, wpos = 0; rpos < input_len; rpos += 4){

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -99,7 +99,7 @@ bool get_keyword_value(const std::string& target, const char* keyword, std::stri
 std::string s3fs_hex_lower(const unsigned char* input, size_t length);
 std::string s3fs_hex_upper(const unsigned char* input, size_t length);
 char* s3fs_base64(const unsigned char* input, size_t length);
-unsigned char* s3fs_decode64(const char* input, size_t* plength);
+unsigned char* s3fs_decode64(const char* input, size_t input_len, size_t* plength);
 
 //
 // WTF8

--- a/src/test_string_util.cpp
+++ b/src/test_string_util.cpp
@@ -68,30 +68,30 @@ void test_base64()
     size_t len;
 
     ASSERT_STREQUALS(s3fs_base64(NULL, 0), NULL);
-    buf = s3fs_decode64(NULL, &len);
+    buf = s3fs_decode64(NULL, 0, &len);
     ASSERT_BUFEQUALS(reinterpret_cast<const char *>(buf), len, NULL, 0);
 
     ASSERT_STREQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>(""), 0), NULL);
-    buf = s3fs_decode64("", &len);
+    buf = s3fs_decode64("", 0, &len);
     ASSERT_BUFEQUALS(reinterpret_cast<const char *>(buf), len, NULL, 0);
 
     ASSERT_STREQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>("1"), 1), "MQ==");
-    buf = s3fs_decode64("MQ==", &len);
+    buf = s3fs_decode64("MQ==", 4, &len);
     ASSERT_BUFEQUALS(reinterpret_cast<const char *>(buf), len, "1", 1);
     ASSERT_EQUALS(len, static_cast<size_t>(1));
 
     ASSERT_STREQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>("12"), 2), "MTI=");
-    buf = s3fs_decode64("MTI=", &len);
+    buf = s3fs_decode64("MTI=", 4, &len);
     ASSERT_BUFEQUALS(reinterpret_cast<const char *>(buf), len, "12", 2);
     ASSERT_EQUALS(len, static_cast<size_t>(2));
 
     ASSERT_STREQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>("123"), 3), "MTIz");
-    buf = s3fs_decode64("MTIz", &len);
+    buf = s3fs_decode64("MTIz", 4, &len);
     ASSERT_BUFEQUALS(reinterpret_cast<const char *>(buf), len, "123", 3);
     ASSERT_EQUALS(len, static_cast<size_t>(3));
 
     ASSERT_STREQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>("1234"), 4), "MTIzNA==");
-    buf = s3fs_decode64("MTIzNA==", &len);
+    buf = s3fs_decode64("MTIzNA==", 8, &len);
     ASSERT_BUFEQUALS(reinterpret_cast<const char *>(buf), len, "1234", 4);
     ASSERT_EQUALS(len, static_cast<size_t>(4));
 


### PR DESCRIPTION
This is available from `std::string::size` in callers.