### PR TITLE
Fixed a test_truncate_cache failure on macos

### DIFF
--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -147,19 +147,20 @@ static char* get_object_name(xmlDocPtr doc, xmlNodePtr node, const char* path)
         S3FS_PRN_ERR("could not get object full path name..");
         return NULL;
     }
-    // basepath(path) is as same as fullpath.
-    if(0 == strcmp(reinterpret_cast<char*>(fullpath), path)){
-        xmlFree(fullpath);
+    std::string strfullpath = reinterpret_cast<char*>(fullpath);
+    xmlFree(fullpath);
+
+    // basepath(path) is as same as strfullpath.
+    if(0 == strcmp(strfullpath.c_str(), path)){
         return (char*)c_strErrorObjectName;
     }
 
     // Make dir path and filename
-    std::string   strdirpath = mydirname(std::string(reinterpret_cast<char*>(fullpath)));
-    std::string   strmybpath = mybasename(std::string(reinterpret_cast<char*>(fullpath)));
+    std::string   strdirpath = mydirname(strfullpath.c_str());
+    std::string   strmybpath = mybasename(strfullpath.c_str());
     const char* dirpath = strdirpath.c_str();
     const char* mybname = strmybpath.c_str();
     const char* basepath= (path && '/' == path[0]) ? &path[1] : path;
-    xmlFree(fullpath);
 
     if('\0' == mybname[0]){
         return NULL;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1987

### Details
About #1987, I found out where `test_truncate_cache` sometimes fails on macos.

It happens with `rm -rf $ (seq 2)` in `test_truncate_cache` test.
When deleting two directories, `s3fs_rmdir` fails because sometimes files remain in the directories.

When FUSE receives a system call to delete a directory, it lists the files in the directory.
It then deletes each of the listed files in turn(`s3fs_unlink`), deletes them all, and then calls `s3fs_rmdir`.
For macos(which may also happen on Linux?), any files were missing from the list of files in this directory at deleting each one.

The location of the problem has been identified and it has been fixed (as much as possible) with this PR code.
_(However, it remains unclear why the value of that buffer changed.)_

This PR should be applied early to avoid failing on macos tests.
