### PR TITLE
Fixed a bug could not change the mode while the file was opened

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -412,6 +412,9 @@ bool StatCache::AddStat(const std::string& key, headers_t& meta, bool forcedir, 
 // Updates only meta data if cached data exists.
 // And when these are updated, it also updates the cache time.
 //
+// Since the file mode may change while the file is open, it is
+// updated as well.
+//
 bool StatCache::UpdateMetaStats(const std::string& key, headers_t& meta)
 {
     if(CacheSize < 1){
@@ -445,6 +448,9 @@ bool StatCache::UpdateMetaStats(const std::string& key, headers_t& meta)
 
     // Update time.
     SetStatCacheTime(ent->cache_date);
+
+    // Update only mode
+    ent->stbuf.st_mode = get_mode(meta);
 
     return true;
 }

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -1222,6 +1222,36 @@ function test_update_directory_time_subdir() {
     rm -rf "${TEST_DIR}"
 }
 
+# [NOTE]
+# This test changes the file mode while creating/editing a new file,
+# and finally closes it.
+# Test with the sed command as it occurs when in place mode of the sed
+# command. (If trying it with a standard C function(and shell script),
+# it will be not the same result of sed, so sed is used.)
+#
+function test_update_chmod_opened_file() {
+    describe "Testing create, modify the file by sed in place mode"
+
+    # test file
+    local BEFORE_STRING_DATA; BEFORE_STRING_DATA="sed in place test : BEFORE DATA"
+    local AFTER_STRING_DATA;  AFTER_STRING_DATA="sed in place test : AFTER DATA"
+    echo "${BEFORE_STRING_DATA}" > "${TEST_TEXT_FILE}"
+
+    # sed in place
+    sed -i -e 's/BEFORE DATA/AFTER DATA/g' "${TEST_TEXT_FILE}"
+
+    # compare result
+    local RESULT_STRING; RESULT_STRING=$(cat "${TEST_TEXT_FILE}")
+
+    if [ -z "${RESULT_STRING}" ] || [ "${RESULT_STRING}" != "${AFTER_STRING_DATA}" ]; then
+       echo "the file conversion by sed in place command failed."
+       return 1
+    fi
+
+    # clean up
+    rm_test_file "${ALT_TEST_TEXT_FILE}"
+}
+
 function test_rm_rf_dir {
    describe "Test that rm -rf will remove directory with contents ..."
    # Create a dir with some files and directories
@@ -1890,6 +1920,7 @@ function add_all_tests {
         add_tests test_update_directory_time_touch_a
     fi
     add_tests test_update_directory_time_subdir
+    add_tests test_update_chmod_opened_file
 
     add_tests test_rm_rf_dir
     add_tests test_copy_file


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1947 

### Details
When using the `--in-place(-c)` option of the sed command, sed seems to behave as follows:
- Create a new temporary file(create the file mode as a `0000`)
- Read the original file and write the replacement result to the temporary file
- Changed temporary file mode to `0644`
- Close file, and replace file

In s3fs, the stat information of a file is internally cached until flush is executed, during the file is opened.
In sed `--in-place` mode, a `Permission denied(EACCESS)` error occurred because s3fs forgot to update the open file mode to the stat cache.
So this PR fixed this bug.

#### NOTE
This PR added a test case.
Added test case was implemented with the sed command.
I made a shell script and a simple C test code and tried bug reproduction, but I couldn't reproduce the same error.
So the test is implemented with the sed command.

And in addition to the file mode, the file owner and group cache may also change, but I couldn't find a pattern that would cause an error while doing these things.
Therefore, this fix is limited to the file mode only.