### PR TITLE
Replace uses of lock_already_held flag with AutoLock::Type

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -23,6 +23,7 @@
 
 #include <cstring>
 
+#include "autolock.h"
 #include "metaheader.h"
 
 //-------------------------------------------------------------------
@@ -171,16 +172,16 @@ class StatCache
         void ChangeNoTruncateFlag(const std::string& key, bool no_truncate);
 
         // Delete stat cache
-        bool DelStat(const char* key, bool lock_already_held = false);
-        bool DelStat(const std::string& key, bool lock_already_held = false)
+        bool DelStat(const char* key, AutoLock::Type locktype = AutoLock::NONE);
+        bool DelStat(const std::string& key, AutoLock::Type locktype = AutoLock::NONE)
         {
-            return DelStat(key.c_str(), lock_already_held);
+            return DelStat(key.c_str(), locktype);
         }
 
         // Cache for symbolic link
         bool GetSymlink(const std::string& key, std::string& value);
         bool AddSymlink(const std::string& key, const std::string& value);
-        bool DelSymlink(const char* key, bool lock_already_held = false);
+        bool DelSymlink(const char* key, AutoLock::Type locktype = AutoLock::NONE);
 };
 
 //-------------------------------------------------------------------

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1834,7 +1834,7 @@ S3fsCurl::~S3fsCurl()
     DestroyCurlHandle();
 }
 
-bool S3fsCurl::ResetHandle(bool lock_already_held)
+bool S3fsCurl::ResetHandle(AutoLock::Type locktype)
 {
     bool run_once;
     {
@@ -1912,7 +1912,7 @@ bool S3fsCurl::ResetHandle(bool lock_already_held)
         }
     }
 
-    AutoLock lock(&S3fsCurl::curl_handles_lock, lock_already_held ? AutoLock::ALREADY_LOCKED : AutoLock::NONE);
+    AutoLock lock(&S3fsCurl::curl_handles_lock, locktype);
     S3fsCurl::curl_times[hCurl]    = time(0);
     S3fsCurl::curl_progress[hCurl] = progress_t(-1, -1);
 
@@ -1944,7 +1944,7 @@ bool S3fsCurl::CreateCurlHandle(bool only_pool, bool remake)
             }
         }
     }
-    ResetHandle(/*lock_already_held=*/ true);
+    ResetHandle(AutoLock::ALREADY_LOCKED);
 
     return true;
 }

--- a/src/curl.h
+++ b/src/curl.h
@@ -243,7 +243,7 @@ class S3fsCurl
         static int RawCurlDebugFunc(const CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr, curl_infotype datatype);
 
         // methods
-        bool ResetHandle(bool lock_already_held = false);
+        bool ResetHandle(AutoLock::Type locktype = AutoLock::NONE);
         bool RemakeHandle();
         bool ClearInternalData();
         void insertV4Headers(const std::string& access_key_id, const std::string& secret_access_key, const std::string& access_token);

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -402,7 +402,7 @@ bool FdManager::HasOpenEntityFd(const char* path)
 
     FdEntity*   ent;
     int         fd = -1;
-    if(NULL == (ent = FdManager::singleton.GetFdEntity(path, fd, false, true))){
+    if(NULL == (ent = FdManager::singleton.GetFdEntity(path, fd, false, AutoLock::ALREADY_LOCKED))){
         return false;
     }
     return (0 < ent->GetOpenCount());
@@ -479,14 +479,14 @@ FdManager::~FdManager()
     }
 }
 
