### PR TITLE
More parallelized GithubActions(CI) execution and reduced time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
 
       #
-      # matrix for containers
+      # matrix for containers and test cases
       #
       matrix:
         container:
@@ -60,6 +60,15 @@ jobs:
           - centos:centos7
           - fedora:35
           - opensuse/leap:15
+
+        # [Test case]
+        # The symbol defined in this variable will be tested.
+        # The following symbols are defined in small-integration-test.sh.
+        #
+        testcase:
+          - STANDARD:MD5:STATSIZE:CPLIMIT
+          - NOOBJ:NOCOPY:NOMULTI:NOCOMPAT
+          - SIGV2:SIGV4
 
     container:
       image: ${{ matrix.container }}
@@ -103,7 +112,7 @@ jobs:
 
       - name: Test suite
         run: |
-          make ALL_TESTS=1 check -C test || (test/filter-suite-log.sh test/test-suite.log; exit 1)
+          make TESTCASE=${{ matrix.testcase }} check -C test || (test/filter-suite-log.sh test/test-suite.log; exit 1)
 
   # [NOTE]
   # A case of "runs-on: macos-11.0" does not work,
@@ -114,6 +123,28 @@ jobs:
   #
   macos10:
     runs-on: macos-10.15
+
+    #
+    # build matrix for test cases
+    #
+    strategy:
+      #
+      # do not stop jobs automatically if any of the jobs fail
+      #
+      fail-fast: false
+
+      #
+      # matrix for test cases
+      #
+      matrix:
+        # [Test case]
+        # The symbol defined in this variable will be tested.
+        # The following symbols are defined in small-integration-test.sh.
+        #
+        testcase:
+          - STANDARD:MD5:STATSIZE:CPLIMIT
+          - NOOBJ:NOCOPY:NOMULTI:NOCOMPAT
+          - SIGV2:SIGV4
 
     steps:
       - name: Checkout source code
@@ -157,7 +188,7 @@ jobs:
           make check -C src
           echo "user_allow_other" | sudo tee -a /etc/fuse.conf >/dev/null
           if [ -f /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ]; then /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs; elif [ -f /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ]; then /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse; else exit 1; fi
-          make ALL_TESTS=1 check -C test || (test/filter-suite-log.sh test/test-suite.log; exit 1)
+          make TESTCASE=${{ matrix.testcase }} check -C test || (test/filter-suite-log.sh test/test-suite.log; exit 1)
 
 #
 # Local variables:

--- a/test/small-integration-test.sh
+++ b/test/small-integration-test.sh
@@ -39,6 +39,7 @@ ENSURE_DISKFREE_SIZE=10
 
 export CACHE_DIR
 export ENSURE_DISKFREE_SIZE 
+
 if [ -n "${ALL_TESTS}" ]; then
     FLAGS=(
         "use_cache=${CACHE_DIR} -o ensure_diskfree=${ENSURE_DISKFREE_SIZE} -o fake_diskfree=${FAKE_FREE_DISK_SIZE}"
@@ -53,10 +54,56 @@ if [ -n "${ALL_TESTS}" ]; then
         singlepart_copy_limit=10  # limit size to exercise multipart code paths
         #use_sse  # TODO: S3Proxy does not support SSE
     )
-else
-    FLAGS=(
-        sigv4
-    )
+
+elif [ -n "${TESTCASE}" ]; then
+    # [Case name]
+    #   STANDARD    -> use_cache=${CACHE_DIR} -o ensure_diskfree=${ENSURE_DISKFREE_SIZE} -o fake_diskfree=${FAKE_FREE_DISK_SIZE}
+    #   MD5         -> enable_content_md5
+    #   NOOBJ       -> enable_noobj_cache
+    #   STATSIZE    -> max_stat_cache_size=100
+    #   NOCOPY      -> nocopyapi
+    #   NOMULTI     -> nomultipart
+    #   NOCOMPAT    -> notsup_compat_dir
+    #   SIGV2       -> sigv2
+    #   SIGV4       -> sigv4
+    #   CPLIMIT     -> singlepart_copy_limit=10
+    #   SSE         -> use_sse
+    #
+    FLAGS=()
+    for ONECASE in $(echo "${TESTCASE}" | tr ':' ' '); do
+        if [ "${ONECASE}" = "STANDARD" ]; then
+            FLAGS+=("use_cache=${CACHE_DIR} -o ensure_diskfree=${ENSURE_DISKFREE_SIZE} -o fake_diskfree=${FAKE_FREE_DISK_SIZE}")
+        elif [ "${ONECASE}" = "MD5" ]; then
+            FLAGS+=("enable_content_md5")
+        elif [ "${ONECASE}" = "NOOBJ" ]; then
+            FLAGS+=("enable_noobj_cache")
+        elif [ "${ONECASE}" = "STATSIZE" ]; then
+            FLAGS+=("max_stat_cache_size=100")
+        elif [ "${ONECASE}" = "NOCOPY" ]; then
+            FLAGS+=("nocopyapi")
+        elif [ "${ONECASE}" = "NOMULTI" ]; then
+            FLAGS+=("nomultipart")
+        elif [ "${ONECASE}" = "NOCOMPAT" ]; then
+            FLAGS+=("notsup_compat_dir")
+        elif [ "${ONECASE}" = "SIGV2" ]; then
+            FLAGS+=("sigv2")
+        elif [ "${ONECASE}" = "SIGV4" ]; then
+            FLAGS+=("sigv4")
+        elif [ "${ONECASE}" = "CPLIMIT" ]; then
+            FLAGS+=("singlepart_copy_limit=10")
+        elif [ "${ONECASE}" = "SSE" ]; then
+            FLAGS+=("use_sse")
+        else
+            # Unknown case, skip this. (or should exit?)
+            :
+        fi
+    done
+    if [ "${#FLAGS[*]}" -eq 0 ]; then
+        #
+        # Set default one case
+        #
+        FLAGS=("sigv4")
+    fi
 fi
 
 start_s3proxy


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Execution of current our GithubActions is matrixed by only OS.
For each OS, we are testing cases of 10 different s3fs option combinations.
Thus, due to the long execution time of the entire test, it takes more than 15m-20m.

To save time, I've changed the test to be isolated in a combination case of 2-4 options and run matrix in this isolated test case with the OS.
This reduced the test time to 3m-5m.

This fix increases the number of parallel runs of Runner from 10 to 30.
I can't tell if this increase is violent for Github Actions, but since the execution time for each Runner is less than 1/3, I think that the occupancy time for Github Actions is the same or less.

Assuming that the number of test cases will increase in the future, I have shortened it as much as possible.
If you have any problems, please point them out.
