### PR TITLE
Fixed the fault tolerance when time stamp getting fails

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -786,6 +786,10 @@ bool convert_header_to_stat(const char* path, const headers_t& meta, struct stat
     if(pst->st_mtime < 0){
         pst->st_mtime = 0L;
     }else{
+        if(mtime.tv_sec < 0){
+            mtime.tv_sec  = 0;
+            mtime.tv_nsec = 0;
+        }
 #if defined(__APPLE__)
         pst->st_mtime = mtime.tv_sec;
 #else
@@ -799,6 +803,10 @@ bool convert_header_to_stat(const char* path, const headers_t& meta, struct stat
     if(pst->st_ctime < 0){
         pst->st_ctime = 0L;
     }else{
+        if(ctime.tv_sec < 0){
+            ctime.tv_sec  = 0;
+            ctime.tv_nsec = 0;
+        }
 #if defined(__APPLE__)
         pst->st_ctime = ctime.tv_sec;
 #else
@@ -812,6 +820,10 @@ bool convert_header_to_stat(const char* path, const headers_t& meta, struct stat
     if(pst->st_atime < 0){
         pst->st_atime = 0L;
     }else{
+        if(atime.tv_sec < 0){
+            atime.tv_sec  = 0;
+            atime.tv_nsec = 0;
+        }
 #if defined(__APPLE__)
         pst->st_atime = atime.tv_sec;
 #else

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -371,6 +371,21 @@ function test_read_external_object() {
     rm -f "${TEST_TEXT_FILE}"
 }
 
+function test_read_external_dir_object() {
+    describe "create directory objects via aws CLI and read via s3fs ..."
+    local SUB_DIR_NAME;      SUB_DIR_NAME="subdir"
+    local SUB_DIR_TEST_FILE; SUB_DIR_TEST_FILE="${SUB_DIR_NAME}/${TEST_TEXT_FILE}"
+    local OBJECT_NAME;       OBJECT_NAME=$(basename "${PWD}")/"${SUB_DIR_TEST_FILE}"
+
+    echo "test" | aws_cli s3 cp - "s3://${TEST_BUCKET_1}/${OBJECT_NAME}"
+
+    if stat "${SUB_DIR_NAME}" | grep -q '1969-12-31[[:space:]]23:59:59[.]000000000'; then
+        echo "sub directory a/c/m time is underflow(-1)."
+        return 1
+    fi
+    rm -rf "${SUB_DIR_NAME}"
+}
+
 function test_update_metadata_external_small_object() {
     describe "update meta to small file after created file by aws cli"
 
@@ -1796,6 +1811,7 @@ function add_all_tests {
     fi
     add_tests test_external_modification
     add_tests test_read_external_object
+    add_tests test_read_external_dir_object
     add_tests test_update_metadata_external_small_object
     add_tests test_update_metadata_external_large_object
     add_tests test_rename_before_close


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1872

### Details
Fixed a problem in processing when get_atime(ctime/mtime) failed to get the time.
In convert_header_to_stat, reset 0 if the above function returns -1.
