### PR TITLE
Improved to avoid unnecessary head request

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -150,6 +150,10 @@ class StatCache
         {
             return GetStat(key, NULL, NULL, overcheck, etag, NULL);
         }
+        bool HasStat(const std::string& key, struct stat* pst, const char* etag)
+        {
+            return GetStat(key, pst, NULL, true, etag, NULL);
+        }
 
         // Cache For no object
         bool IsNoObjectCache(const std::string& key, bool overcheck = true);

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1049,18 +1049,22 @@ int S3fsCurl::SetMaxMultiRequest(int max)
     return old;
 }
 
-bool S3fsCurl::UploadMultipartPostCallback(S3fsCurl* s3fscurl)
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameter
+bool S3fsCurl::UploadMultipartPostCallback(S3fsCurl* s3fscurl, void* param)
 {
-    if(!s3fscurl){
+    if(!s3fscurl || param){     // this callback does not need a parameter
         return false;
     }
 
     return s3fscurl->UploadMultipartPostComplete();
 }
 
-bool S3fsCurl::MixMultipartPostCallback(S3fsCurl* s3fscurl)
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameter
+bool S3fsCurl::MixMultipartPostCallback(S3fsCurl* s3fscurl, void* param)
 {
-    if(!s3fscurl){
+    if(!s3fscurl || param){     // this callback does not need a parameter
         return false;
     }
 
@@ -4111,9 +4115,11 @@ bool S3fsCurl::UploadMultipartPostComplete()
     return true;
 }
 
-bool S3fsCurl::CopyMultipartPostCallback(S3fsCurl* s3fscurl)
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameter
+bool S3fsCurl::CopyMultipartPostCallback(S3fsCurl* s3fscurl, void* param)
 {
-    if(!s3fscurl){
+    if(!s3fscurl || param){     // this callback does not need a parameter
         return false;
     }
 

--- a/src/curl.h
+++ b/src/curl.h
@@ -221,9 +221,9 @@ class S3fsCurl
         static size_t UploadReadCallback(void *ptr, size_t size, size_t nmemb, void *userp);
         static size_t DownloadWriteCallback(void* ptr, size_t size, size_t nmemb, void* userp);
 
-        static bool UploadMultipartPostCallback(S3fsCurl* s3fscurl);
-        static bool CopyMultipartPostCallback(S3fsCurl* s3fscurl);
-        static bool MixMultipartPostCallback(S3fsCurl* s3fscurl);
+        static bool UploadMultipartPostCallback(S3fsCurl* s3fscurl, void* param);
+        static bool CopyMultipartPostCallback(S3fsCurl* s3fscurl, void* param);
+        static bool MixMultipartPostCallback(S3fsCurl* s3fscurl, void* param);
         static S3fsCurl* UploadMultipartPostRetryCallback(S3fsCurl* s3fscurl);
         static S3fsCurl* CopyMultipartPostRetryCallback(S3fsCurl* s3fscurl);
         static S3fsCurl* MixMultipartPostRetryCallback(S3fsCurl* s3fscurl);

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -31,7 +31,7 @@
 //-------------------------------------------------------------------
 // Class S3fsMultiCurl 
 //-------------------------------------------------------------------
-S3fsMultiCurl::S3fsMultiCurl(int maxParallelism) : maxParallelism(maxParallelism), SuccessCallback(NULL), RetryCallback(NULL)
+S3fsMultiCurl::S3fsMultiCurl(int maxParallelism) : maxParallelism(maxParallelism), SuccessCallback(NULL), RetryCallback(NULL), pSuccessCallbackParam(NULL)
 {
     int result;
     pthread_mutexattr_t attr;
@@ -91,6 +91,13 @@ S3fsMultiRetryCallback S3fsMultiCurl::SetRetryCallback(S3fsMultiRetryCallback fu
 {
     S3fsMultiRetryCallback old = RetryCallback;
     RetryCallback = function;
+    return old;
+}
+
+void* S3fsMultiCurl::SetSuccessCallbackParam(void* param)
+{
+    void* old = pSuccessCallbackParam;
+    pSuccessCallbackParam = param;
     return old;
 }
   
@@ -197,7 +204,7 @@ int S3fsMultiCurl::MultiRead()
                 isPostpone = true;
             }else if(400 > responseCode){
                 // add into stat cache
-                if(SuccessCallback && !SuccessCallback(s3fscurl)){
+                if(SuccessCallback && !SuccessCallback(s3fscurl, pSuccessCallbackParam)){
                     S3FS_PRN_WARN("error from callback function(%s).", s3fscurl->url.c_str());
                 }
             }else if(400 == responseCode){

--- a/src/curl_multi.h
+++ b/src/curl_multi.h
@@ -27,8 +27,8 @@
 class S3fsCurl;
 
 typedef std::vector<S3fsCurl*>       s3fscurllist_t;
-typedef bool (*S3fsMultiSuccessCallback)(S3fsCurl* s3fscurl);    // callback for succeed multi request
-typedef S3fsCurl* (*S3fsMultiRetryCallback)(S3fsCurl* s3fscurl); // callback for failure and retrying
+typedef bool (*S3fsMultiSuccessCallback)(S3fsCurl* s3fscurl, void* param);  // callback for succeed multi request
+typedef S3fsCurl* (*S3fsMultiRetryCallback)(S3fsCurl* s3fscurl);            // callback for failure and retrying
 
 //----------------------------------------------
 // class S3fsMultiCurl
@@ -43,6 +43,7 @@ class S3fsMultiCurl
 
         S3fsMultiSuccessCallback SuccessCallback;
         S3fsMultiRetryCallback   RetryCallback;
+        void*                    pSuccessCallbackParam;
 
         pthread_mutex_t completed_tids_lock;
         std::vector<pthread_t> completed_tids;
@@ -62,6 +63,7 @@ class S3fsMultiCurl
 
         S3fsMultiSuccessCallback SetSuccessCallback(S3fsMultiSuccessCallback function);
         S3fsMultiRetryCallback SetRetryCallback(S3fsMultiRetryCallback function);
+        void* SetSuccessCallbackParam(void* param);
         bool Clear() { return ClearEx(true); }
         bool SetS3fsCurlObject(S3fsCurl* s3fscurl);
         int Request();


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Fixed the `readdir_multi_head` function called from `s3fs_readdir` because it is inefficient.

This fixes an inefficiency if the stat cache was cached out during the processing of `readdir_multi_head`.

`readdir_multi_head` uses a `filler`(FUSE param) to return a list of files and directories stat returned by `list_bucket`.
At this time, even though the files and directories returned by `list_bucket` existed in the stat cache, s3fs was always sending a HEAD request.
Also, HEAD requests are processed in parallel, and those results are stored in the stat cache.
And `readdir_multi_head` reads the value from the stat cache after all request finished.
When the number of stat caches is small and stat cache of those result is out, s3fs requests HEADs which are unnecessary processing.

So `readdir_multi_head` passes its value to the filler as is, if it exists in the stat cache.
Also, the result of the HEAD request is passed to the filler without going through stat cache.(but it will be cached to stat)

This will reduce unnecessary HEAD requests and improve performance. (depending on the stat cache conditions)
