### PR TITLE
Fixed race condition in dirname and basename call

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4529,6 +4529,14 @@ int main(int argc, char* argv[])
         exit(EXIT_FAILURE);
     }
 
+    // mutex for basename/dirname
+    if(!init_basename_lock()){
+        S3FS_PRN_EXIT("could not initialize mutex for basename/dirname.");
+        s3fs_destroy_global_ssl();
+        destroy_parser_xml_lock();
+        exit(EXIT_FAILURE);
+    }
+
     // init curl (without mime types)
     //
     // [NOTE]
@@ -4549,6 +4557,7 @@ int main(int argc, char* argv[])
         S3FS_PRN_EXIT("Could not initiate curl library.");
         s3fs_destroy_global_ssl();
         destroy_parser_xml_lock();
+        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -4563,6 +4572,7 @@ int main(int argc, char* argv[])
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
         destroy_parser_xml_lock();
+        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -4579,6 +4589,7 @@ int main(int argc, char* argv[])
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
         destroy_parser_xml_lock();
+        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
     if(!S3fsCurl::FinalCheckSse()){
@@ -4586,6 +4597,7 @@ int main(int argc, char* argv[])
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
         destroy_parser_xml_lock();
+        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -4605,6 +4617,7 @@ int main(int argc, char* argv[])
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
         destroy_parser_xml_lock();
+        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -4619,6 +4632,7 @@ int main(int argc, char* argv[])
             S3fsCurl::DestroyS3fsCurl();
             s3fs_destroy_global_ssl();
             destroy_parser_xml_lock();
+            destroy_basename_lock();
             exit(EXIT_FAILURE);
         }
     }
@@ -4629,6 +4643,7 @@ int main(int argc, char* argv[])
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
         destroy_parser_xml_lock();
+        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -4638,6 +4653,7 @@ int main(int argc, char* argv[])
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
         destroy_parser_xml_lock();
+        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -4681,6 +4697,7 @@ int main(int argc, char* argv[])
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
         destroy_parser_xml_lock();
+        destroy_basename_lock();
         exit(exitcode);
     }
 
@@ -4695,6 +4712,7 @@ int main(int argc, char* argv[])
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
         destroy_parser_xml_lock();
+        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -4704,6 +4722,7 @@ int main(int argc, char* argv[])
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
         destroy_parser_xml_lock();
+        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -4764,6 +4783,7 @@ int main(int argc, char* argv[])
     }
     s3fs_destroy_global_ssl();
     destroy_parser_xml_lock();
+    destroy_basename_lock();
 
     // cleanup xml2
     xmlCleanupParser();

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -40,6 +40,8 @@ void init_sysconf_vars();
 std::string get_username(uid_t uid);
 int is_uid_include_group(uid_t uid, gid_t gid);
 
+bool init_basename_lock();
+bool destroy_basename_lock();
 std::string mydirname(const char* path);
 std::string mydirname(const std::string& path);
 std::string mybasename(const char* path);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#1987
#1994

### Details
The cause of `test_truncate_cache` test error was a race between threads in the `dirname` call.(Only confirmed with macos10)

This happened because in `test_truncate_cache` test, `s3fs_getattr` was called by another thread while calling `list_bucket`.
Specifically, another `dirname` call was made shortly during receiving a static pointer from `dirname` and setting it to `std::string` buffer.
Therefore, the value set in `std::string` was replaced with the result called by another thread.

To fix this, we introduced `mutex` for exclusive control of `dirname` and `basename`(which return pointers to static variables).