### PR TITLE
Fixed errors reported by cppcheck 2.8

### DIFF
--- a/src/bodydata.cpp
+++ b/src/bodydata.cpp
@@ -63,7 +63,7 @@ bool BodyData::Resize(size_t addbytes)
     }
     // realloc
     char* newtext;
-    if(NULL == (newtext = (char*)realloc(text, (bufsize + need_size)))){
+    if(NULL == (newtext = reinterpret_cast<char*>(realloc(text, (bufsize + need_size))))){
         S3FS_PRN_CRIT("not enough memory (realloc returned NULL)");
         free(text);
         text = NULL;

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -337,17 +337,17 @@ void* S3fsMultiCurl::RequestPerformWrapper(void* arg)
     S3fsCurl* s3fscurl= static_cast<S3fsCurl*>(arg);
     void*     result  = NULL;
     if(!s3fscurl){
-        return (void*)(intptr_t)(-EIO);
+        return reinterpret_cast<void*>(static_cast<intptr_t>(-EIO));
     }
     if(s3fscurl->fpLazySetup){
         if(!s3fscurl->fpLazySetup(s3fscurl)){
             S3FS_PRN_ERR("Failed to lazy setup, then respond EIO.");
-            result  = (void*)(intptr_t)(-EIO);
+            result  = reinterpret_cast<void*>(static_cast<intptr_t>(-EIO));
         }
     }
 
     if(!result){
-        result = (void*)(intptr_t)(s3fscurl->RequestPerform());
+        result = reinterpret_cast<void*>(static_cast<intptr_t>(s3fscurl->RequestPerform()));
         s3fscurl->DestroyCurlHandle(true, false);
     }
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -233,7 +233,7 @@ static bool is_special_name_folder_object(const char* path)
 //
 static int chk_dir_object_type(const char* path, std::string& newpath, std::string& nowpath, std::string& nowcache, headers_t* pmeta, dirtype* pDirType)
 {
-    dirtype TypeTmp;
+    dirtype TypeTmp = DIRTYPE_UNKNOWN;
     int  result  = -1;
     bool isforce = false;
     dirtype* pType = pDirType ? pDirType : &TypeTmp;
@@ -2767,10 +2767,10 @@ static int list_bucket(const char* path, S3ObjList& head, const char* delimiter,
         if(true == (truncated = is_truncated(doc))){
             xmlChar* tmpch;
             if(NULL != (tmpch = get_next_continuation_token(doc))){
-                next_continuation_token = (char*)tmpch;
+                next_continuation_token = reinterpret_cast<char*>(tmpch);
                 xmlFree(tmpch);
             }else if(NULL != (tmpch = get_next_marker(doc))){
-                next_marker = (char*)tmpch;
+                next_marker = reinterpret_cast<char*>(tmpch);
                 xmlFree(tmpch);
             }
 
@@ -3650,7 +3650,7 @@ static bool set_mountpoint_attribute(struct stat& mpst)
 //
 static int set_bucket(const char* arg)
 {
-    char *bucket_name = (char*)arg;
+    char *bucket_name = const_cast<char*>(arg);
     if(strstr(arg, ":")){
         if(strstr(arg, "://")){
             S3FS_PRN_EXIT("bucket name and path(\"%s\") is wrong, it must be \"bucket[:/path]\".", arg);

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -172,7 +172,7 @@ int is_uid_include_group(uid_t uid, gid_t gid)
 //-------------------------------------------------------------------
 std::string mydirname(const std::string& path)
 {
-    return std::string(dirname((char*)path.c_str()));
+    return std::string(dirname(const_cast<char*>(path.c_str())));
 }
 
 // safe variant of dirname
@@ -187,7 +187,7 @@ std::string mydirname(const char* path)
 
 std::string mybasename(const std::string& path)
 {
-    return std::string(basename((char*)path.c_str()));
+    return std::string(basename(const_cast<char*>(path.c_str())));
 }
 
 // safe variant of basename

--- a/src/sighandlers.cpp
+++ b/src/sighandlers.cpp
@@ -103,6 +103,9 @@ void* S3fsSignals::CheckCacheWorker(void* arg)
     while(S3fsSignals::enableUsr1){
         // wait
         pSem->wait();
+
+        // cppcheck-suppress unmatchedSuppression
+        // cppcheck-suppress knownConditionTrueFalse
         if(!S3fsSignals::enableUsr1){
             break;    // assap
         }


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
It seems that the version of cppcheck has been upgraded from 2.7 to 2.8 on some macos runners.
Along with that, some errors were reported, so we took corrective action.
_(Still, it doesn't seem to be all macos runners)_
