### PR TITLE
Fixed a bug about truncation for shrinking file

### DIFF
--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -47,9 +47,11 @@ class FdManager
 
   private:
       static off_t GetFreeDiskSpace(const char* path);
+      static bool IsDir(const std::string* dir);
+
+      int GetPseudoFdCount(const char* path);
       void CleanupCacheDirInternal(const std::string &path = "");
       bool RawCheckAllCache(FILE* fp, const char* cache_stat_top_dir, const char* sub_path, int& total_file_cnt, int& err_file_cnt, int& err_dir_cnt);
-      static bool IsDir(const std::string* dir);
 
   public:
       FdManager();
@@ -71,6 +73,7 @@ class FdManager
       static bool SetCheckCacheDirExist(bool is_check);
       static bool CheckCacheDirExist();
       static bool HasOpenEntityFd(const char* path);
+      static int GetOpenFdCount(const char* path);
       static off_t GetEnsureFreeDiskSpace();
       static off_t SetEnsureFreeDiskSpace(off_t size);
       static bool InitFakeUsedDiskSize(off_t fake_freesize);
@@ -84,7 +87,7 @@ class FdManager
 
       // Return FdEntity associated with path, returning NULL on error.  This operation increments the reference count; callers must decrement via Close after use.
       FdEntity* GetFdEntity(const char* path, int& existfd, bool newfd = true, bool lock_already_held = false);
-      FdEntity* Open(int& fd, const char* path, headers_t* pmeta, off_t size, time_t time, int flags, bool force_tmpfile, bool is_create, AutoLock::Type type);
+      FdEntity* Open(int& fd, const char* path, headers_t* pmeta, off_t size, time_t time, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);
       FdEntity* GetExistFdEntity(const char* path, int existfd = -1);
       FdEntity* OpenExistFdEntity(const char* path, int& fd, int flags = O_RDONLY);
       void Rename(const std::string &from, const std::string &to);

--- a/src/fdcache_auto.cpp
+++ b/src/fdcache_auto.cpp
@@ -98,11 +98,11 @@ bool AutoFdEntity::Attach(const char* path, int existfd)
     return true;
 }
 
