### PR TITLE
Fixed deadlock in S3fsCurl::DestroyCurlHandle

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1920,7 +1920,7 @@ bool S3fsCurl::CreateCurlHandle(bool only_pool, bool remake)
     AutoLock lock(&S3fsCurl::curl_handles_lock);
 
     if(hCurl && remake){
-        if(!DestroyCurlHandle(false)){
+        if(!DestroyCurlHandle(false, true, AutoLock::ALREADY_LOCKED)){
             S3FS_PRN_ERR("could not destroy handle.");
             return false;
         }
@@ -1945,7 +1945,7 @@ bool S3fsCurl::CreateCurlHandle(bool only_pool, bool remake)
     return true;
 }
 
-bool S3fsCurl::DestroyCurlHandle(bool restore_pool, bool clear_internal_data)
+bool S3fsCurl::DestroyCurlHandle(bool restore_pool, bool clear_internal_data, AutoLock::Type locktype)
 {
     // [NOTE]
     // If type is REQTYPE_IAMCRED or REQTYPE_IAMROLE, do not clear type.
@@ -1961,7 +1961,7 @@ bool S3fsCurl::DestroyCurlHandle(bool restore_pool, bool clear_internal_data)
     }
 
     if(hCurl){
-        AutoLock lock(&S3fsCurl::curl_handles_lock);
+        AutoLock lock(&S3fsCurl::curl_handles_lock, locktype);
   
         S3fsCurl::curl_times.erase(hCurl);
         S3fsCurl::curl_progress.erase(hCurl);

--- a/src/curl.h
+++ b/src/curl.h
@@ -336,7 +336,7 @@ class S3fsCurl
 
         // methods
         bool CreateCurlHandle(bool only_pool = false, bool remake = false);
-        bool DestroyCurlHandle(bool restore_pool = true, bool clear_internal_data = true);
+        bool DestroyCurlHandle(bool restore_pool = true, bool clear_internal_data = true, AutoLock::Type locktype = AutoLock::NONE);
 
         bool GetIAMCredentials(const char* cred_url, const char* iam_v2_token, const char* ibm_secret_access_key, std::string& response);
         bool GetIAMRoleFromMetaData(const char* cred_url, const char* iam_v2_token, std::string& token);


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
In the case where `S3fsCurl::DestroyCurlHandle` is called from `S3fsCurl::CreateCurlHandle`, there was a flow that caused a deadlock.

#### NOTE
Now, the build of macos10 for Github Actions is blocked for 24H.
I'll try again later.