### PR TITLE
Added S3fsCred class and moved Credential related processing in it

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,6 +41,7 @@ s3fs_SOURCES = \
     s3objlist.cpp \
     cache.cpp \
     string_util.cpp \
+    s3fs_cred.cpp \
     s3fs_util.cpp \
     fdcache.cpp \
     fdcache_entity.cpp \

--- a/src/common.h
+++ b/src/common.h
@@ -42,12 +42,10 @@ extern bool           noxmlns;
 extern std::string    program_name;
 extern std::string    service_path;
 extern std::string    s3host;
-extern std::string    bucket;
 extern std::string    mount_prefix;
 extern std::string    endpoint;
 extern std::string    cipher_suites;
 extern std::string    instance_name;
-extern std::string    aws_profile;
 
 #endif // S3FS_COMMON_H_
 

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -27,6 +27,7 @@
 #include "curl_util.h"
 #include "string_util.h"
 #include "s3fs_auth.h"
+#include "s3fs_cred.h"
 
 //-------------------------------------------------------------------
 // Utility Functions
@@ -244,7 +245,7 @@ bool MakeUrlResource(const char* realpath, std::string& resourcepath, std::strin
     if(!realpath){
         return false;
     }
-    resourcepath = urlEncode(service_path + bucket + realpath);
+    resourcepath = urlEncode(service_path + S3fsCred::GetBucket() + realpath);
     url          = s3host + resourcepath;
     return true;
 }
@@ -257,7 +258,7 @@ std::string prepare_url(const char* url)
     std::string hostname;
     std::string path;
     std::string url_str = std::string(url);
-    std::string token = std::string("/") + bucket;
+    std::string token = std::string("/") + S3fsCred::GetBucket();
     size_t bucket_pos;
     size_t bucket_length = token.size();
     size_t uri_length = 0;
@@ -271,7 +272,7 @@ std::string prepare_url(const char* url)
     bucket_pos = url_str.find(token, uri_length);
 
     if(!pathrequeststyle){
-        hostname = bucket + "." + url_str.substr(uri_length, bucket_pos - uri_length);
+        hostname = S3fsCred::GetBucket() + "." + url_str.substr(uri_length, bucket_pos - uri_length);
         path = url_str.substr((bucket_pos + bucket_length));
     }else{
         hostname = url_str.substr(uri_length, bucket_pos - uri_length);
@@ -279,7 +280,7 @@ std::string prepare_url(const char* url)
         if('/' != part[0]){
             part = "/" + part;
         }
-        path = "/" + bucket + part;
+        path = "/" + S3fsCred::GetBucket() + part;
     }
 
     url_str = uri + hostname + path;
@@ -354,7 +355,7 @@ std::string url_to_host(const std::string &url)
 std::string get_bucket_host()
 {
     if(!pathrequeststyle){
-        return bucket + "." + url_to_host(s3host);
+        return S3fsCred::GetBucket() + "." + url_to_host(s3host);
     }
     return url_to_host(s3host);
 }

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -31,6 +31,7 @@
 #include "fdcache_pseudofd.h"
 #include "s3fs_util.h"
 #include "s3fs_logger.h"
+#include "s3fs_cred.h"
 #include "string_util.h"
 #include "autolock.h"
 
@@ -125,7 +126,7 @@ bool FdManager::DeleteCacheDirectory()
         return false;
     }
 
-    std::string mirror_path = FdManager::cache_dir + "/." + bucket + ".mirror";
+    std::string mirror_path = FdManager::cache_dir + "/." + S3fsCred::GetBucket() + ".mirror";
     if(!delete_files_in_dir(mirror_path.c_str(), true)){
         return false;
     }
@@ -181,10 +182,10 @@ bool FdManager::MakeCachePath(const char* path, std::string& cache_path, bool is
     std::string resolved_path(FdManager::cache_dir);
     if(!is_mirror_path){
         resolved_path += "/";
-        resolved_path += bucket;
+        resolved_path += S3fsCred::GetBucket();
     }else{
         resolved_path += "/.";
-        resolved_path += bucket;
+        resolved_path += S3fsCred::GetBucket();
         resolved_path += ".mirror";
     }
 
@@ -208,7 +209,7 @@ bool FdManager::CheckCacheTopDir()
     if(FdManager::cache_dir.empty()){
         return true;
     }
-    std::string toppath(FdManager::cache_dir + "/" + bucket);
+    std::string toppath(FdManager::cache_dir + "/" + S3fsCred::GetBucket());
 
     return check_exist_dir_permission(toppath.c_str());
 }
