### PR TITLE
Remove unneedd binary_function inheritance

### DIFF
--- a/src/metaheader.h
+++ b/src/metaheader.h
@@ -28,7 +28,7 @@
 //-------------------------------------------------------------------
 // headers_t
 //-------------------------------------------------------------------
-struct header_nocase_cmp : public std::binary_function<std::string, std::string, bool>
+struct header_nocase_cmp
 {
     bool operator()(const std::string &strleft, const std::string &strright) const
     {


### PR DESCRIPTION
GCC 12 warns that C++17 removes this.