### PR TITLE
Set mtime/ctime/atime of all objects as nanosecond

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -796,13 +796,7 @@ bool convert_header_to_stat(const char* path, const headers_t& meta, struct stat
             mtime.tv_sec  = 0;
             mtime.tv_nsec = 0;
         }
-#if defined(__APPLE__)
-        pst->st_mtime = mtime.tv_sec;
-        pst->st_mtimespec.tv_nsec = mtime.tv_nsec;
-#else
-        pst->st_mtim.tv_sec = mtime.tv_sec;
-        pst->st_mtim.tv_nsec = mtime.tv_nsec;
-#endif
+        set_timespec_to_stat(*pst, ST_TYPE_MTIME, mtime);
     }
 
     // ctime
@@ -814,13 +808,7 @@ bool convert_header_to_stat(const char* path, const headers_t& meta, struct stat
             ctime.tv_sec  = 0;
             ctime.tv_nsec = 0;
         }
-#if defined(__APPLE__)
-        pst->st_ctime = ctime.tv_sec;
-        pst->st_ctimespec.tv_nsec = ctime.tv_nsec;
-#else
-        pst->st_ctim.tv_sec = ctime.tv_sec;
-        pst->st_ctim.tv_nsec = ctime.tv_nsec;
-#endif
+        set_timespec_to_stat(*pst, ST_TYPE_CTIME, ctime);
     }
 
     // atime
@@ -832,13 +820,7 @@ bool convert_header_to_stat(const char* path, const headers_t& meta, struct stat
             atime.tv_sec  = 0;
             atime.tv_nsec = 0;
         }
-#if defined(__APPLE__)
-        pst->st_atime = atime.tv_sec;
-        pst->st_atimespec.tv_nsec = atime.tv_nsec;
-#else
-        pst->st_atim.tv_sec = atime.tv_sec;
-        pst->st_atim.tv_nsec = atime.tv_nsec;
-#endif
+        set_timespec_to_stat(*pst, ST_TYPE_ATIME, atime);
     }
 
     // size

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -533,9 +533,9 @@ FdEntity* FdManager::GetFdEntity(const char* path, int& existfd, bool newfd, boo
     return NULL;
 }
 
