### PR TITLE
Fixed not to call Flush even if the file size is increased

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -552,6 +552,11 @@ FdEntity* FdManager::Open(int& fd, const char* path, headers_t* pmeta, off_t siz
         // found
         ent = iter->second;
 
+        // [NOTE]
+        // Even if getting the request to change the size of modifying
+        // file to small, we do not change it. Because if it will change,
+        // test_open_second_fd test will be failed.
+        //
         if(ent->IsModified()){
             // If the file is being modified and it's size is larger than size parameter, it will not be resized.
             off_t cur_size = 0;

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -426,7 +426,7 @@ int FdEntity::Open(const headers_t* pmeta, off_t size, time_t time, int flags, A
         // check only file size(do not need to save cfs and time.
         if(0 <= size && pagelist.Size() != size){
             // truncate temporary file size
-            if(-1 == ftruncate(physical_fd, size)){
+            if(-1 == ftruncate(physical_fd, size) || -1 == fsync(physical_fd)){
                 S3FS_PRN_ERR("failed to truncate temporary file(physical_fd=%d) by errno(%d).", physical_fd, errno);
                 return -errno;
             }
@@ -440,7 +440,7 @@ int FdEntity::Open(const headers_t* pmeta, off_t size, time_t time, int flags, A
         off_t new_size = (0 <= size ? size : size_orgmeta);
         if(pmeta){
             orgmeta  = *pmeta;
-            new_size = get_size(orgmeta);
+            size_orgmeta = get_size(orgmeta);
         }
         if(new_size < size_orgmeta){
             size_orgmeta = new_size;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2184,6 +2184,7 @@ static int s3fs_truncate(const char* _path, off_t size)
         }
         ent->UpdateCtime();
 
+#if defined(__APPLE__)
         // [NOTE]
         // Only for macos, this truncate calls to "size=0" do not reflect size.
         // The cause is unknown now, but it can be avoided by flushing the file.
@@ -2195,6 +2196,8 @@ static int s3fs_truncate(const char* _path, off_t size)
             }
             StatCache::getStatCacheData()->DelStat(path);
         }
+#endif
+
     }else{
         // Not found -> Make tmpfile(with size)
         struct fuse_context* pcxt;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1875 

### Details
Changed s3fs_truncate function.
This change reduces the number of file uploads if the file size is changed.

On macos, I have found that the truncate call when "size=0" cannot reflect the file size.(This reason is not understood...)
To avoid this, only when "size=0", the flush method is called as before.

Other than that, I found a bug in FdEntity::Open() and fixed it.

