### PR TITLE
Add Debian Bullseye to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           - ubuntu:21.10
           - ubuntu:20.04
           - ubuntu:18.04
+          - debian:bullseye
           - debian:buster
           - debian:stretch
           - centos:centos8

--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -86,6 +86,13 @@ elif [ "${CONTAINER_FULLNAME}" = "ubuntu:16.04" ]; then
     INSTALL_PACKAGES="autoconf autotools-dev default-jre-headless fuse libfuse-dev libcurl4-openssl-dev libxml2-dev locales-all mime-support libtool pkg-config libssl-dev attr curl python3-pip"
     INSTALL_CPPCHECK_OPTIONS=""
 
+elif [ "${CONTAINER_FULLNAME}" = "debian:bullseye" ]; then
+    PACKAGE_MANAGER_BIN="apt-get"
+    PACKAGE_UPDATE_OPTIONS="update -y -qq"
+
+    INSTALL_PACKAGES="autoconf autotools-dev default-jre-headless fuse libfuse-dev libcurl4-openssl-dev libxml2-dev locales-all mime-support libtool pkg-config libssl-dev attr curl python2 procps python3-pip"
+    INSTALL_CPPCHECK_OPTIONS=""
+
 elif [ "${CONTAINER_FULLNAME}" = "debian:buster" ]; then
     PACKAGE_MANAGER_BIN="apt-get"
     PACKAGE_UPDATE_OPTIONS="update -y -qq"


### PR DESCRIPTION
Stretch is supported until June 2022:

https://wiki.debian.org/LTS