### PR TITLE
Fixed a bug that regular files could not be created by mknod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ test/chaos-http-proxy-*
 test/junk_data
 test/s3proxy-*
 test/write_multiblock
+test/mknod_test
 
 #
 # Windows ports

--- a/src/fdcache_auto.cpp
+++ b/src/fdcache_auto.cpp
@@ -86,16 +86,16 @@ int AutoFdEntity::Detach()
     return fd;
 }
 
-bool AutoFdEntity::Attach(const char* path, int existfd)
+FdEntity* AutoFdEntity::Attach(const char* path, int existfd)
 {
     Close();
 
     if(NULL == (pFdEntity = FdManager::get()->GetFdEntity(path, existfd, false))){
         S3FS_PRN_DBG("Could not find fd entity object(file=%s, pseudo_fd=%d)", path, existfd);
-        return false;
+        return NULL;
     }
     pseudo_fd = existfd;
-    return true;
+    return pFdEntity;
 }
 
 FdEntity* AutoFdEntity::Open(const char* path, headers_t* pmeta, off_t size, time_t time, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type)

--- a/src/fdcache_auto.h
+++ b/src/fdcache_auto.h
@@ -48,7 +48,7 @@ class AutoFdEntity
 
       bool Close();
       int Detach();
-      bool Attach(const char* path, int existfd);
+      FdEntity* Attach(const char* path, int existfd);
       int GetPseudoFd() const { return pseudo_fd; }
 
       FdEntity* Open(const char* path, headers_t* pmeta, off_t size, time_t time, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1545,7 +1545,7 @@ int FdEntity::RowFlushMultipart(PseudoFdInfo* pseudo_obj, const char* tpath)
             S3FS_PRN_ERR("failed to truncate file(physical_fd=%d) to zero, but continue...", physical_fd);
         }
         // put pending headers or create new file
-        if(0 != (result = UploadPending())){
+        if(0 != (result = UploadPending(-1))){
             return result;
         }
     }
@@ -1673,7 +1673,7 @@ int FdEntity::RowFlushMixMultipart(PseudoFdInfo* pseudo_obj, const char* tpath)
             S3FS_PRN_ERR("failed to truncate file(physical_fd=%d) to zero, but continue...", physical_fd);
         }
         // put pending headers or create new file
-        if(0 != (result = UploadPending())){
+        if(0 != (result = UploadPending(-1))){
             return result;
         }
     }

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -105,7 +105,7 @@ class FdEntity
         int GetPhysicalFd() const { return physical_fd; }
         bool IsModified() const;
         bool MergeOrgMeta(headers_t& updatemeta);
-        int UploadPending(int fd = -1);
+        int UploadPending(int fd);
 
         bool GetStats(struct stat& st, bool lock_already_held = false);
         int SetCtime(struct timespec time, bool lock_already_held = false);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2488,9 +2488,16 @@ static int s3fs_release(const char* _path, struct fuse_file_info* fi)
         // The pseudo fd stored in fi->fh is attached to AutoFdEntry so that it can be
         // destroyed here.
         //
-        if(!autoent.Attach(path, static_cast<int>(fi->fh))){
+        FdEntity* ent;
+        if(NULL == (ent = autoent.Attach(path, static_cast<int>(fi->fh)))){
             S3FS_PRN_ERR("could not find pseudo_fd(%llu) for path(%s)", (unsigned long long)(fi->fh), path);
             return -EIO;
+        }
+
+        int result = ent->UploadPending(static_cast<int>(fi->fh));
+        if(0 != result){
+            S3FS_PRN_ERR("could not upload pending data(meta, etc) for pseudo_fd(%llu) / path(%s)", (unsigned long long)(fi->fh), path);
+            return result;
         }
     }
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -31,10 +31,12 @@ testdir = test
 
 noinst_PROGRAMS = \
     junk_data \
-    write_multiblock
+    write_multiblock \
+    mknod_test
 
 junk_data_SOURCES = junk_data.c
 write_multiblock_SOURCES = write_multiblock.cc
+mknod_test_SOURCES = mknod_test.c
 
 #
 # Local variables:

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -749,6 +749,16 @@ function test_hardlink {
     rm_test_file "${ALT_TEST_TEXT_FILE}"
 }
 
