### PR TITLE
Fixed data race in ThreadPoolMan

### DIFF
--- a/src/threadpoolman.h
+++ b/src/threadpoolman.h
@@ -60,7 +60,7 @@ class ThreadPoolMan
     private:
         static ThreadPoolMan* singleton;
 
-        volatile bool         is_exit;
+        bool                  is_exit;
         Semaphore             thpoolman_sem;
 
         bool                  is_lock_init;
@@ -69,11 +69,17 @@ class ThreadPoolMan
 
         thpoolman_params_t    instruction_list;
 
+        bool                  is_exit_flag_init;
+        pthread_mutex_t       thread_exit_flag_lock;
+
     private:
         static void* Worker(void* arg);
 
         explicit ThreadPoolMan(int count = 1);
         ~ThreadPoolMan();
+
+        bool IsExit();
+        void SetExitFlag(bool exit_flag);
 
         bool StopThreads();
         bool StartThreads(int count);


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
I got the following report with `-fsanitize=thread` in `run_tests_using_sanitizers.sh`, so It was fixed.
```
WARNING: ThreadSanitizer: data race (pid=17275)
  Write of size 1 at 0x7b2400000090 by main thread:
    #0 ThreadPoolMan::StopThreads() /home/ggtakec/work/s3fs-fuse/src/threadpoolman.cpp:176:13 (s3fs+0x58a3e2)
    #1 ThreadPoolMan::~ThreadPoolMan() /home/ggtakec/work/s3fs-fuse/src/threadpoolman.cpp:156:5 (s3fs+0x58a26f)
    #2 ThreadPoolMan::Destroy() /home/ggtakec/work/s3fs-fuse/src/threadpoolman.cpp:52:9 (s3fs+0x589902)
    #3 main /home/ggtakec/work/s3fs-fuse/src/s3fs.cpp:4802:5 (s3fs+0x4bc632)

  Previous read of size 1 at 0x7b2400000090 by thread T5:
    #0 ThreadPoolMan::Worker(void*) /home/ggtakec/work/s3fs-fuse/src/threadpoolman.cpp:79:24 (s3fs+0x589bc8)

  Location is heap block of size 144 at 0x7b2400000090 allocated by main thread:
    #0 operator new(unsigned long) <null> (s3fs+0x4b6fbb)
    #1 ThreadPoolMan::Initialize(int) /home/ggtakec/work/s3fs-fuse/src/threadpoolman.cpp:45:32 (s3fs+0x589850)
    #2 main /home/ggtakec/work/s3fs-fuse/src/s3fs.cpp:4734:9 (s3fs+0x4bc091)

  Thread T5 (tid=17281, running) created by main thread at:
    #0 pthread_create <null> (s3fs+0x42a0ab)
    #1 ThreadPoolMan::StartThreads(int) /home/ggtakec/work/s3fs-fuse/src/threadpoolman.cpp:225:27 (s3fs+0x58a197)
    #2 ThreadPoolMan::ThreadPoolMan(int) /home/ggtakec/work/s3fs-fuse/src/threadpoolman.cpp:148:9 (s3fs+0x58a037)
    #3 ThreadPoolMan::Initialize(int) /home/ggtakec/work/s3fs-fuse/src/threadpoolman.cpp:45:36 (s3fs+0x58985f)
    #4 main /home/ggtakec/work/s3fs-fuse/src/s3fs.cpp:4734:9 (s3fs+0x4bc091)

SUMMARY: ThreadSanitizer: data race /home/ggtakec/work/s3fs-fuse/src/threadpoolman.cpp:176:13 in ThreadPoolMan::StopThreads()
```