### PR TITLE
Propagate return code properly

### DIFF
--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -250,7 +250,7 @@ function run_suite {
        # Ensure test input name differs every iteration
        TEST_TEXT_FILE="test-s3fs.txt-${RANDOM}"
        TEST_DIR="testdir-${RANDOM}"
-       "${t}" "${key_prefix}" && rc=$? || rc=$?
+       "${t}" "${key_prefix}"; rc=$?
 
        if [[ "${rc}" = 0 ]] ; then
            report_pass "${t}"


### PR DESCRIPTION
Previously this did not propagate test failures.  A bad rebase
introduced this logic in 495d51113cbe4da63493a51d47dc94145481455a.