### PR TITLE
Removed unnecessary debug options for aws command

### DIFF
--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -339,7 +339,7 @@ function aws_cli() {
     # [NOTE]
     # AWS_EC2_METADATA_DISABLED for preventing the metadata service(to 169.254.169.254).
     # shellcheck disable=SC2086,SC2068
-    AWS_EC2_METADATA_DISABLED=true aws $@ --endpoint-url "${S3_URL}" --ca-bundle /tmp/keystore.pem ${FLAGS} --debug
+    AWS_EC2_METADATA_DISABLED=true aws $@ --endpoint-url "${S3_URL}" --ca-bundle /tmp/keystore.pem ${FLAGS}
 }
 
 function wait_for_port() {


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1933

### Details
With the fix in #1933, I left the aws command with the unnecessary `--debug` option.
It's an option I don't need except when debugging test cases and I forgot to remove it.
