### PR TITLE
Do not call exit in individual test functions

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -794,7 +794,7 @@ function test_extended_attributes {
 
     # remove value
     del_xattr key1 "${TEST_TEXT_FILE}"
-    get_xattr key1 "${TEST_TEXT_FILE}" && exit 1
+    get_xattr key1 "${TEST_TEXT_FILE}" && return 1
     get_xattr key2 "${TEST_TEXT_FILE}" | grep -q '^value2$'
 
     rm_test_file


### PR DESCRIPTION
This could prevent the test runner from reporting failures.