### PR TITLE
Excluded ubuntu 16.04 from the CI build execution environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
           - ubuntu:21.04
           - ubuntu:20.04
           - ubuntu:18.04
-          - ubuntu:16.04
           - debian:buster
           - debian:stretch
           - centos:centos8


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1774 

### Details
Ubuntu 16.04 was out of LTS support in April 2021.
Also, it is an environment where python3.6 cannot be installed by default.
Support for Github Actions will be coming to an end, as follows:
https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/

So I would like to stop the test run of Ubuntu 16.04 on Github Actions.
But this is a problem of the test environment, and I think we will continue to support it as much as possible without performing CI testing.