-FdEntity* FdManager::GetFdEntity(const char* path, int& existfd, bool newfd, bool lock_already_held)
+FdEntity* FdManager::GetFdEntity(const char* path, int& existfd, bool newfd, AutoLock::Type locktype)
 {
     S3FS_PRN_INFO3("[path=%s][pseudo_fd=%d]", SAFESTRPTR(path), existfd);
 
     if(!path || '\0' == path[0]){
         return NULL;
     }
-    AutoLock auto_lock(&FdManager::fd_manager_lock, lock_already_held ? AutoLock::ALREADY_LOCKED : AutoLock::NONE);
+    AutoLock auto_lock(&FdManager::fd_manager_lock, locktype);
 
     fdent_map_t::iterator iter = fent.find(std::string(path));
     if(fent.end() != iter && iter->second){

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -86,7 +86,7 @@ class FdManager
       static FILE* MakeTempFile();
 
       // Return FdEntity associated with path, returning NULL on error.  This operation increments the reference count; callers must decrement via Close after use.
-      FdEntity* GetFdEntity(const char* path, int& existfd, bool newfd = true, bool lock_already_held = false);
+      FdEntity* GetFdEntity(const char* path, int& existfd, bool newfd = true, AutoLock::Type locktype = AutoLock::NONE);
       FdEntity* Open(int& fd, const char* path, headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);
       FdEntity* GetExistFdEntity(const char* path, int existfd = -1);
       FdEntity* OpenExistFdEntity(const char* path, int& fd, int flags = O_RDONLY);

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -76,8 +76,8 @@ class FdEntity
         ino_t GetInode();
         int OpenMirrorFile();
         int NoCacheLoadAndPost(PseudoFdInfo* pseudo_obj, off_t start = 0, off_t size = 0);  // size=0 means loading to end
-        PseudoFdInfo* CheckPseudoFdFlags(int fd, bool writable, bool lock_already_held = false);
-        bool IsUploading(bool lock_already_held = false);
+        PseudoFdInfo* CheckPseudoFdFlags(int fd, bool writable, AutoLock::Type locktype = AutoLock::NONE);
+        bool IsUploading(AutoLock::Type locktype = AutoLock::NONE);
         bool SetAllStatus(bool is_loaded);                          // [NOTE] not locking
         bool SetAllStatusUnloaded() { return SetAllStatus(false); }
         int NoCachePreMultipartPost(PseudoFdInfo* pseudo_obj);
@@ -105,12 +105,12 @@ class FdEntity
 
         void Close(int fd);
         bool IsOpen() const { return (-1 != physical_fd); }
-        bool FindPseudoFd(int fd, bool lock_already_held = false);
+        bool FindPseudoFd(int fd, AutoLock::Type locktype = AutoLock::NONE);
         int Open(const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, AutoLock::Type type);
         bool LoadAll(int fd, headers_t* pmeta = NULL, off_t* size = NULL, bool force_load = false);
-        int Dup(int fd, bool lock_already_held = false);
-        int OpenPseudoFd(int flags = O_RDONLY, bool lock_already_held = false);
-        int GetOpenCount(bool lock_already_held = false);
+        int Dup(int fd, AutoLock::Type locktype = AutoLock::NONE);
+        int OpenPseudoFd(int flags = O_RDONLY, AutoLock::Type locktype = AutoLock::NONE);
+        int GetOpenCount(AutoLock::Type locktype = AutoLock::NONE);
         const char* GetPath() const { return path.c_str(); }
         bool RenamePath(const std::string& newpath, std::string& fentmapkey);
         int GetPhysicalFd() const { return physical_fd; }
@@ -118,16 +118,16 @@ class FdEntity
         bool MergeOrgMeta(headers_t& updatemeta);
         int UploadPending(int fd, AutoLock::Type type);
 
-        bool GetStats(struct stat& st, bool lock_already_held = false);
-        int SetCtime(struct timespec time, bool lock_already_held = false);
-        int SetAtime(struct timespec time, bool lock_already_held = false);
-        int SetMCtime(struct timespec mtime, struct timespec ctime, bool lock_already_held = false);
+        bool GetStats(struct stat& st, AutoLock::Type locktype = AutoLock::NONE);
+        int SetCtime(struct timespec time, AutoLock::Type locktype = AutoLock::NONE);
+        int SetAtime(struct timespec time, AutoLock::Type locktype = AutoLock::NONE);
+        int SetMCtime(struct timespec mtime, struct timespec ctime, AutoLock::Type locktype = AutoLock::NONE);
         bool UpdateCtime();
         bool UpdateAtime();
         bool UpdateMtime(bool clear_holding_mtime = false);
         bool UpdateMCtime();
-        bool SetHoldingMtime(struct timespec mtime, bool lock_already_held = false);
-        bool ClearHoldingMtime(bool lock_already_held = false);
+        bool SetHoldingMtime(struct timespec mtime, AutoLock::Type locktype = AutoLock::NONE);
+        bool ClearHoldingMtime(AutoLock::Type locktype = AutoLock::NONE);
         bool GetSize(off_t& size);
         bool GetXattr(std::string& xattr);
         bool SetXattr(const std::string& xattr);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2009

### Details
Replaced all `lock_already_held` flags with `AutoLock::Type`.