### PR TITLE
Support CEPH multi tenancy bucket naming convention

### DIFF
--- a/doc/man/s3fs.1
+++ b/doc/man/s3fs.1
@@ -148,6 +148,9 @@ Note that this format matches the AWS CLI format and differs from the s3fs passw
 anonymously mount a public bucket when set to 1, ignores the $HOME/.passwd-s3fs and /etc/passwd-s3fs files.
 S3 does not allow copy object api for anonymous users, then s3fs sets nocopyapi option automatically when public_bucket=1 option is specified.
 .TP
+\fB\-o\fR tenancy_id (default="" which means disabled)
+Tenancy id for CEPH multi tenancy naming convention (tenancy_id:bucket_name)
+.TP
 \fB\-o\fR connect_timeout (default="300" seconds)
 time to wait for connection before giving up.
 .TP

--- a/src/common.h
+++ b/src/common.h
@@ -39,6 +39,7 @@ extern bool           nomultipart;
 extern bool           pathrequeststyle;
 extern bool           complement_stat;
 extern bool           noxmlns;
+extern bool           is_multi_tenancy;
 extern std::string    program_name;
 extern std::string    service_path;
 extern std::string    s3host;
@@ -48,6 +49,7 @@ extern std::string    endpoint;
 extern std::string    cipher_suites;
 extern std::string    instance_name;
 extern std::string    aws_profile;
+extern std::string    tenancy_id;
 
 #endif // S3FS_COMMON_H_
 

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -288,6 +288,7 @@ std::string prepare_url(const char* url)
     }
 
     url_str = uri + hostname + path;
+
     S3FS_PRN_INFO3("URL changed is %s", url_str.c_str());
 
     return url_str;

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -256,8 +256,13 @@ std::string prepare_url(const char* url)
     std::string uri;
     std::string hostname;
     std::string path;
+    std::string token;
     std::string url_str = std::string(url);
-    std::string token = std::string("/") + bucket;
+    if(is_multi_tenancy) {
+      token = std::string("/") + urlEncode(bucket);
+    } else {
+      token = std::string("/") + bucket;
+    }
     size_t bucket_pos;
     size_t bucket_length = token.size();
     size_t uri_length = 0;
@@ -283,7 +288,6 @@ std::string prepare_url(const char* url)
     }
 
     url_str = uri + hostname + path;
-
     S3FS_PRN_INFO3("URL changed is %s", url_str.c_str());
 
     return url_str;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -73,7 +73,7 @@ static bool is_mp_umask           = false;// default does not set.
 static std::string mountpoint;
 static std::string passwd_file;
 static std::string mimetype_file;
-//static std::string tenancy_id;
+
 static bool nocopyapi             = false;
 static bool norenameapi           = false;
 static bool nonempty              = false;
@@ -94,7 +94,6 @@ static bool create_bucket         = false;
 static off_t multipart_threshold  = 25 * 1024 * 1024;
 static int64_t singlepart_copy_limit = 512 * 1024 * 1024;
 static bool is_specified_endpoint = false;
-//static bool is_multi_tenancy      = true;
 static int s3fs_init_deferred_exit_status = 0;
 static bool support_compat_dir    = true;// default supports compatibility directory type
 static int max_keys_list_object   = 1000;// default is 1000

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -5122,6 +5122,13 @@ int main(int argc, char* argv[])
     }
 
     if(is_multi_tenancy){
+      if(!pathrequeststyle) {
+        S3FS_PRN_EXIT("CEPH multi tenancy naming convention can't be used without use_path_request_style");
+        S3fsCurl::DestroyS3fsCurl();
+        s3fs_destroy_global_ssl();
+        destroy_parser_xml_lock();
+        exit(EXIT_FAILURE);
+      }
       bucket = tenancy_id+":"+bucket;
       S3FS_PRN_INFO("bucket name: %s", bucket.c_str());
     }

--- a/src/s3fs_global.cpp
+++ b/src/s3fs_global.cpp
@@ -29,6 +29,7 @@ bool nomultipart                  = false;
 bool pathrequeststyle             = false;
 bool complement_stat              = false;
 bool noxmlns                      = false;
+bool is_multi_tenancy             = false;
 std::string program_name;
 std::string service_path          = "/";
 std::string s3host                = "https://s3.amazonaws.com";
@@ -37,6 +38,7 @@ std::string endpoint              = "us-east-1";
 std::string cipher_suites;
 std::string instance_name;
 std::string aws_profile           = "default";
+std::string tenancy_id;
 
 /*
 * Local variables:

--- a/src/s3fs_help.cpp
+++ b/src/s3fs_help.cpp
@@ -31,7 +31,7 @@
 //-------------------------------------------------------------------
 // Contents
 //-------------------------------------------------------------------
-static const char help_string[] = 
+static const char help_string[] =
     "\n"
     "Mount an Amazon S3 bucket as a file system.\n"
     "\n"
@@ -146,6 +146,10 @@ static const char help_string[] =
     "        S3 does not allow copy object api for anonymous users, then\n"
     "        s3fs sets nocopyapi option automatically when public_bucket=1\n"
     "        option is specified.\n"
+    "\n"
+    "   tenancy_id (default=\"\" which means disabled)\n"
+    "      - Tenancy id for CEPH multi tenancy naming convention\n"
+    "        (tenancy_id:bucket_name)\n"
     "\n"
     "   passwd_file (default=\"\")\n"
     "      - specify which s3fs password file to use\n"


### PR DESCRIPTION
### Relevant Issue (if applicable)
None

### Details
I added flag to handle CEPH multi tenancy naming convention (https://docs.ceph.com/en/latest/radosgw/multitenancy/), and would be great to the official version.
