### PR TITLE
Add Debian Bullseye to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           - ubuntu:21.04
           - ubuntu:20.04
           - ubuntu:18.04
+          - debian:bullseye
           - debian:buster
           - debian:stretch
           - centos:centos8


### PR DESCRIPTION
Stretch is supported until June 2022:

https://wiki.debian.org/LTS