### PR TITLE
Allow listing implicit directories

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -427,7 +427,7 @@ static int get_object_attribute(const char* path, struct stat* pstbuf, headers_t
               }
             }
         }
-        if(support_compat_dir && 0 != result && std::string::npos == strpath.find("_$folder$", 0)){
+        if(0 != result && std::string::npos == strpath.find("_$folder$", 0)){
             // now path is "object" or "object/", do check "no dir object" which is not object but has only children.
             if('/' == *strpath.rbegin()){
                 strpath.erase(strpath.length() - 1);
@@ -440,7 +440,7 @@ static int get_object_attribute(const char* path, struct stat* pstbuf, headers_t
             }
         }
     }else{
-        if(support_compat_dir && '/' != *strpath.rbegin() && std::string::npos == strpath.find("_$folder$", 0) && is_need_check_obj_detail(*pheader)){
+        if('/' != *strpath.rbegin() && std::string::npos == strpath.find("_$folder$", 0) && is_need_check_obj_detail(*pheader)){
             // check a case of that "object" does not have attribute and "object" is possible to be directory.
             if(-ENOTEMPTY == directory_empty(strpath.c_str())){
                 // found "no dir object".


### PR DESCRIPTION
This fixes an issue when using `-o notsup_compat_dir flag`, dating back
to its introduction 3ac39d61f84134bb4dbc60b203be154cf56eae1b.  The new
default exposed this in my local testing but a test runner bug masked
a test failure in test_external_directory_creation.  References #927.
References #1984.