### PR TITLE
Always call clock_gettime(2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Many systems provide pre-built packages:
   sudo zypper install s3fs
   ```
 
-* macOS via [Homebrew](https://brew.sh/):
+* macOS 10.12 and newer via [Homebrew](https://brew.sh/):
 
   ```
   brew install --cask osxfuse


### PR DESCRIPTION
e01ded9e27f41af45e8614860b29164d13c0101e introduced this compatibility
shim but macOS 10.12 (2016) added this:
https://stackoverflow.com/a/39801564 .  Also remove fallback to
`time(3)` which loses precision.