-FdEntity* FdManager::Open(int& fd, const char* path, headers_t* pmeta, off_t size, time_t time, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type)
+FdEntity* FdManager::Open(int& fd, const char* path, headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type)
 {
-    S3FS_PRN_DBG("[path=%s][size=%lld][time=%lld][flags=0x%x][force_tmpfile=%s][create=%s][ignore_modify=%s]", SAFESTRPTR(path), static_cast<long long>(size), static_cast<long long>(time), flags, (force_tmpfile ? "yes" : "no"), (is_create ? "yes" : "no"), (ignore_modify ? "yes" : "no"));
+    S3FS_PRN_DBG("[path=%s][size=%lld][ts_mctime=%s][flags=0x%x][force_tmpfile=%s][create=%s][ignore_modify=%s]", SAFESTRPTR(path), static_cast<long long>(size), str(ts_mctime).c_str(), flags, (force_tmpfile ? "yes" : "no"), (is_create ? "yes" : "no"), (ignore_modify ? "yes" : "no"));
 
     if(!path || '\0' == path[0]){
         return NULL;
@@ -578,7 +578,7 @@ FdEntity* FdManager::Open(int& fd, const char* path, headers_t* pmeta, off_t siz
         }
 
         // (re)open
-        if(-1 == (fd = ent->Open(pmeta, size, time, flags, type))){
+        if(-1 == (fd = ent->Open(pmeta, size, ts_mctime, flags, type))){
             S3FS_PRN_ERR("failed to (re)open and create new pseudo fd for path(%s).", path);
             return NULL;
         }
@@ -594,7 +594,7 @@ FdEntity* FdManager::Open(int& fd, const char* path, headers_t* pmeta, off_t siz
         ent = new FdEntity(path, cache_path.c_str());
 
         // open
-        if(-1 == (fd = ent->Open(pmeta, size, time, flags, type))){
+        if(-1 == (fd = ent->Open(pmeta, size, ts_mctime, flags, type))){
             delete ent;
             return NULL;
         }
@@ -646,7 +646,7 @@ FdEntity* FdManager::OpenExistFdEntity(const char* path, int& fd, int flags)
     S3FS_PRN_DBG("[path=%s][flags=0x%x]", SAFESTRPTR(path), flags);
 
     // search entity by path, and create pseudo fd
-    FdEntity* ent = Open(fd, path, NULL, -1, -1, flags, false, false, false, AutoLock::NONE);
+    FdEntity* ent = Open(fd, path, NULL, -1, S3FS_OMIT_TS, flags, false, false, false, AutoLock::NONE);
     if(!ent){
         // Not found entity
         return NULL;

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -87,7 +87,7 @@ class FdManager
 
       // Return FdEntity associated with path, returning NULL on error.  This operation increments the reference count; callers must decrement via Close after use.
       FdEntity* GetFdEntity(const char* path, int& existfd, bool newfd = true, bool lock_already_held = false);
-      FdEntity* Open(int& fd, const char* path, headers_t* pmeta, off_t size, time_t time, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);
+      FdEntity* Open(int& fd, const char* path, headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);
       FdEntity* GetExistFdEntity(const char* path, int existfd = -1);
       FdEntity* OpenExistFdEntity(const char* path, int& fd, int flags = O_RDONLY);
       void Rename(const std::string &from, const std::string &to);

--- a/src/fdcache_auto.cpp
+++ b/src/fdcache_auto.cpp
@@ -98,11 +98,11 @@ FdEntity* AutoFdEntity::Attach(const char* path, int existfd)
     return pFdEntity;
 }
 
-FdEntity* AutoFdEntity::Open(const char* path, headers_t* pmeta, off_t size, time_t time, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type)
+FdEntity* AutoFdEntity::Open(const char* path, headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type)
 {
     Close();
 
-    if(NULL == (pFdEntity = FdManager::get()->Open(pseudo_fd, path, pmeta, size, time, flags, force_tmpfile, is_create, ignore_modify, type))){
+    if(NULL == (pFdEntity = FdManager::get()->Open(pseudo_fd, path, pmeta, size, ts_mctime, flags, force_tmpfile, is_create, ignore_modify, type))){
         pseudo_fd = -1;
         return NULL;
     }

--- a/src/fdcache_auto.h
+++ b/src/fdcache_auto.h
@@ -51,7 +51,7 @@ class AutoFdEntity
       FdEntity* Attach(const char* path, int existfd);
       int GetPseudoFd() const { return pseudo_fd; }
 
-      FdEntity* Open(const char* path, headers_t* pmeta, off_t size, time_t time, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);
+      FdEntity* Open(const char* path, headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);
       FdEntity* GetExistFdEntity(const char* path, int existfd = -1);
       FdEntity* OpenExistFdEntity(const char* path, int flags = O_RDONLY);
 };

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -104,7 +104,7 @@ class FdEntity
         void Close(int fd);
         bool IsOpen() const { return (-1 != physical_fd); }
         bool FindPseudoFd(int fd, bool lock_already_held = false);
-        int Open(const headers_t* pmeta, off_t size, time_t time, int flags, AutoLock::Type type);
+        int Open(const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, AutoLock::Type type);
         bool LoadAll(int fd, headers_t* pmeta = NULL, off_t* size = NULL, bool force_load = false);
         int Dup(int fd, bool lock_already_held = false);
         int OpenPseudoFd(int flags = O_RDONLY, bool lock_already_held = false);

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -56,6 +56,24 @@ bool compare_sysname(const char* target);
 
 void print_launch_message(int argc, char** argv);
 
+//
+// Utility for nanosecond time(timespec)
+//
+enum stat_time_type{
+    ST_TYPE_ATIME,
+    ST_TYPE_MTIME,
+    ST_TYPE_CTIME
+};
+extern const struct timespec S3FS_OMIT_TS;
+
+int compare_timespec(const struct timespec& ts1, const struct timespec& ts2);
+int compare_timespec(const struct stat& st, stat_time_type type, const struct timespec& ts);
+void set_timespec_to_stat(struct stat& st, stat_time_type type, const struct timespec& ts);
+struct timespec* set_stat_to_timespec(const struct stat& st, stat_time_type type, struct timespec& ts);
+std::string str_stat_time(const struct stat& st, stat_time_type type);
+struct timespec* s3fs_realtime(struct timespec& ts);
+std::string s3fs_str_realtime();
+
 #endif // S3FS_S3FS_UTIL_H_
 
 /*

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -56,7 +56,8 @@ template std::string str(unsigned long value);
 template std::string str(long long value);
 template std::string str(unsigned long long value);
 
-template<> std::string str(struct timespec value) {
+template<> std::string str(const struct timespec value)
+{
     std::ostringstream s;
     s << value.tv_sec;
     if(value.tv_nsec != 0){


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2000 

### Details
Changed the stat time of the object for testing in #2000 to nanosecond units.
However, there was a part where the time of some objects(directories) created/modified by s3fs remained time_t/timeval unit.
Some tests could fail instability because of using time as second/usec units.

This PR code changed them to nanosecond units.
As a result, `mtime`/`ctime`/`atime` of all objects created and modified by s3fs are set in nanosecond units.
With the fix, I prepared some common utility functions and decided to use them.

#### NOTE
On macos10, we have detected that `test_mtime_file` fails.
The reason is that when copying a file with `cp -p`, the `mtime` argument of the `s3fs_utimens` call should pass the `mtime` of the original file if it is in the correct state, but this value was different.
In macos10, this `mtime` is rounded down to microseconds instead of nanoseconds.
I could not know how to fix this.(in the first place, it is hard to think that it can be fixed with s3fs)
Therefore, I changed the `test_mtime_file` test result scrutiny only slightly for macos.