-FdEntity* AutoFdEntity::Open(const char* path, headers_t* pmeta, off_t size, time_t time, int flags, bool force_tmpfile, bool is_create, AutoLock::Type type)
+FdEntity* AutoFdEntity::Open(const char* path, headers_t* pmeta, off_t size, time_t time, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type)
 {
     Close();
 
-    if(NULL == (pFdEntity = FdManager::get()->Open(pseudo_fd, path, pmeta, size, time, flags, force_tmpfile, is_create, type))){
+    if(NULL == (pFdEntity = FdManager::get()->Open(pseudo_fd, path, pmeta, size, time, flags, force_tmpfile, is_create, ignore_modify, type))){
         pseudo_fd = -1;
         return NULL;
     }

--- a/src/fdcache_auto.h
+++ b/src/fdcache_auto.h
@@ -51,7 +51,7 @@ class AutoFdEntity
       bool Attach(const char* path, int existfd);
       int GetPseudoFd() const { return pseudo_fd; }
 
-      FdEntity* Open(const char* path, headers_t* pmeta, off_t size, time_t time, int flags, bool force_tmpfile, bool is_create, AutoLock::Type type);
+      FdEntity* Open(const char* path, headers_t* pmeta, off_t size, time_t time, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);
       FdEntity* GetExistFdEntity(const char* path, int existfd = -1);
       FdEntity* OpenExistFdEntity(const char* path, int flags = O_RDONLY);
 };

--- a/src/fdcache_page.h
+++ b/src/fdcache_page.h
@@ -77,6 +77,7 @@ class PageList
 
     private:
         fdpage_list_t pages;
+        bool          is_shrink;    // [NOTE] true if it has been shrinked even once
 
     public:
         enum page_status{
@@ -97,7 +98,7 @@ class PageList
     public:
         static void FreeList(fdpage_list_t& list);
 
-        explicit PageList(off_t size = 0, bool is_loaded = false, bool is_modified = false);
+        explicit PageList(off_t size = 0, bool is_loaded = false, bool is_modified = false, bool shrinked = false);
         explicit PageList(const PageList& other);
         ~PageList();
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -705,7 +705,7 @@ static int get_local_fent(AutoFdEntity& autoent, FdEntity **entity, const char* 
     time_t mtime         = (!S_ISREG(stobj.st_mode) && !S_ISLNK(stobj.st_mode)) ? -1 : stobj.st_mtime;
     bool   force_tmpfile = S_ISREG(stobj.st_mode) ? false : true;
 
-    if(NULL == (ent = autoent.Open(path, &meta, stobj.st_size, mtime, flags, force_tmpfile, true, AutoLock::NONE))){
+    if(NULL == (ent = autoent.Open(path, &meta, stobj.st_size, mtime, flags, force_tmpfile, true, false, AutoLock::NONE))){
         S3FS_PRN_ERR("Could not open file. errno(%d)", errno);
         return -EIO;
     }
@@ -939,7 +939,7 @@ static int s3fs_create(const char* _path, mode_t mode, struct fuse_file_info* fi
 
     AutoFdEntity autoent;
     FdEntity*    ent;
-    if(NULL == (ent = autoent.Open(path, &meta, 0, -1, fi->flags, false, true, AutoLock::NONE))){
+    if(NULL == (ent = autoent.Open(path, &meta, 0, -1, fi->flags, false, true, false, AutoLock::NONE))){
         StatCache::getStatCacheData()->DelStat(path);
         return -EIO;
     }
@@ -1135,7 +1135,7 @@ static int s3fs_symlink(const char* _from, const char* _to)
     {   // scope for AutoFdEntity
         AutoFdEntity autoent;
         FdEntity*    ent;
-        if(NULL == (ent = autoent.Open(to, &headers, 0, -1, O_RDWR, true, true, AutoLock::NONE))){
+        if(NULL == (ent = autoent.Open(to, &headers, 0, -1, O_RDWR, true, true, false, AutoLock::NONE))){
             S3FS_PRN_ERR("could not open tmpfile(errno=%d)", errno);
             return -errno;
         }
@@ -1208,7 +1208,7 @@ static int rename_object(const char* from, const char* to, bool update_ctime)
             // no opened fd
             if(FdManager::IsCacheDir()){
                 // create cache file if be needed
-                ent = autoent.Open(from, &meta, buf.st_size, -1, O_RDONLY, false, true, AutoLock::NONE);
+                ent = autoent.Open(from, &meta, buf.st_size, -1, O_RDONLY, false, true, false, AutoLock::NONE);
             }
             if(ent){
                 struct timespec mtime = get_mtime(meta);
@@ -2178,7 +2178,25 @@ static int s3fs_truncate(const char* _path, off_t size)
         // The Flush is called before this file is closed, so there is no need
         // to do it here.
         //
-        if(NULL == (ent = autoent.Open(path, &meta, size, -1, O_RDWR, false, true, AutoLock::NONE))){
+        // [NOTICE]
+        // FdManager::Open() ignores changes that reduce the file size for the
+        // file you are editing. However, if user opens only onece, edit it,
+        // and then shrink the file, it should be done.
+        // When this function is called, the file is already open by FUSE or
+        // some other operation. Therefore, if the number of open files is 1,
+        // no edits other than that fd will be made, and the files will be
+        // shrunk using ignore_modify flag even while editing.
+        // See the comments when merging this code for FUSE2 limitations.
+        // (In FUSE3, it will be possible to handle it reliably using fuse_file_info.)
+        //
+        bool ignore_modify;
+        if(1 < FdManager::GetOpenFdCount(path)){
+            ignore_modify = false;
+        }else{
+            ignore_modify = true;
+        }
+
+        if(NULL == (ent = autoent.Open(path, &meta, size, -1, O_RDWR, false, true, ignore_modify, AutoLock::NONE))){
             S3FS_PRN_ERR("could not open file(%s): errno=%d", path, errno);
             return -EIO;
         }
@@ -2212,7 +2230,7 @@ static int s3fs_truncate(const char* _path, off_t size)
         meta["x-amz-meta-uid"]   = str(pcxt->uid);
         meta["x-amz-meta-gid"]   = str(pcxt->gid);
 
-        if(NULL == (ent = autoent.Open(path, &meta, size, -1, O_RDWR, true, true, AutoLock::NONE))){
+        if(NULL == (ent = autoent.Open(path, &meta, size, -1, O_RDWR, true, true, false, AutoLock::NONE))){
             S3FS_PRN_ERR("could not open file(%s): errno=%d", path, errno);
             return -EIO;
         }
@@ -2280,7 +2298,7 @@ static int s3fs_open(const char* _path, struct fuse_file_info* fi)
     FdEntity*    ent;
     headers_t    meta;
     get_object_attribute(path, NULL, &meta, true, NULL, true);    // no truncate cache
-    if(NULL == (ent = autoent.Open(path, &meta, st.st_size, st.st_mtime, fi->flags, false, true, AutoLock::NONE))){
+    if(NULL == (ent = autoent.Open(path, &meta, st.st_size, st.st_mtime, fi->flags, false, true, false, AutoLock::NONE))){
         StatCache::getStatCacheData()->DelStat(path);
         return -EIO;
     }

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -92,6 +92,26 @@ function test_truncate_empty_file {
     rm_test_file
 }
 
+function test_truncate_shrink_file {
+    describe "Testing truncate shrinking large binary file ..."
+
+    local BIG_TRUNCATE_TEST_FILE="big-truncate-test.bin"
+    local t_size=$((1024 * 1024 * 32 + 64))
+
+    dd if=/dev/urandom of="${TEMP_DIR}/${BIG_TRUNCATE_TEST_FILE}" bs=1024 count=$((1024 * 64))
+    cp "${TEMP_DIR}/${BIG_TRUNCATE_TEST_FILE}" "${BIG_TRUNCATE_TEST_FILE}"
+
+    "${TRUNCATE_BIN}" "${TEMP_DIR}/${BIG_TRUNCATE_TEST_FILE}" -s "${t_size}"
+    "${TRUNCATE_BIN}" "${BIG_TRUNCATE_TEST_FILE}" -s "${t_size}"
+
+    if ! cmp "${TEMP_DIR}/${BIG_TRUNCATE_TEST_FILE}" "${BIG_TRUNCATE_TEST_FILE}"; then
+       return 1
+    fi
+
+    rm -f "${TEMP_DIR}/${BIG_TRUNCATE_TEST_FILE}"
+    rm_test_file "${BIG_TRUNCATE_TEST_FILE}"
+}
+
 function test_mv_file {
     describe "Testing mv file function ..."
     # if the rename file exists, delete it
@@ -1818,6 +1838,7 @@ function add_all_tests {
     add_tests test_truncate_file
     add_tests test_truncate_upload
     add_tests test_truncate_empty_file
+    add_tests test_truncate_shrink_file
     add_tests test_mv_file
     add_tests test_mv_to_exist_file
     add_tests test_mv_empty_directory


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1631 #1875 #1887

### Details
#### Overview
Due to the bug(#1875) fix(#1887), there was a bug in truncate that shrinks the file.
(A bug occurred by fixing #1887 after fixing #1631.)

#1631 bypasses the resize-process if it shrinks the file being edited.
This assumes the case where the file are multiple open(multiple fd).

And with the fix of #1887, flush to the file is delayed when truncate is called.
Before these fixes, it was always flushed after truncation, so this hidden potential bug was not materialized.

#### Fix - 1
The modification of #1631(in `FdManager::Open`) should be bypassed only if there is an open fd other than the fd opened by the truncate process.
Therefore, `FdManager::Open` should only be bypassed if there are more than one file descriptor already open.
_(`FUSE` always preopens a file when truncate it, if it hasn't already been opened, so one fd is open when you call truncate.)_

So s3fs has been changed to check if more than one fd is open when truncate is called.
There are two way shown below to fix, but the former is adopted.

##### Add an argument to `FdManager::Open`
This changes needs to modify many lines, but I adopted in consideration of the effect of other processing.
I wanted to limit the scope of influence to only truncate.

##### Modify only inside `FdManager::Open`
It can be modified more easily than the former by using `if(2 <= ent->GetOpenCount() && ent->IsModified()){`.
_However, I didn't use this method because the scope of influence was not clear._
_Also, I think the former is better when supporting `FUSE3`._

##### [NOTE] Limitations on `FUSE2`
truncate does not pass an open file descriptor(`pseudo_fd` for s3fs) to the truncate function in `FUSE2`.
Therefore, the following cannot be realized at present.(This will be a limitation.)

For example, suppose you have two files open.(Tentatively `fd1` and `fd2`)
One of them(`fd1`) stretchs the file.
In `fd2`, it is does not change the file size.
If `fd1` then shrinks the file size(for example, restores it to the original file size for clarity), s3fs will still increase the file size.
This is because it doesn't keep track of which file descriptor is trying to increase and shrink the file, and it can't be determined.

If it corresponds to `FUSE3`, fd is passed in `fuse_file_info`, so I think that it can be made into strict code.

#### Fix - 2
In addition to the above `FdManager::Open` and `s3fs_truncate` modifications, it was necessary to modify the `PageList` class.
This is a problem revealed by the fix of #1887(delayed execution of flush).

`PageList` has the information of the opened file inside s3fs.
`PageList` sets a flag internally when the file is modified or increased.(`modify flag`)
But when the file was shrunk, it didn't have the information being edited.(Not needed before #1887)

Therefore, I am also modifying the PageList in case the file size is reduced.

#### Add truncate test
There was no simple file shrink test case.
Added a simple truncate test for file sizes that require multipart uploads.

