### PR TITLE
Re-re-fix propagating the return code

### DIFF
--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -250,9 +250,8 @@ function run_suite {
        # Ensure test input name differs every iteration
        TEST_TEXT_FILE="test-s3fs.txt-${RANDOM}"
        TEST_DIR="testdir-${RANDOM}"
-       "${t}" "${key_prefix}"; rc=$?
-
-       if [[ "${rc}" = 0 ]] ; then
+       "${t}" "${key_prefix}" && rc=$? || rc=$?
+       if [ $rc = 0 ]; then
            report_pass "${t}"
        else
            report_fail "${t}"


### PR DESCRIPTION
Previously the integration tests were exiting after the first failed
test instead of running all of them an reporting their statuses.
Follows on to dbf93c01528f97933c291de9fbba5fb26b60ac03.