+function test_mknod {
+    describe "Testing mknod system call function ..."
+
+    local MKNOD_TEST_FILE_BASENAME="mknod_testfile"
+
+    rm -f "${MKNOD_TEST_FILE_BASENAME}*"
+
+    ../../mknod_test "${MKNOD_TEST_FILE_BASENAME}"
+}
+
 function test_symlink {
     describe "Testing symlinks ..."
 
@@ -1894,6 +1904,9 @@ function add_all_tests {
     add_tests test_special_characters
     add_tests test_hardlink
     add_tests test_symlink
+    if ! uname | grep -q Darwin; then
+        add_tests test_mknod
+    fi
     add_tests test_extended_attributes
     add_tests test_mtime_file
 

--- a/test/mknod_test.c
+++ b/test/mknod_test.c
@@ -82,7 +82,7 @@ bool TestMknod(const char* basepath, mode_t mode)
             break;
         case S_IFBLK:
             str_mode = str_mode_blk;
-            dev      = makedev((long long)(259), 0);     // temporary value
+            dev      = makedev((unsigned int)(259), 0);     // temporary value
             sprintf(filepath, "%s.%s", basepath, str_ext_blk);
             break;
         case S_IFIFO:
@@ -93,7 +93,8 @@ bool TestMknod(const char* basepath, mode_t mode)
         case S_IFSOCK:
             str_mode = str_mode_sock;
             dev      = 0;
-            sprintf(filepath, "%s.%s", basepath, str_ext_sock);
+            snprintf(filepath, S3FS_TEST_PATH_MAX, "%s.%s", basepath, str_ext_sock);
+            filepath[S3FS_TEST_PATH_MAX - 1] = '\0';    // for safety
             break;
         default:
             fprintf(stderr, "[ERROR] Called function with wrong mode argument.\n");
@@ -137,11 +138,11 @@ int main(int argc, char *argv[])
 {
     // Parse parameters
     if(2 != argc){
-        fprintf(stderr, "[ERROR] No paraemter is specified.\n");
+        fprintf(stderr, "[ERROR] No parameter is specified.\n");
         fprintf(stderr, "%s\n", usage_string);
         exit(EXIT_FAILURE);
     }
-    if(0 == strcasecmp("-h", argv[1]) || 0 == strcasecmp("--help", argv[1])){
+    if(0 == strcmp("-h", argv[1]) || 0 == strcmp("--help", argv[1])){
         fprintf(stdout, "%s\n", usage_string);
         exit(EXIT_SUCCESS);
     }
@@ -155,6 +156,9 @@ int main(int argc, char *argv[])
     // [NOTE]
     // Privilege is required to execute S_IFBLK.
     //
+    if(0 != geteuid()){
+        fprintf(stderr, "[WARNING] Skipping mknod(S_IFBLK) due to missing root privileges.\n");
+    }
     if(!TestMknod(argv[1], S_IFREG)  ||
        !TestMknod(argv[1], S_IFCHR)  ||
        !TestMknod(argv[1], S_IFIFO)  ||

--- a/test/mknod_test.c
+++ b/test/mknod_test.c
@@ -1,0 +1,177 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2021 Andrew Gaul <andrew@gaul.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#ifndef __APPLE__
+#include <sys/sysmacros.h>
+#endif
+
+//---------------------------------------------------------
+// Const
+//---------------------------------------------------------
+const char usage_string[]  = "Usage : \"mknod_test <base file path>\"";
+
+const char str_mode_reg[]  = "REGULAR";
+const char str_mode_chr[]  = "CHARACTER";
+const char str_mode_blk[]  = "BLOCK";
+const char str_mode_fifo[] = "FIFO";
+const char str_mode_sock[] = "SOCK";
+
+const char str_ext_reg[]   = "reg";
+const char str_ext_chr[]   = "chr";
+const char str_ext_blk[]   = "blk";
+const char str_ext_fifo[]  = "fifo";
+const char str_ext_sock[]  = "sock";
+
+// [NOTE]
+// It would be nice if PATH_MAX could be used as is, but since there are
+// issues using on Linux and we also must support for macos, this simple
+// test program defines a fixed value for simplicity.
+//
+#define S3FS_TEST_PATH_MAX   255
+int max_base_path_length   = S3FS_TEST_PATH_MAX - 5;
+
+//---------------------------------------------------------
+// Test function
+//---------------------------------------------------------
+bool TestMknod(const char* basepath, mode_t mode)
+{
+    if(!basepath){
+        fprintf(stderr, "[ERROR] Called function with wrong basepath argument.\n");
+        return false;
+    }
+
+    const char* str_mode;
+    dev_t       dev;
+    char        filepath[S3FS_TEST_PATH_MAX];
+    switch(mode){
+        case S_IFREG:
+            str_mode = str_mode_reg;
+            dev      = 0;
+            sprintf(filepath, "%s.%s", basepath, str_ext_reg);
+            break;
+        case S_IFCHR:
+            str_mode = str_mode_chr;
+            dev      = makedev(0, 0);
+            sprintf(filepath, "%s.%s", basepath, str_ext_chr);
+            break;
+        case S_IFBLK:
+            str_mode = str_mode_blk;
+            dev      = makedev((long long)(259), 0);     // temporary value
+            sprintf(filepath, "%s.%s", basepath, str_ext_blk);
+            break;
+        case S_IFIFO:
+            str_mode = str_mode_fifo;
+            dev      = 0;
+            sprintf(filepath, "%s.%s", basepath, str_ext_fifo);
+            break;
+        case S_IFSOCK:
+            str_mode = str_mode_sock;
+            dev      = 0;
+            sprintf(filepath, "%s.%s", basepath, str_ext_sock);
+            break;
+        default:
+            fprintf(stderr, "[ERROR] Called function with wrong mode argument.\n");
+            return false;
+    }
+
+    //
+    // Create
+    //
+    if(0 != mknod(filepath, mode | S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH, dev)){
+        fprintf(stderr, "[ERROR] Could not create %s file(%s) : errno = %d\n", str_mode, filepath, errno);
+        return false;
+    }
+
+    //
+    // Check
+    //
+    struct stat st;
+    if(0 != stat(filepath, &st)){
+        fprintf(stderr, "[ERROR] Could not get stat from %s file(%s) : errno = %d\n", str_mode, filepath, errno);
+        return false;
+    }
+    if(mode != (st.st_mode & S_IFMT)){
+        fprintf(stderr, "[ERROR] Created %s file(%s) does not have 0%o stat\n", str_mode, filepath, mode);
+        return false;
+    }
+
+    //
+    // Remove
+    //
+    if(0 != unlink(filepath)){
+        fprintf(stderr, "[WARNING] Could not remove %s file(%s) : errno = %d\n", str_mode, filepath, mode);
+    }
+    return true;
+}
+
+//---------------------------------------------------------
+// Main
+//---------------------------------------------------------
+int main(int argc, char *argv[])
+{
+    // Parse parameters
+    if(2 != argc){
+        fprintf(stderr, "[ERROR] No paraemter is specified.\n");
+        fprintf(stderr, "%s\n", usage_string);
+        exit(EXIT_FAILURE);
+    }
+    if(0 == strcasecmp("-h", argv[1]) || 0 == strcasecmp("--help", argv[1])){
+        fprintf(stdout, "%s\n", usage_string);
+        exit(EXIT_SUCCESS);
+    }
+    if(max_base_path_length < strlen(argv[1])){
+        fprintf(stderr, "[ERROR] Base file path is too long, it must be less than %d\n", max_base_path_length);
+        exit(EXIT_FAILURE);
+    }
+
+    // Test
+    //
+    // [NOTE]
+    // Privilege is required to execute S_IFBLK.
+    //
+    if(!TestMknod(argv[1], S_IFREG)  ||
+       !TestMknod(argv[1], S_IFCHR)  ||
+       !TestMknod(argv[1], S_IFIFO)  ||
+       !TestMknod(argv[1], S_IFSOCK) ||
+       (0 == geteuid() && !TestMknod(argv[1], S_IFBLK)))
+    {
+        exit(EXIT_FAILURE);
+    }
+
+    exit(EXIT_SUCCESS);
+}
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1934

### Details

The touch command fails when the directory on which s3fs is mounted is mounted with NFS, by #1934.
As a result of investigating this, it turned out to be a bug.

#### Cause

FUSE calls the `create`(`s3fs_sreate`) hook when creating a regular file with mknod.
After that, `flush`(`s3fs_flush`) is not called because mknod is the trigger, and `release`(`s3fs_release`) closes the file handle.
After this, file attribute changes such as `utimens` are called.

Also, when creating a file such as a `touch` command, NFS does not call `open`/`close`, but calls `mknod`.

Due to the above operation of FUSE and NFS, to create a new file with zero file size by the `touch` command, `create`(`s3fs_create`) is called, and `release`(`s3fs_release`) is called without `flush`(`s3fs_flush`).

s3fs delays the creation of new zero file size files until `flush`(`s3fs_flush`). (you know #1640, #1655, #1780, etc.)
This does not take into account the call flow by mknod, so the pending file creation(and meta update) is not done.
After that, calling `utimens` will result in an error because the file has not been created.
Therefore, the touch command failed via NFS.

#### Fix
When `release`(`s3fs_release`) is called, if it is in the pending state(new file creation, meta information update), it has been modified to update them.
This allows you to `create`(`touch` command) regular files with `mknod`(from NFS).

I also added a test for `mknod`.
FUSE is called by `create`(`s3fs_create`) in the case of regular file creation, but by `mknod`(`s3fs_mknod`) in other cases.
Including these, I am making it possible to inspect with this test.
All `mknod` tests are bypassed on macos (because root privileges are required).
It will also be bypassed if you create a BLOCK device as well.

#### Remaining issues
It looks like mknod's non-regular file creation is supported, but it doesn't work correctly.
I think that `BLOCK`, `FIFO` and `SOCK` will not work.
As for `CHARACTER`, it may work, but it has not been implemented as a block device.
I will post new issue about it.

