### PR TITLE
fix for segfault while reseting handle for retrying

### DIFF
--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -122,6 +122,7 @@ struct curl_slist* curl_slist_remove(struct curl_slist* list, const char* key)
             struct curl_slist *tmp = *p;
             *p = (*p)->next;
             free(tmp);
+            break;
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Neeraj Kumar Kashyap <nkashyap@in.ibm.com>

### Relevant Issue (if applicable)
s3fs is terminating with Segmentation fault
The issue is occurring with s3fs release v1.91
 
### Details
_Please describe the details of PullRequest._
In one situation, with `ibm_iam_auth` option `s3fs` tries to re-connect `private.iam.cloud.ibm.com` and getting `NSS error -5938 (PR_END_OF_FILE_ERROR)`. To handle this, `s3fs` resets the handle by calling `RemakeHandle` which in-turn calls `curl_slist_remove` to remove the key `Authorization` and finally hitting with `SIGSEGV`.

```
Found bundle for host private.iam.cloud.ibm.com: 0x7f0f6e1cd410
Connection 22 seems to be dead!
Closing connection 22 
About to connect() to private.iam.cloud.ibm.com port 443 (#23)
    Trying 166.9.251.2... 
    
Connected to private.iam.cloud.ibm.com (166.9.251.2) port 443 (#23)
NSS error -5938 (PR_END_OF_FILE_ERROR)
Encountered end of file
Closing connection 23 
curl.cpp:RequestPerform(2450): ### CURLE_SSL_CONNECT_ERROR  
kernel: s3fs[54514]: segfault at 8 ip 0000000000457e61 sp 00007f0f827f1e50 error 4 in s3fs[400000+bb000]
```

The code change in this PR provides the fix for the issue by terminating the `for loop` in `curl_slist_remove` once the key is removed from `requestHeaders`. 


