### PR TITLE
Check bucket before trying to create it

### DIFF
--- a/test/small-integration-test.sh
+++ b/test/small-integration-test.sh
@@ -62,7 +62,9 @@ fi
 
 start_s3proxy
 
-aws_cli s3 mb "s3://${TEST_BUCKET_1}" --region "${S3_ENDPOINT}"
+if ! aws_cli s3api head-bucket --bucket "${TEST_BUCKET_1}" --region "${S3_ENDPOINT}"; then
+    aws_cli s3 mb "s3://${TEST_BUCKET_1}" --region "${S3_ENDPOINT}"
+fi
 
 for flag in "${FLAGS[@]}"; do
     echo "testing s3fs flag: ${flag}"


### PR DESCRIPTION
This makes it easier to run tests against S3 other than S3Proxy.