### PR TITLE
Fixed bugs about stream upload

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -198,6 +198,33 @@ struct etagpair
 
 typedef std::list<etagpair> etaglist_t;
 
+struct petagpool
+{
+    std::list<etagpair*> petaglist;
+
+    ~petagpool()
+    {
+        clear();
+    }
+
+    void clear()
+    {
+        for(std::list<etagpair*>::iterator it = petaglist.begin(); petaglist.end() != it; ++it){
+            if(*it){
+                delete (*it);
+            }
+        }
+        petaglist.clear();
+    }
+
+    etagpair* add(const etagpair& etag_entity)
+    {
+        etagpair* petag = new etagpair(etag_entity);
+        petaglist.push_back(petag);
+        return petag;
+    }
+};
+
 //
 // Each part information for Multipart upload
 //


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1802

### Details
There was a bug in the code merged in #1802, so this PR fixed it.
(The tests for `test_truncate_upload` and `test_upload_sparsefile` are failed.)

#### Fixed this bug
Perhaps the inconvenience was manifested in this `stream upload` logic after merged #1887.
The range areas which were untreated area was managed by `UntreatedParts untreated_list` value, which was implemented in the `PseudoFdInfo` class.
This has been fixed by moving it to the `FdEntity` class.

#### Fixed another bug
Along with this fix, I found that there was a possibility of SEGV error, so it was fixed.
It was a problem with pointer management of `etagpair structure` (which had etag and upload number).
I fixed this by adding and using the `petagpool structure`.
