### PR TITLE
Fixed forgetting to clear the dirty flag for meta information

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1878,22 +1878,22 @@ bool S3fsCurl::AddUserAgent(CURL* hCurl)
     return true;
 }
 
-int S3fsCurl::CurlDebugFunc(CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr)
+int S3fsCurl::CurlDebugFunc(const CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr)
 {
     return S3fsCurl::RawCurlDebugFunc(hcurl, type, data, size, userptr, CURLINFO_END);
 }
 
-int S3fsCurl::CurlDebugBodyInFunc(CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr)
+int S3fsCurl::CurlDebugBodyInFunc(const CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr)
 {
     return S3fsCurl::RawCurlDebugFunc(hcurl, type, data, size, userptr, CURLINFO_DATA_IN);
 }
 
-int S3fsCurl::CurlDebugBodyOutFunc(CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr)
+int S3fsCurl::CurlDebugBodyOutFunc(const CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr)
 {
     return S3fsCurl::RawCurlDebugFunc(hcurl, type, data, size, userptr, CURLINFO_DATA_OUT);
 }
 
-int S3fsCurl::RawCurlDebugFunc(CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr, curl_infotype datatype)
+int S3fsCurl::RawCurlDebugFunc(const CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr, curl_infotype datatype)
 {
     if(!hcurl){
         // something wrong...

--- a/src/curl.h
+++ b/src/curl.h
@@ -261,10 +261,10 @@ class S3fsCurl
         static bool PushbackSseKeys(const std::string& onekey);
         static bool AddUserAgent(CURL* hCurl);
 
-        static int CurlDebugFunc(CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr);
-        static int CurlDebugBodyInFunc(CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr);
-        static int CurlDebugBodyOutFunc(CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr);
-        static int RawCurlDebugFunc(CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr, curl_infotype datatype);
+        static int CurlDebugFunc(const CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr);
+        static int CurlDebugBodyInFunc(const CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr);
+        static int CurlDebugBodyOutFunc(const CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr);
+        static int RawCurlDebugFunc(const CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr, curl_infotype datatype);
 
         // methods
         bool ResetHandle(bool lock_already_held = false);

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -404,7 +404,7 @@ bool FdEntity::IsUploading(bool lock_already_held)
 // If the open is successful, returns pseudo fd.
 // If it fails, it returns an error code with a negative value.
 //
-int FdEntity::Open(headers_t* pmeta, off_t size, time_t time, int flags, AutoLock::Type type)
+int FdEntity::Open(const headers_t* pmeta, off_t size, time_t time, int flags, AutoLock::Type type)
 {
     AutoLock auto_lock(&fdent_lock, type);
 
@@ -1240,6 +1240,9 @@ int FdEntity::NoCachePreMultipartPost(PseudoFdInfo* pseudo_obj)
     }
     s3fscurl.DestroyCurlHandle();
 
+    // Clear the dirty flag, because the meta data is updated.
+    is_meta_pending = false;
+
     // reset upload_id
     if(!pseudo_obj->InitialUploadInfo(upload_id)){
         return -EIO;
@@ -1535,6 +1538,7 @@ int FdEntity::RowFlushMultipart(PseudoFdInfo* pseudo_obj, const char* tpath)
 
     if(0 == result){
         pagelist.ClearAllModified();
+        is_meta_pending = false;
     }
     return result;
 }
@@ -1662,6 +1666,7 @@ int FdEntity::RowFlushMixMultipart(PseudoFdInfo* pseudo_obj, const char* tpath)
 
     if(0 == result){
         pagelist.ClearAllModified();
+        is_meta_pending = false;
     }
     return result;
 }

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -85,7 +85,7 @@ class FdEntity
         void Close(int fd);
         bool IsOpen() const { return (-1 != physical_fd); }
         bool FindPseudoFd(int fd, bool lock_already_held = false);
-        int Open(headers_t* pmeta, off_t size, time_t time, int flags, AutoLock::Type type);
+        int Open(const headers_t* pmeta, off_t size, time_t time, int flags, AutoLock::Type type);
         bool LoadAll(int fd, headers_t* pmeta = NULL, off_t* size = NULL, bool force_load = false);
         int Dup(int fd, bool lock_already_held = false);
         int OpenPseudoFd(int flags = O_RDONLY, bool lock_already_held = false);

--- a/src/fdcache_page.cpp
+++ b/src/fdcache_page.cpp
@@ -293,7 +293,7 @@ bool PageList::CheckAreaInSparseFile(const struct fdpage& checkpage, const fdpag
             check_start = checkpage.offset;
             check_bytes = iter->bytes - (checkpage.offset - iter->offset);
 
-        }else if(iter->offset < (checkpage.offset + checkpage.bytes) && (checkpage.offset + checkpage.bytes) < (iter->offset + iter->bytes)){
+        }else if((checkpage.offset + checkpage.bytes) < (iter->offset + iter->bytes)){  // here, already "iter->offset < (checkpage.offset + checkpage.bytes)" is true.
             // case 3
             check_start = iter->offset;
             check_bytes = checkpage.bytes - (iter->offset - checkpage.offset);

--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -175,6 +175,8 @@ static char* get_object_name(xmlDocPtr doc, xmlNodePtr node, const char* path)
                 if(strlen(dirpath) > strlen(basepath)){
                     withdirname = &dirpath[strlen(basepath)];
                 }
+                // cppcheck-suppress unmatchedSuppression
+                // cppcheck-suppress knownConditionTrueFalse
                 if(!withdirname.empty() && '/' != *withdirname.rbegin()){
                     withdirname += "/";
                 }


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
In the case where the dirty flag was set for the meta information, there was a case where this flag was not reset.
If s3fs started a file upload(containing a multipart upload) when flushed, this flag could not be reset.

Also, a new error was reported in cppcheck, so I fixed it.



