### PR TITLE
Reduce errexit modifications

### DIFF
--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -235,22 +235,12 @@ function run_suite {
    key_prefix="testrun-$RANDOM"
    cd_run_dir $key_prefix
    for t in "${TEST_LIST[@]}"; do
-       # The following sequence runs tests in a subshell to allow continuation
-       # on test failure, but still allowing errexit to be in effect during
-       # the test.
-       #
-       # See:
-       #     https://groups.google.com/d/msg/gnu.bash.bug/NCK_0GmIv2M/dkeZ9MFhPOIJ
-       # Other ways of trying to capture the return value will also disable
-       # errexit in the function due to bash... compliance with POSIX? 
-       set +o errexit
-       (set -o errexit; $t $key_prefix)
-       if [[ $? == 0 ]]; then
+       $t $key_prefix && rc=$? || rc=$?
+       if [[ $rc == 0 ]] ; then
            report_pass $t
        else
            report_fail $t
        fi
-       set -o errexit
    done
    cd ${orig_dir}
    clean_run_dir


### PR DESCRIPTION
This is less error prone but requires some magic `&&` `||`.