### PR TITLE
fix  mixupload return EntityTooSmall while a copypart is less than 5MB after split

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1458,11 +1458,15 @@ int S3fsCurl::ParallelMixMultipartUploadRequest(const char* tpath, headers_t& me
                 S3fsCurl* s3fscurl_para              = new S3fsCurl(true);
 
                 bytes = std::min(static_cast<off_t>(GetMultipartCopySize()), iter->bytes - i);
-                /* every part should be larger than MIN_MULTIPART_SIZE */
+                /* every part should be larger than MIN_MULTIPART_SIZE and smaller than FIVE_GB */
                 off_t remain_bytes = iter->bytes - i - bytes;
 
                 if ((MIN_MULTIPART_SIZE > remain_bytes) && (0 < remain_bytes)){
-                    bytes += remain_bytes;
+                    if(FIVE_GB < (bytes + remain_bytes)){
+                        bytes = (bytes + remain_bytes)/2;
+                    } else{
+                        bytes += remain_bytes;
+                    }
                 }
 
                 std::ostringstream strrange;

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1453,8 +1453,7 @@ int S3fsCurl::ParallelMixMultipartUploadRequest(const char* tpath, headers_t& me
             }
         }else{
             // Multipart copy
-            off_t bytes = 0;
-            for(off_t i = 0; i < iter->bytes; i += bytes){
+            for(off_t i = 0, bytes = 0; i < iter->bytes; i += bytes){
                 S3fsCurl* s3fscurl_para              = new S3fsCurl(true);
 
                 bytes = std::min(static_cast<off_t>(GetMultipartCopySize()), iter->bytes - i);


### PR DESCRIPTION

### Relevant Issue (if applicable)
None

### Details
When I test append file, I found append 1 byte after a 513MB file while always reulsting in EIO.
The reason is mixupload will use copy API for previous 513MB.This will be splited into 512MB and 1MB. The data appeded will be uploaded as part 3. So we have 512M, 1M and 1 Byte part, this will cause EntityTooSmall when completing the MultipartUpload. 
