### PR TITLE
remove Expect: 100-continue header when requesting an IMDSv2 access t…

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3028,6 +3028,12 @@ int S3fsCurl::GetIAMv2ApiToken()
     std::string ttlstr = str(S3fsCurl::IAMv2_token_ttl);
     requestHeaders = curl_slist_sort_insert(requestHeaders, S3fsCurl::IAMv2_token_ttl_hdr.c_str(),
                                             ttlstr.c_str());
+
+    // Curl appends an "Expect: 100-continue" header to the token request, 
+    // and aws responds with a 417 Expectation Failed. This ensures the 
+    // Expect header is empty before the request is sent.
+    requestHeaders = curl_slist_sort_insert(requestHeaders, "Expect", "");
+
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_PUT, true)){
         return -EIO;
     }


### PR DESCRIPTION
### Relevant Issue (if applicable)
Fixes #1765 by explicitly setting the `Expect` header to be empty before making the request to retrieve the IMDSv2 token from `/latest/api/token`

Potentially fixes #1581 as well. Verified on my ec2-instance that the Expect 100 is removed from the request:
```
Sep  8 10:28:51:      Get IAM Role name
Sep  8 10:28:51: *   Trying 169.254.169.254:80...
Sep  8 10:28:51: * Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
Sep  8 10:28:51: > PUT /latest/api/token HTTP/1.1
Sep  8 10:28:51: > Host: 169.254.169.254
Sep  8 10:28:51: > User-Agent: s3fs/1.90 (commit hash 9d1552a; OpenSSL)
Sep  8 10:28:51: > Accept: */*
Sep  8 10:28:51: > Transfer-Encoding: chunked
Sep  8 10:28:51: > X-aws-ec2-metadata-token-ttl-seconds: 21600
Sep  8 10:28:51: >
Sep  8 10:28:51: * Signaling end of chunked upload via terminating chunk.
Sep  8 10:28:51: * Mark bundle as not supporting multiuse
Sep  8 10:28:51: * HTTP 1.0, assume close after body
Sep  8 10:28:51: < HTTP/1.0 200 OK
Sep  8 10:28:51: < Content-Length: 56
Sep  8 10:28:51: < Content-Type: text/plain
Sep  8 10:28:51: < Date: Wed, 08 Sep 2021 10:28:51 GMT
Sep  8 10:28:51: < X-Aws-Ec2-Metadata-Token-Ttl-Seconds: 21600
Sep  8 10:28:51: < Connection: close
Sep  8 10:28:51: < Server: EC2ws
Sep  8 10:28:51: <
Sep  8 10:28:51: * Closing connection 0
Sep  8 10:28:51:      HTTP response code 200
Sep  8 10:28:51:      Setting AWS IMDSv2 API token to *********************************
```

