### PR TITLE
Always flush open files with O_CREAT flag

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1343,7 +1343,7 @@ int FdEntity::RowFlush(int fd, const char* tpath, bool force_sync)
     if(pseudo_fd_map.end() == miter || NULL == miter->second){
         return -EBADF;
     }
-    if(!miter->second->Writable()){
+    if(!miter->second->Writable() && !(miter->second->GetFlags() & O_CREAT)){
         // If the entity is opened read-only, it will end normally without updating.
         return 0;
     }


### PR DESCRIPTION
Previously s3fs only created files that had dirty data and not those
with zero-bytes.  Regression from
771bbfeac5e93da96ee39cb32d59e0b5dfe96377.  References #1013.  Found
via pjdfstest.  References #1589.