### PR TITLE
Fixed wrong stat of cache after new creation file

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -2173,6 +2173,16 @@ bool FdEntity::PunchHole(off_t start, size_t size)
     return true;
 }
 
+// [NOTE]
+// Indicate that a new file's is dirty.
+// This ensures that both metadata and data are synced during flush.
+//
+void FdEntity::MarkDirtyNewFile()
+{
+    pagelist.Init(0, false, true);
+    is_meta_pending = true;
+}
+
 /*
 * Local variables:
 * tab-width: 4

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -126,11 +126,7 @@ class FdEntity
         bool ReserveDiskSpace(off_t size);
         bool PunchHole(off_t start = 0, size_t size = 0);
 
-        // Indicate that a new file's is dirty.  This ensures that both metadata and data are synced during flush.
-        void MarkDirtyNewFile() {
-            pagelist.SetPageLoadedStatus(0, 1, PageList::PAGE_LOAD_MODIFIED);
-            is_meta_pending = true;
-        }
+        void MarkDirtyNewFile();
 };
 
 typedef std::map<std::string, class FdEntity*> fdent_map_t;   // key=path, value=FdEntity*

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -1321,6 +1321,32 @@ function test_cache_file_stat() {
     rm_test_file "${BIG_FILE}"
 }
 
+function test_zero_cache_file_stat() {
+    describe "Test zero byte cache file stat ..."
+
+    rm_test_file ${TEST_TEXT_FILE}
+
+    #
+    # create empty file
+    #
+    touch ${TEST_TEXT_FILE}
+
+    #
+    # get "testrun-xxx" directory name
+    #
+    CACHE_TESTRUN_DIR=$(ls -1 ${CACHE_DIR}/${TEST_BUCKET_1}/ 2>/dev/null | grep testrun 2>/dev/null)
+
+    # [NOTE]
+    # The stat file is a one-line text file, expecting for "<inode>:0"(ex. "4543937: 0").
+    #
+    head -1 ${CACHE_DIR}/.${TEST_BUCKET_1}.stat/${CACHE_TESTRUN_DIR}/${TEST_TEXT_FILE} 2>/dev/null | grep -q ':0$' 2>/dev/null
+    if [ $? -ne 0 ]; then
+        echo "The cache file stat after creating an empty file is incorrect : ${CACHE_DIR}/.${TEST_BUCKET_1}.stat/${CACHE_TESTRUN_DIR}/${TEST_TEXT_FILE}"
+        return 1;
+    fi
+    rm_test_file ${TEST_TEXT_FILE}
+}
+
 function test_upload_sparsefile {
     describe "Testing upload sparse file ..."
 
@@ -1462,6 +1488,7 @@ function test_ut_ossfs {
 function add_all_tests {
     if ps u $S3FS_PID | grep -q use_cache; then
         add_tests test_cache_file_stat
+        add_tests test_zero_cache_file_stat
     fi
     if ! ps u $S3FS_PID | grep -q ensure_diskfree && ! uname | grep -q Darwin; then
         add_tests test_clean_up_cache


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1640

### Details
When creating an empty file(when opening a non-existent file with the create flag), the `FdEntity::MarkDirtyNewFile()` method adds a page information to the pagelist.
The page information to be added was start=0 and size=1.

This works now, but the stat information(`.<bucket>.stat/<file>`) for the cache file immediately after the file is created that it shows a 1byte file.
However, the size of the real cache file is zero and it seems to work correctly.

If s3fs does not have the modified page information, it can not create an empty file, so it is as above for avoiding this.

But it is not correct, since the stat information for cache file is creating an incorrect state, this page addition process has been fixed.
After that, enabled to add page information of size 0 to pagelist.

For safety, if any other page information exists, the size 0 page information will be compressed and deleted.
This empty page information can exist only when there is no other page information(ex: when creating an empty file).
