### PR TITLE
Include climits to support musl libc

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cerrno>
+#include <climits>
 #include <unistd.h>
 #include <sys/types.h>
 #include <dirent.h>


### PR DESCRIPTION
`PATH_MAX` constant is not visible from any of currently included header files in system with musl libc, where compilation fails with an error below. The constant is defined in `limits.h` which is directly include via `climits` header file.

```
fdcache.cpp: In static member function 'static FILE* FdManager::MakeTempFile()':
fdcache.cpp:381:14: error: 'PATH_MAX' was not declared in this scope
  381 |     char cfn[PATH_MAX];
      |              ^~~~~~~~
```
