### PR TITLE
Fixed Mac install Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Many systems provide pre-built packages:
 
   ```
   brew install --cask osxfuse
-  brew install s3fs
+  brew install gromgit/fuse/s3fs-mac
   ```
 
 * FreeBSD:


### PR DESCRIPTION
Fixed install error

### Relevant Issue (if applicable)
[_If there are Issues related to this PullRequest, please list it._](https://github.com/s3fs-fuse/s3fs-fuse/issues/1618#issuecomment-952174574)

### Details
There is an error on Mac while install s3fs like it suggested in README. 
Found a solution, share with you
