### PR TITLE
Dynamically generate dates for man page file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,11 @@ compile
 missing
 
 #
+# man page
+#
+doc/man/s3fs.1
+
+#
 # object directories
 #
 .deps

--- a/configure.ac
+++ b/configure.ac
@@ -311,9 +311,18 @@ AC_COMPILE_IFELSE(
 )
 
 dnl ----------------------------------------------
+dnl build date
+dnl ----------------------------------------------
+AC_SUBST([MAN_PAGE_DATE], [$(date +"%B %Y")])
+
+dnl ----------------------------------------------
 dnl output files
 dnl ----------------------------------------------
-AC_CONFIG_FILES(Makefile src/Makefile test/Makefile doc/Makefile)
+AC_CONFIG_FILES(Makefile
+                src/Makefile
+                test/Makefile
+                doc/Makefile
+                doc/man/s3fs.1)
 
 dnl ----------------------------------------------
 dnl short commit hash

--- a/doc/man/s3fs.1.in
+++ b/doc/man/s3fs.1.in
@@ -1,4 +1,4 @@
-.TH S3FS "1" "February 2011" "S3FS" "User Commands"
+.TH S3FS "1" "@MAN_PAGE_DATE@" "S3FS" "User Commands"
 .SH NAME
 S3FS \- FUSE-based file system backed by Amazon S3
 .SH SYNOPSIS


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1907

### Details
The date of the man file is now generated when configure is executed.
The old `s3fs.1` file is renamed to `s3fs.1.in` and then `s3fs.1` is dynamically created.
