### PR TITLE
Fixed test_external_directory_creation test when cache enabled

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -357,6 +357,17 @@ function test_external_directory_creation {
 function test_external_modification {
     describe "Test external modification to an object ..."
     echo "old" > "${TEST_TEXT_FILE}"
+
+    # [NOTE]
+    # If the stat and file cache directory are enabled, an error will
+    # occur if the unixtime(sec) value does not change.
+    # If mtime(ctime/atime) when updating from the external program
+    # (awscli) is the same unixtime value as immediately before, the
+    # cache will be read out.
+    # Therefore, we need to wait over 1 second here.
+    #
+    sleep 1
+
     local OBJECT_NAME; OBJECT_NAME=$(basename "${PWD}")/"${TEST_TEXT_FILE}"
     echo "new new" | aws_cli s3 cp - "s3://${TEST_BUCKET_1}/${OBJECT_NAME}"
     cmp "${TEST_TEXT_FILE}" <(echo "new new")


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1884 

### Details
It is a correction of the defect detected by the correction of #1884.

The `test_external_modification` test checks the reflection of the updated file from the external program (awscli).

However, if s3fs currently has the stat cache and cache directory enabled, this test will fail.
This is because the time value of the file timestamp does not change before and after the change.
When using the stat cache and the file does not update after modifying, the cache hit and reading contents from local cache file.
Then the test is failed.
_To fix this test, use sleep in `test_external_modification`._