@@ -749,7 +750,7 @@ void FdManager::CleanupCacheDirInternal(const std::string &path)
 {
     DIR*           dp;
     struct dirent* dent;
-    std::string    abs_path = cache_dir + "/" + bucket + path;
+    std::string    abs_path = cache_dir + "/" + S3fsCred::GetBucket() + path;
 
     if(NULL == (dp = opendir(abs_path.c_str()))){
         S3FS_PRN_ERR("could not open cache dir(%s) - errno(%d)", abs_path.c_str(), errno);

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -2090,7 +2090,7 @@ int FdEntity::UploadPendingMeta()
     }
 
     headers_t updatemeta = orgmeta;
-    updatemeta["x-amz-copy-source"]        = urlEncode(service_path + bucket + get_realpath(path.c_str()));
+    updatemeta["x-amz-copy-source"]        = urlEncode(service_path + S3fsCred::GetBucket() + get_realpath(path.c_str()));
     updatemeta["x-amz-metadata-directive"] = "REPLACE";
     // put headers, no need to update mtime to avoid dead lock
     int result = put_headers(path.c_str(), updatemeta, true);

--- a/src/fdcache_stat.cpp
+++ b/src/fdcache_stat.cpp
@@ -29,6 +29,7 @@
 #include "fdcache_stat.h"
 #include "fdcache.h"
 #include "s3fs_util.h"
+#include "s3fs_cred.h"
 #include "string_util.h"
 
 //------------------------------------------------
@@ -37,14 +38,14 @@
 std::string CacheFileStat::GetCacheFileStatTopDir()
 {
     std::string top_path;
-    if(!FdManager::IsCacheDir() || bucket.empty()){
+    if(!FdManager::IsCacheDir() || S3fsCred::GetBucket().empty()){
         return top_path;
     }
 
     // stat top dir( "/<cache_dir>/.<bucket_name>.stat" )
     top_path += FdManager::GetCacheDir();
     top_path += "/.";
-    top_path += bucket;
+    top_path += S3fsCred::GetBucket();
     top_path += ".stat";
     return top_path;
 }

--- a/src/s3fs_cred.cpp
+++ b/src/s3fs_cred.cpp
@@ -1,0 +1,920 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <unistd.h>
+#include <pwd.h>
+#include <sys/types.h>
+#include <fstream>
+#include <sstream>
+
+#include "common.h"
+#include "s3fs.h"
+#include "s3fs_cred.h"
+#include "curl.h"
+#include "string_util.h"
+#include "metaheader.h"
+
+//-------------------------------------------------------------------
+// Symbols
+//-------------------------------------------------------------------
+#define	DEFAULT_AWS_PROFILE_NAME	"default"
+
+//-------------------------------------------------------------------
+// Class Variables
+//-------------------------------------------------------------------
+const char* S3fsCred::ALLBUCKET_FIELDS_TYPE     = "";
+const char*	S3fsCred::KEYVAL_FIELDS_TYPE        = "\t";
+const char* S3fsCred::AWS_ACCESSKEYID           = "AWSAccessKeyId";
+const char* S3fsCred::AWS_SECRETKEY             = "AWSSecretKey";
+
+const int   S3fsCred::IAM_EXPIRE_MERGIN         = 20 * 60;              // update timing
+const char* S3fsCred::ECS_IAM_ENV_VAR           = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+const char* S3fsCred::IAMCRED_ACCESSKEYID       = "AccessKeyId";
+const char* S3fsCred::IAMCRED_SECRETACCESSKEY   = "SecretAccessKey";
+const char* S3fsCred::IAMCRED_ROLEARN           = "RoleArn";
+
+const char* S3fsCred::IAMv2_token_url           = "http://169.254.169.254/latest/api/token";
+int         S3fsCred::IAMv2_token_ttl           = 21600;
+const char* S3fsCred::IAMv2_token_ttl_hdr       = "X-aws-ec2-metadata-token-ttl-seconds";
+const char* S3fsCred::IAMv2_token_hdr           = "X-aws-ec2-metadata-token";
+
+std::string S3fsCred::bucket_name;
+
+//-------------------------------------------------------------------
+// Class Methods 
+//-------------------------------------------------------------------
+bool S3fsCred::SetBucket(const char* bucket)
+{
+    if(!bucket || strlen(bucket) == 0){
+        return false;
+    }
+    S3fsCred::bucket_name = bucket;
+    return true;
+}
+
+const std::string& S3fsCred::GetBucket()
+{
+	return S3fsCred::bucket_name;
+}
+
+bool S3fsCred::ParseIAMRoleFromMetaDataResponse(const char* response, std::string& rolename)
+{
+    if(!response){
+        return false;
+    }
+    // [NOTE]
+    // expected following strings.
+    // 
+    // myrolename
+    //
+    std::istringstream ssrole(response);
+    std::string        oneline;
+    if (getline(ssrole, oneline, '\n')){
+        rolename = oneline;
+        return !rolename.empty();
+    }
+    return false;
+}
+
+//-------------------------------------------------------------------
+// Methods : Constructor / Destructor
+//-------------------------------------------------------------------
+S3fsCred::S3fsCred() :
+    passwd_file(""),
+    aws_profile(DEFAULT_AWS_PROFILE_NAME),
+    load_iamrole(false),
+    AWSAccessKeyId(""),
+    AWSSecretAccessKey(""),
+    AWSAccessToken(""),
+    AWSAccessTokenExpire(0),
+    is_ecs(false),
+    is_use_session_token(false),
+    is_ibm_iam_auth(false),
+    IAM_cred_url("http://169.254.169.254/latest/meta-data/iam/security-credentials/"),
+    IAM_api_version(2),
+    IAMv2_api_token(""),
+    IAM_field_count(4),
+    IAM_token_field("Token"),
+    IAM_expiry_field("Expiration"),
+    IAM_role("")
+{
+}
+
+S3fsCred::~S3fsCred()
+{
+}
+
+//-------------------------------------------------------------------
+// Methods : Access member variables
+//-------------------------------------------------------------------
+bool S3fsCred::SetS3fsPasswdFile(const char* file)
+{
+    if(!file || strlen(file) == 0){
+        return false;
+    }
+    passwd_file = file;
+
+    return true;
+}
+
+bool S3fsCred::IsSetPasswdFile()
+{
+    return !passwd_file.empty();
+}
+
+bool S3fsCred::SetAwsProfileName(const char* name)
+{
+    if(!name || strlen(name) == 0){
+        return false;
+    }
+    aws_profile = name;
+
+    return true;
+}
+
+bool S3fsCred::SetIAMRoleMetadataType(bool flag)
+{
+    bool old = load_iamrole;
+    load_iamrole = flag;
+    return old;
+}
+
+bool S3fsCred::SetAccessKey(const char* AccessKeyId, const char* SecretAccessKey)
+{
+    if((!is_ibm_iam_auth && (!AccessKeyId || '\0' == AccessKeyId[0])) || !SecretAccessKey || '\0' == SecretAccessKey[0]){
+        return false;
+    }
+    AWSAccessKeyId     = AccessKeyId;
+    AWSSecretAccessKey = SecretAccessKey;
+
+    return true;
+}
+
+bool S3fsCred::SetAccessKeyWithSessionToken(const char* AccessKeyId, const char* SecretAccessKey, const char * SessionToken)
+{
+    bool access_key_is_empty        = !AccessKeyId     || '\0' == AccessKeyId[0];
+    bool secret_access_key_is_empty = !SecretAccessKey || '\0' == SecretAccessKey[0];
+    bool session_token_is_empty     = !SessionToken    || '\0' == SessionToken[0];
+
+    if((!is_ibm_iam_auth && access_key_is_empty) || secret_access_key_is_empty || session_token_is_empty){
+        return false;
+    }
+    AWSAccessKeyId      = AccessKeyId;
+    AWSSecretAccessKey  = SecretAccessKey;
+    AWSAccessToken      = SessionToken;
+    is_use_session_token= true;
+
+    return true;
+}
+
+bool S3fsCred::IsSetAccessKeyID() const
+{
+    return !AWSAccessKeyId.empty();
+}
+
+bool S3fsCred::IsSetAccessKeys() const
+{
+    return !IAM_role.empty() || ((!AWSAccessKeyId.empty() || is_ibm_iam_auth) && !AWSSecretAccessKey.empty());
+}
+
+bool S3fsCred::SetIsECS(bool flag)
+{
+    bool old = is_ecs;
+    is_ecs = flag;
+    return old;
+}
+
+bool S3fsCred::SetIsUseSessionToken(bool flag)
+{
+    bool old = is_use_session_token;
+    is_use_session_token = flag;
+    return old;
+}
+
+bool S3fsCred::SetIsIBMIAMAuth(bool flag)
+{
+    bool old = is_ibm_iam_auth;
+    is_ibm_iam_auth = flag;
+    return old;
+}
+
+std::string S3fsCred::SetIAMRole(const char* role)
+{
+    std::string old = IAM_role;
+    IAM_role = role ? role : "";
+    return old;
+}
+
+size_t S3fsCred::SetIAMFieldCount(size_t field_count)
+{
+    size_t old = IAM_field_count;
+    IAM_field_count = field_count;
+    return old;
+}
+
+std::string S3fsCred::SetIAMCredentialsURL(const char* url)
+{
+    std::string old = IAM_cred_url;
+    IAM_cred_url = url ? url : "";
+    return old;
+}
+
+std::string S3fsCred::SetIAMTokenField(const char* token_field)
+{
+    std::string old = IAM_token_field;
+    IAM_token_field = token_field ? token_field : "";
+    return old;
+}
+
+std::string S3fsCred::SetIAMExpiryField(const char* expiry_field)
+{
+    std::string old = IAM_expiry_field;
+    IAM_expiry_field = expiry_field ? expiry_field : "";
+    return old;
+}
+
+int S3fsCred::SetIMDSVersion(int version)
+{
+    int old = IAM_api_version;
+    IAM_api_version = version;
+    return old;
+}
+
+bool S3fsCred::SetIAMv2APIToken(const char* response)
+{
+    S3FS_PRN_INFO3("Setting AWS IMDSv2 API token to %s", response ? response : "(null)");
+    if(!response){
+        return false;
+    }
+    IAMv2_api_token = std::string(response);
+    return true;
+}
+
+bool S3fsCred::SetIAMCredentials(const char* response)
+{
+    S3FS_PRN_INFO3("IAM credential response = \"%s\"", response);
+
+    iamcredmap_t keyval;
+
+    if(!ParseIAMCredentialResponse(response, keyval)){
+        return false;
+    }
+
+    if(IAM_field_count != keyval.size()){
+        return false;
+    }
+
+    AWSAccessToken = keyval[IAM_token_field];
+
+    if(is_ibm_iam_auth){
+        off_t tmp_expire = 0;
+        if(!s3fs_strtoofft(&tmp_expire, keyval[IAM_expiry_field].c_str(), /*base=*/ 10)){
+            return false;
+        }
+        AWSAccessTokenExpire = static_cast<time_t>(tmp_expire);
+    }else{
+        AWSAccessKeyId       = keyval[std::string(S3fsCred::IAMCRED_ACCESSKEYID)];
+        AWSSecretAccessKey   = keyval[std::string(S3fsCred::IAMCRED_SECRETACCESSKEY)];
+        AWSAccessTokenExpire = cvtIAMExpireStringToTime(keyval[IAM_expiry_field].c_str());
+    }
+    return true;
+}
+
+bool S3fsCred::SetIAMRoleFromMetaData(const char* response)
+{
+    S3FS_PRN_INFO3("IAM role name response = \"%s\"", response ? response : "(null)");
+
+    std::string rolename;
+    if(!S3fsCred::ParseIAMRoleFromMetaDataResponse(response, rolename)){
+        return false;
+    }
+
+    SetIAMRole(rolename.c_str());
+    return true;
+}
+
+
+//-------------------------------------------------------------------
+// Methods : for Credentials
+//-------------------------------------------------------------------
+//
+// Check passwd file readable
+//
+bool S3fsCred::IsReadableS3fsPasswdFile()
+{
+    if(passwd_file.empty()){
+        return false;
+    }
+
+    std::ifstream PF(passwd_file.c_str());
+    if(!PF.good()){
+        return false;
+    }
+    PF.close();
+
+    return true;
+}
+
+//
+// S3fsCred::CheckS3fsPasswdFilePerms
+//
+// expect that global passwd_file variable contains
+// a non-empty value and is readable by the current user
+//
+// Check for too permissive access to the file
+// help save users from themselves via a security hole
+//
+// only two options: return or error out
+//
+bool S3fsCred::CheckS3fsPasswdFilePerms()
+{
+    struct stat info;
+
+    // let's get the file info
+    if(stat(passwd_file.c_str(), &info) != 0){
+        S3FS_PRN_EXIT("unexpected error from stat(%s).", passwd_file.c_str());
+        return false;
+    }
+
+	// Check readable
+    if(!IsReadableS3fsPasswdFile()){
+        S3FS_PRN_EXIT("S3fs passwd file \"%s\" is not readable.", passwd_file.c_str());
+        return false;
+    }
+
+    // return error if any file has others permissions
+    if( (info.st_mode & S_IROTH) ||
+        (info.st_mode & S_IWOTH) ||
+        (info.st_mode & S_IXOTH)) {
+        S3FS_PRN_EXIT("credentials file %s should not have others permissions.", passwd_file.c_str());
+        return false;
+    }
+
+    // Any local file should not have any group permissions
+    // /etc/passwd-s3fs can have group permissions
+    if(passwd_file != "/etc/passwd-s3fs"){
+        if( (info.st_mode & S_IRGRP) ||
+            (info.st_mode & S_IWGRP) ||
+            (info.st_mode & S_IXGRP)) {
+            S3FS_PRN_EXIT("credentials file %s should not have group permissions.", passwd_file.c_str());
+            return false;
+        }
+    }else{
+        // "/etc/passwd-s3fs" does not allow group write.
+        if((info.st_mode & S_IWGRP)){
+            S3FS_PRN_EXIT("credentials file %s should not have group writable permissions.", passwd_file.c_str());
+            return false;
+        }
+    }
+    if((info.st_mode & S_IXUSR) || (info.st_mode & S_IXGRP)){
+        S3FS_PRN_EXIT("credentials file %s should not have executable permissions.", passwd_file.c_str());
+        return false;
+    }
+    return true;
+}
+
+//
+// Read and Parse passwd file
+//
+// The line of the password file is one of the following formats:
+//   (1) "accesskey:secretkey"         : AWS format for default(all) access key/secret key
+//   (2) "bucket:accesskey:secretkey"  : AWS format for bucket's access key/secret key
+//   (3) "key=value"                   : Content-dependent KeyValue contents
+//
+// This function sets result into bucketkvmap_t, it bucket name and key&value mapping.
+// If bucket name is empty(1 or 3 format), bucket name for mapping is set "\t" or "".
+//
+// Return: true  - Succeed parsing
+//         false - Should shutdown immediately
+//
+bool S3fsCred::ParseS3fsPasswdFile(bucketkvmap_t& resmap)
+{
+    std::string          line;
+    size_t               first_pos;
+    readline_t           linelist;
+    readline_t::iterator iter;
+
+    // open passwd file
+    std::ifstream PF(passwd_file.c_str());
+    if(!PF.good()){
+        S3FS_PRN_EXIT("could not open passwd file : %s", passwd_file.c_str());
+        return false;;
+    }
+
+    // read each line
+    while(getline(PF, line)){
+        line = trim(line);
+        if(line.empty()){
+            continue;
+        }
+        if('#' == line[0]){
+            continue;
+        }
+        if(std::string::npos != line.find_first_of(" \t")){
+            S3FS_PRN_EXIT("invalid line in passwd file, found whitespace character.");
+            return false;;
+        }
+        if('[' == line[0]){
+            S3FS_PRN_EXIT("invalid line in passwd file, found a bracket \"[\" character.");
+            return false;;
+        }
+        linelist.push_back(line);
+    }
+
+    // read '=' type
+    kvmap_t kv;
+    for(iter = linelist.begin(); iter != linelist.end(); ++iter){
+        first_pos = iter->find_first_of('=');
+        if(first_pos == std::string::npos){
+            continue;
+        }
+        // formatted by "key=val"
+        std::string key = trim(iter->substr(0, first_pos));
+        std::string val = trim(iter->substr(first_pos + 1, std::string::npos));
+        if(key.empty()){
+            continue;
+        }
+        if(kv.end() != kv.find(key)){
+            S3FS_PRN_WARN("same key name(%s) found in passwd file, skip this.", key.c_str());
+            continue;
+        }
+        kv[key] = val;
+    }
+    // set special key name
+    resmap[S3fsCred::KEYVAL_FIELDS_TYPE] = kv;
+
+    // read ':' type
+    for(iter = linelist.begin(); iter != linelist.end(); ++iter){
+        first_pos       = iter->find_first_of(':');
+        size_t last_pos = iter->find_last_of(':');
+        if(first_pos == std::string::npos){
+            continue;
+        }
+        std::string bucketname;
+        std::string accesskey;
+        std::string secret;
+        if(first_pos != last_pos){
+            // formatted by "bucket:accesskey:secretkey"
+            bucketname= trim(iter->substr(0, first_pos));
+            accesskey = trim(iter->substr(first_pos + 1, last_pos - first_pos - 1));
+            secret    = trim(iter->substr(last_pos + 1, std::string::npos));
+        }else{
+            // formatted by "accesskey:secretkey"
+            bucketname= S3fsCred::ALLBUCKET_FIELDS_TYPE;
+            accesskey = trim(iter->substr(0, first_pos));
+            secret    = trim(iter->substr(first_pos + 1, std::string::npos));
+        }
+        if(resmap.end() != resmap.find(bucketname)){
+            S3FS_PRN_EXIT("there are multiple entries for the same bucket(%s) in the passwd file.", (bucketname.empty() ? "default" : bucketname.c_str()));
+            return false;;
+        }
+        kv.clear();
+        kv[S3fsCred::AWS_ACCESSKEYID] = accesskey;
+        kv[S3fsCred::AWS_SECRETKEY]   = secret;
+        resmap[bucketname] = kv;
+    }
+    return true;
+}
+
+//
+// ReadS3fsPasswdFile
+//
+// Support for per bucket credentials
+//
+// Format for the credentials file:
+// [bucket:]AccessKeyId:SecretAccessKey
+//
+// Lines beginning with # are considered comments
+// and ignored, as are empty lines
+//
+// Uncommented lines without the ":" character are flagged as
+// an error, so are lines with spaces or tabs
+//
+// only one default key pair is allowed, but not required
+//
+bool S3fsCred::ReadS3fsPasswdFile()
+{
+    bucketkvmap_t bucketmap;
+    kvmap_t       keyval;
+
+    // if you got here, the password file
+    // exists and is readable by the
+    // current user, check for permissions
+    if(!CheckS3fsPasswdFilePerms()){
+        return false;
+    }
+
+    //
+    // parse passwd file
+    //
+    if(!ParseS3fsPasswdFile(bucketmap)){
+        return false;
+    }
+
+    //
+    // check key=value type format.
+    //
+    bucketkvmap_t::iterator it = bucketmap.find(S3fsCred::KEYVAL_FIELDS_TYPE);
+    if(bucketmap.end() != it){
+        // aws format
+        int result = CheckS3fsCredentialAwsFormat(it->second);
+        if(-1 == result){
+            return false;
+        }else if(1 == result){
+            // success to set
+            return true;
+        }
+    }
+
+    std::string bucket_key = S3fsCred::ALLBUCKET_FIELDS_TYPE;
+    if(!S3fsCred::bucket_name.empty() && bucketmap.end() != bucketmap.find(S3fsCred::bucket_name)){
+        bucket_key = S3fsCred::bucket_name;
+    }
+
+    it = bucketmap.find(bucket_key);
+    if(bucketmap.end() == it){
+        S3FS_PRN_EXIT("Not found access key/secret key in passwd file.");
+        return false;
+    }
+    keyval = it->second;
+    kvmap_t::iterator aws_accesskeyid_it = keyval.find(S3fsCred::AWS_ACCESSKEYID);
+    kvmap_t::iterator aws_secretkey_it   = keyval.find(S3fsCred::AWS_SECRETKEY);
+    if(keyval.end() == aws_accesskeyid_it || keyval.end() == aws_secretkey_it){
+        S3FS_PRN_EXIT("Not found access key/secret key in passwd file.");
+        return false;
+    }
+
+    if(!SetAccessKey(aws_accesskeyid_it->second.c_str(), aws_secretkey_it->second.c_str())){
+        S3FS_PRN_EXIT("failed to set internal data for access key/secret key from passwd file.");
+        return false;
+    }
+    return true;
+}
+
+//
+// Return:  1 - OK(could read and set accesskey etc.)
+//          0 - NG(could not read)
+//         -1 - Should shutdown immediately
+//
+int S3fsCred::CheckS3fsCredentialAwsFormat(const kvmap_t& kvmap)
+{
+    std::string str1(S3fsCred::AWS_ACCESSKEYID);
+    std::string str2(S3fsCred::AWS_SECRETKEY);
+
+    if(kvmap.empty()){
+        return 0;
+    }
+    kvmap_t::const_iterator str1_it = kvmap.find(str1);
+    kvmap_t::const_iterator str2_it = kvmap.find(str2);
+    if(kvmap.end() == str1_it && kvmap.end() == str2_it){
+        return 0;
+    }
+    if(kvmap.end() == str1_it || kvmap.end() == str2_it){
+        S3FS_PRN_EXIT("AWSAccesskey or AWSSecretkey is not specified.");
+        return -1;
+    }
+    if(!SetAccessKey(str1_it->second.c_str(), str2_it->second.c_str())){
+        S3FS_PRN_EXIT("failed to set access key/secret key.");
+        return -1;
+    }
+    return 1;
+}
+
+//
+// Read Aws Credential File
+//
+bool S3fsCred::ReadAwsCredentialFile(const std::string &filename)
+{
+    // open passwd file
+    std::ifstream PF(filename.c_str());
+    if(!PF.good()){
+        return false;
+    }
+
+    std::string profile;
+    std::string accesskey;
+    std::string secret;
+    std::string session_token;
+
+    // read each line
+    std::string line;
+    while(getline(PF, line)){
+        line = trim(line);
+        if(line.empty()){
+            continue;
+        }
+        if('#' == line[0]){
+            continue;
+        }
+
+        if(line.size() > 2 && line[0] == '[' && line[line.size() - 1] == ']') {
+            if(profile == aws_profile){
+                break;
+            }
+            profile = line.substr(1, line.size() - 2);
+            accesskey.clear();
+            secret.clear();
+            session_token.clear();
+        }
+
+        size_t pos = line.find_first_of('=');
+        if(pos == std::string::npos){
+            continue;
+        }
+        std::string key   = trim(line.substr(0, pos));
+        std::string value = trim(line.substr(pos + 1, std::string::npos));
+        if(key == "aws_access_key_id"){
+            accesskey = value;
+        }else if(key == "aws_secret_access_key"){
+            secret = value;
+        }else if(key == "aws_session_token"){
+            session_token = value;
+        }
+    }
+
+    if(profile != aws_profile){
+        return false;
+    }
+    if(session_token.empty()){
+        if(is_use_session_token){
+            S3FS_PRN_EXIT("AWS session token was expected but wasn't provided in aws/credentials file for profile: %s.", aws_profile.c_str());
+            return false;
+        }
+        if(!SetAccessKey(accesskey.c_str(), secret.c_str())){
+            S3FS_PRN_EXIT("failed to set internal data for access key/secret key from aws credential file.");
+            return false;
+        }
+    }else{
+        if(!SetAccessKeyWithSessionToken(accesskey.c_str(), secret.c_str(), session_token.c_str())){
+            S3FS_PRN_EXIT("session token is invalid.");
+            return false;
+        }
+    }
+    return true;
+}
+
+//
+// InitialS3fsCredentials
+//
+// called only when were are not mounting a
+// public bucket
+//
+// Here is the order precedence for getting the
+// keys:
+//
+// 1 - from the command line  (security risk)
+// 2 - from a password file specified on the command line
+// 3 - from environment variables
+// 3a - from the AWS_CREDENTIAL_FILE environment variable
+// 3b - from ${HOME}/.aws/credentials
+// 4 - from the users ~/.passwd-s3fs
+// 5 - from /etc/passwd-s3fs
+//
+bool S3fsCred::InitialS3fsCredentials()
+{
+    // should be redundant
+    if(S3fsCurl::IsPublicBucket()){
+        return true;
+    }
+
+    // access key loading is deferred
+    if(load_iamrole || is_ecs){
+        return true;
+    }
+
+    // 1 - keys specified on the command line
+    if(IsSetAccessKeys()){
+        return true;
+    }
+
+    // 2 - was specified on the command line
+    if(!IsSetPasswdFile()){
+        if(!ReadS3fsPasswdFile()){
+            return false;;
+        }
+        return true;
+    }
+
+    // 3  - environment variables
+    char* AWSACCESSKEYID     = getenv("AWS_ACCESS_KEY_ID") ?     getenv("AWS_ACCESS_KEY_ID") :     getenv("AWSACCESSKEYID");
+    char* AWSSECRETACCESSKEY = getenv("AWS_SECRET_ACCESS_KEY") ? getenv("AWS_SECRET_ACCESS_KEY") : getenv("AWSSECRETACCESSKEY");
+    char* AWSSESSIONTOKEN    = getenv("AWS_SESSION_TOKEN") ?     getenv("AWS_SESSION_TOKEN") :     getenv("AWSSESSIONTOKEN");
+
+    if(AWSACCESSKEYID != NULL || AWSSECRETACCESSKEY != NULL){
+        if( (AWSACCESSKEYID == NULL && AWSSECRETACCESSKEY != NULL) ||
+            (AWSACCESSKEYID != NULL && AWSSECRETACCESSKEY == NULL) ){
+            S3FS_PRN_EXIT("both environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set together.");
+            return false;;
+        }
+        S3FS_PRN_INFO2("access key from env variables");
+        if(AWSSESSIONTOKEN != NULL){
+            S3FS_PRN_INFO2("session token is available");
+            if(!SetAccessKeyWithSessionToken(AWSACCESSKEYID, AWSSECRETACCESSKEY, AWSSESSIONTOKEN)){
+                 S3FS_PRN_EXIT("session token is invalid.");
+                 return false;;
+            }
+        }else{
+            S3FS_PRN_INFO2("session token is not available");
+            if(is_use_session_token){
+                S3FS_PRN_EXIT("environment variable AWS_SESSION_TOKEN is expected to be set.");
+                return false;;
+            }
+        }
+        if(!SetAccessKey(AWSACCESSKEYID, AWSSECRETACCESSKEY)){
+            S3FS_PRN_EXIT("if one access key is specified, both keys need to be specified.");
+            return false;;
+        }
+        return true;
+    }
+
+    // 3a - from the AWS_CREDENTIAL_FILE environment variable
+    char* AWS_CREDENTIAL_FILE = getenv("AWS_CREDENTIAL_FILE");
+    if(AWS_CREDENTIAL_FILE != NULL){
+        passwd_file = AWS_CREDENTIAL_FILE;
+        if(!passwd_file.empty()){
+            if(!ReadS3fsPasswdFile()){
+                return false;;
+            }
+            return true;
+        }
+    }
+
+    // 3b - check ${HOME}/.aws/credentials
+    std::string aws_credentials = std::string(getpwuid(getuid())->pw_dir) + "/.aws/credentials";
+    if(ReadAwsCredentialFile(aws_credentials)){
+        return true;
+    }else if(aws_profile != DEFAULT_AWS_PROFILE_NAME){
+        S3FS_PRN_EXIT("Could not find profile: %s in file: %s", aws_profile.c_str(), aws_credentials.c_str());
+        return false;;
+    }
+
+    // 4 - from the default location in the users home directory
+    char* HOME = getenv("HOME");
+    if(HOME != NULL){
+        passwd_file = HOME;
+        passwd_file += "/.passwd-s3fs";
+        if(IsReadableS3fsPasswdFile()){
+            if(!ReadS3fsPasswdFile()){
+                return false;;
+            }
+
+            // It is possible that the user's file was there but
+            // contained no key pairs i.e. commented out
+            // in that case, go look in the final location
+            if(IsSetAccessKeys()){
+                return true;
+            }
+        }
+    }
+
+    // 5 - from the system default location
+    passwd_file = "/etc/passwd-s3fs";
+    if(IsReadableS3fsPasswdFile()){
+        if(!ReadS3fsPasswdFile()){
+            return false;;
+        }
+        return true;
+    }
+
+    S3FS_PRN_EXIT("could not determine how to establish security credentials.");
+    return false;;
+}
+
+//-------------------------------------------------------------------
+// Methods : for IAM
+//-------------------------------------------------------------------
+bool S3fsCred::ParseIAMCredentialResponse(const char* response, iamcredmap_t& keyval)
+{
+    if(!response){
+      return false;
+    }
+    std::istringstream sscred(response);
+    std::string        oneline;
+    keyval.clear();
+    while(getline(sscred, oneline, ',')){
+        std::string::size_type pos;
+        std::string            key;
+        std::string            val;
+        if(std::string::npos != (pos = oneline.find(S3fsCred::IAMCRED_ACCESSKEYID))){
+            key = S3fsCred::IAMCRED_ACCESSKEYID;
+        }else if(std::string::npos != (pos = oneline.find(S3fsCred::IAMCRED_SECRETACCESSKEY))){
+            key = S3fsCred::IAMCRED_SECRETACCESSKEY;
+        }else if(std::string::npos != (pos = oneline.find(IAM_token_field))){
+            key = IAM_token_field;
+        }else if(std::string::npos != (pos = oneline.find(IAM_expiry_field))){
+            key = IAM_expiry_field;
+        }else if(std::string::npos != (pos = oneline.find(S3fsCred::IAMCRED_ROLEARN))){
+            key = S3fsCred::IAMCRED_ROLEARN;
+        }else{
+            continue;
+        }
+        if(std::string::npos == (pos = oneline.find(':', pos + key.length()))){
+            continue;
+        }
+
+        if(is_ibm_iam_auth && key == IAM_expiry_field){
+            // parse integer value
+            if(std::string::npos == (pos = oneline.find_first_of("0123456789", pos))){
+                continue;
+            }
+            oneline.erase(0, pos);
+            if(std::string::npos == (pos = oneline.find_last_of("0123456789"))){
+                continue;
+            }
+            val = oneline.substr(0, pos+1);
+        }else{
+            // parse std::string value (starts and ends with quotes)
+            if(std::string::npos == (pos = oneline.find('\"', pos))){
+                continue;
+            }
+            oneline.erase(0, pos+1);
+            if(std::string::npos == (pos = oneline.find('\"'))){
+                continue;
+            }
+            val = oneline.substr(0, pos);
+        }
+        keyval[key] = val;
+    }
+    return true;
+}
+
+bool S3fsCred::CheckIAMCredentialUpdate()
+{
+    if(IAM_role.empty() && !is_ecs && !is_ibm_iam_auth){
+        return true;
+    }
+    if(time(NULL) + S3fsCred::IAM_EXPIRE_MERGIN <= AWSAccessTokenExpire){
+        return true;
+    }
+    S3FS_PRN_INFO("IAM Access Token refreshing...");
+
+    // update
+    S3fsCurl s3fscurl;
+    if(0 != s3fscurl.GetIAMCredentials()){
+        S3FS_PRN_ERR("IAM Access Token refresh failed");
+        return false;
+    }
+    S3FS_PRN_INFO("IAM Access Token refreshed");
+
+    return true;
+}
+
+//-------------------------------------------------------------------
+// Methods : Checking forbidden parameters
+//-------------------------------------------------------------------
+//
+// Checking forbidden parameters for bucket
+//
+bool S3fsCred::CheckForbiddenBucketParams()
+{
+    // The first plain argument is the bucket
+    if(bucket_name.empty()){
+        S3FS_PRN_EXIT("missing BUCKET argument.");
+        return false;
+    }
+
+    // bucket names cannot contain upper case characters in virtual-hosted style
+    if(!pathrequeststyle && (lower(bucket_name) != bucket_name)){
+        S3FS_PRN_EXIT("BUCKET %s, name not compatible with virtual-hosted style.", bucket_name.c_str());
+        return false;
+    }
+
+    // check bucket name for illegal characters
+    size_t found = bucket_name.find_first_of("/:\\;!@#$%^&*?|+=");
+    if(found != std::string::npos){
+        S3FS_PRN_EXIT("BUCKET %s -- bucket name contains an illegal character.", bucket_name.c_str());
+        return false;
+    }
+
+    if(!pathrequeststyle && is_prefix(s3host.c_str(), "https://") && bucket_name.find_first_of('.') != std::string::npos) {
+        S3FS_PRN_EXIT("BUCKET %s -- cannot mount bucket with . while using HTTPS without use_path_request_style", bucket_name.c_str());
+        return false;
+    }
+    return true;
+}
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/

--- a/src/s3fs_cred.h
+++ b/src/s3fs_cred.h
@@ -1,0 +1,154 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef S3FS_CRED_H_
+#define S3FS_CRED_H_
+
+//----------------------------------------------
+// Typedefs
+//----------------------------------------------
+typedef std::map<std::string, std::string> iamcredmap_t;
+
+//------------------------------------------------
+// class S3fsCred
+//------------------------------------------------
+// This is a class for operating and managing Credentials(accesskey,
+// secret key, tokens, etc.) used by S3fs.
+// Operations related to Credentials are aggregated in this class.
+//
+// cppcheck-suppress ctuOneDefinitionRuleViolation       ; for stub in test_curl_util.cpp
+class S3fsCred
+{
+    private:
+        static const char*  ALLBUCKET_FIELDS_TYPE;      // special key for mapping(This name is absolutely not used as a bucket name)
+        static const char*  KEYVAL_FIELDS_TYPE;         // special key for mapping(This name is absolutely not used as a bucket name)
+        static const char*  AWS_ACCESSKEYID;
+        static const char*  AWS_SECRETKEY;
+
+        static const int    IAM_EXPIRE_MERGIN;
+        static const char*  IAMCRED_ACCESSKEYID;
+        static const char*  IAMCRED_SECRETACCESSKEY;
+        static const char*  IAMCRED_ROLEARN;
+
+        static std::string  bucket_name;
+
+        std::string         passwd_file;
+        std::string         aws_profile;
+
+        bool                load_iamrole;
+
+        std::string         AWSAccessKeyId;
+        std::string         AWSSecretAccessKey;
+        std::string         AWSAccessToken;
+        time_t              AWSAccessTokenExpire;
+
+        bool                is_ecs;
+        bool                is_use_session_token;
+        bool                is_ibm_iam_auth;
+
+        std::string         IAM_cred_url;
+        int                 IAM_api_version;
+        std::string         IAMv2_api_token;
+        size_t              IAM_field_count;
+        std::string         IAM_token_field;
+        std::string         IAM_expiry_field;
+        std::string         IAM_role;
+
+    public:
+        static const char*  ECS_IAM_ENV_VAR;
+
+        static const char*  IAMv2_token_url;
+        static int          IAMv2_token_ttl;
+        static const char*  IAMv2_token_ttl_hdr;
+        static const char*  IAMv2_token_hdr;
+
+    private:
+        static bool ParseIAMRoleFromMetaDataResponse(const char* response, std::string& rolename);
+
+        bool IsReadableS3fsPasswdFile();
+        bool CheckS3fsPasswdFilePerms();
+        bool ParseS3fsPasswdFile(bucketkvmap_t& resmap);
+        bool ReadS3fsPasswdFile();
+
+        int CheckS3fsCredentialAwsFormat(const kvmap_t& kvmap);
+        bool ReadAwsCredentialFile(const std::string &filename);
+
+        bool ParseIAMCredentialResponse(const char* response, iamcredmap_t& keyval);
+
+    public:
+        static bool SetBucket(const char* bucket);
+        static const std::string& GetBucket();
+
+        S3fsCred();
+        ~S3fsCred();
+
+        bool SetS3fsPasswdFile(const char* file);
+        bool IsSetPasswdFile();
+        bool SetAwsProfileName(const char* profile_name);
+        bool SetIAMRoleMetadataType(bool flag);
+        bool IsIAMRoleMetadataType() const { return load_iamrole; }
+
+        bool SetAccessKey(const char* AccessKeyId, const char* SecretAccessKey);
+        bool SetAccessKeyWithSessionToken(const char* AccessKeyId, const char* SecretAccessKey, const char * SessionToken);
+        bool IsSetAccessKeyID() const;
+        bool IsSetAccessKeys() const;
+        const std::string& GetAccessKeyID() const { return AWSAccessKeyId; }
+        const std::string& GetSecretAccessKey() const { return AWSSecretAccessKey; }
+        const std::string& GetAccessToken() const { return AWSAccessToken; }
+
+        bool SetIsECS(bool flag);
+        bool IsECS() const { return is_ecs; }
+        bool SetIsUseSessionToken(bool flag);
+        bool IsUseSessionToken() const { return is_use_session_token; }
+        bool SetIsIBMIAMAuth(bool flag);
+        bool IsIBMIAMAuth() const { return is_ibm_iam_auth; }
+
+        std::string SetIAMRole(const char* role);
+        const std::string& GetIAMRole() const { return IAM_role; }
+        size_t SetIAMFieldCount(size_t field_count);
+        std::string SetIAMCredentialsURL(const char* url);
+        const std::string& GetIAMCredentialsURL() const { return IAM_cred_url; }
+        std::string SetIAMTokenField(const char* token_field);
+        std::string SetIAMExpiryField(const char* expiry_field);
+        int SetIMDSVersion(int version);
+        int GetIMDSVersion() const { return IAM_api_version; }
+
+        bool SetIAMv2APIToken(const char* response);
+        const std::string& GetIAMv2APIToken() const { return IAMv2_api_token; }
+        bool SetIAMCredentials(const char* response);
+        bool SetIAMRoleFromMetaData(const char* response);
+
+        bool InitialS3fsCredentials();
+
+        bool CheckIAMCredentialUpdate();
+
+        bool CheckForbiddenBucketParams();
+};
+
+#endif // S3FS_CRED_H_
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/

--- a/src/s3fs_global.cpp
+++ b/src/s3fs_global.cpp
@@ -32,11 +32,9 @@ bool noxmlns                      = false;
 std::string program_name;
 std::string service_path          = "/";
 std::string s3host                = "https://s3.amazonaws.com";
-std::string bucket;
 std::string endpoint              = "us-east-1";
 std::string cipher_suites;
 std::string instance_name;
-std::string aws_profile           = "default";
 
 /*
 * Local variables:

--- a/src/test_curl_util.cpp
+++ b/src/test_curl_util.cpp
@@ -24,6 +24,34 @@
 #include "curl_util.h"
 #include "test_util.h"
 
+//---------------------------------------------------------
+// S3fsCred Stub
+//
+// [NOTE]
+// This test program links curl_util.cpp just to use the
+// curl_slist_sort_insert function.
+// This file has a call to S3fsCred::GetBucket(), which
+// results in a link error. That method is not used in
+// this test file, so define a stub class. Linking all
+// implementation of the S3fsCred class or making all
+// stubs is not practical, so this is the best answer.
+//
+class S3fsCred
+{
+    private:
+        static std::string  bucket_name;
+    public:
+        static const std::string& GetBucket();
+};
+
+std::string  S3fsCred::bucket_name;
+
+const std::string& S3fsCred::GetBucket()
+{
+	return S3fsCred::bucket_name;
+}
+//---------------------------------------------------------
+
 #define ASSERT_IS_SORTED(x) assert_is_sorted((x), __FILE__, __LINE__)
 
 void assert_is_sorted(struct curl_slist* list, const char *file, int line)


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
In current s3fs, Management of Credential(or AccessKey, Token, etc) processing and options(variables) for server is scattered in s3fs.cpp and S3fsCurl classes, etc.  
These variables, functions, etc. should be grouped in new S3fsCred class so that information related to Credentials can be centrally managed.  

With this PR code, I didn't change about the logic, I just aggregated those into new S3fsCred class.  

#### NOTE
I think this is necessary in the feture because the code become complicated for the support for aws-sdk-cpp and other providers different from AWS S3.  
If necessary, it is possible to modify this class, such as separating it into a base class and a derived class.
