### PR TITLE
Fixed data race and memory leaks in PseudoFdInfo

### DIFF
--- a/src/fdcache_fdinfo.h
+++ b/src/fdcache_fdinfo.h
@@ -77,7 +77,8 @@ class PseudoFdInfo
         bool Clear();
         void CloseUploadFd(AutoLock::Type type = AutoLock::NONE);
         bool OpenUploadFd(AutoLock::Type type = AutoLock::NONE);
-        bool ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy);
+        bool CompleteInstruction(int result, AutoLock::Type type = AutoLock::NONE);
+        bool ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy, AutoLock::Type type = AutoLock::NONE);
         bool InsertUploadPart(off_t start, off_t size, int part_num, bool is_copy, etagpair** ppetag, AutoLock::Type type = AutoLock::NONE);
         int WaitAllThreadsExit();
         bool ExtractUploadPartsFromUntreatedArea(off_t& untreated_start, off_t& untreated_size, mp_part_list_t& to_upload_list, filepart_list_t& cancel_upload_list, off_t max_mp_size);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2008 

### Details
In addition to #2008 `run_tests_using_sanitizers.sh` detected following, so I fixed it.
```
WARNING: ThreadSanitizer: data race (pid=2385)
  Write of size 4 at 0x7b3400006cd0 by thread T30 (mutexes: write M85703959268558400, write M85985434245269344):
    #0 PseudoFdInfo::ParallelMultipartUpload(char const*, std::__cxx11::list<mp_part, std::allocator<mp_part> > const&, bool) /home/ggtakec/work/s3fs-fuse/src/fdcache_fdinfo.cpp:433:9 (s3fs+0x5762cf)
    #1 PseudoFdInfo::ParallelMultipartUploadAll(char const*, std::__cxx11::list<mp_part, std::allocator<mp_part> > const&, std::__cxx11::list<mp_part, std::allocator<mp_part> > const&, int&) /home/ggtakec/work/s3fs-fuse/src/fdcache_fdinfo.cpp:448:9 (s3fs+0x57649c)
    #2 FdEntity::RowFlushStreamMultipart(PseudoFdInfo*, char const*) /home/ggtakec/work/s3fs-fuse/src/fdcache_entity.cpp:1879:25 (s3fs+0x55f3ec)
    #3 FdEntity::RowFlush(int, char const*, AutoLock::Type, bool) /home/ggtakec/work/s3fs-fuse/src/fdcache_entity.cpp:1437:18 (s3fs+0x55e098)
    #4 FdEntity::Flush(int, AutoLock::Type, bool) /home/ggtakec/work/s3fs-fuse/src/./fdcache_entity.h:141:82 (s3fs+0x4db31c)
    #5 s3fs_flush(char const*, fuse_file_info*) /home/ggtakec/work/s3fs-fuse/src/s3fs.cpp:2491:23 (s3fs+0x4ca876)
    #6 <null> <null> (libfuse.so.2+0xee6e)
...
...
```
Also, there was a memory leak that was fixed.
