### PR TITLE
fclose(FILE*) instead of close(fileno(FILE*))

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -336,7 +336,7 @@ bool FdManager::HaveLseekHole()
             result = false;
         }
     }
-    close(fd);
+    fclose(ptmpfp);
 
     FdManager::checked_lseek   = true;
     FdManager::have_lseek_hole = result;


### PR DESCRIPTION
This is the same thing but confuses Coverity.