### PR TITLE
Use HTTP to avoid unneeded overhead in tests

### DIFF
--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -66,7 +66,7 @@ set -o pipefail
 S3FS=../src/s3fs
 
 # Allow these defaulted values to be overridden
-: ${S3_URL:="https://127.0.0.1:8080"}
+: ${S3_URL:="http://127.0.0.1:8080"}
 : ${S3_ENDPOINT:="us-east-1"}
 : ${S3FS_CREDENTIALS_FILE:="passwd-s3fs"}
 : ${TEST_BUCKET_1:="s3fs-integration-test"}

--- a/test/s3proxy.conf
+++ b/test/s3proxy.conf
@@ -1,4 +1,4 @@
-s3proxy.secure-endpoint=https://127.0.0.1:8080
+s3proxy.endpoint=http://127.0.0.1:8080
 s3proxy.authorization=aws-v2-or-v4
 s3proxy.identity=local-identity
 s3proxy.credential=local-credential


### PR DESCRIPTION
This also may resolve the MIME type issues seen on older Linux CI.
References #1828.