### PR TITLE
Support the object under no directory object path by compat_dir

### DIFF
--- a/src/curl_multi.h
+++ b/src/curl_multi.h
@@ -28,6 +28,7 @@ class S3fsCurl;
 
 typedef std::vector<S3fsCurl*>       s3fscurllist_t;
 typedef bool (*S3fsMultiSuccessCallback)(S3fsCurl* s3fscurl, void* param);  // callback for succeed multi request
+typedef bool (*S3fsMultiNotFoundCallback)(S3fsCurl* s3fscurl, void* param); // callback for succeed multi request
 typedef S3fsCurl* (*S3fsMultiRetryCallback)(S3fsCurl* s3fscurl);            // callback for failure and retrying
 
 //----------------------------------------------
@@ -41,9 +42,11 @@ class S3fsMultiCurl
         s3fscurllist_t clist_all;  // all of curl requests
         s3fscurllist_t clist_req;  // curl requests are sent
 
-        S3fsMultiSuccessCallback SuccessCallback;
-        S3fsMultiRetryCallback   RetryCallback;
-        void*                    pSuccessCallbackParam;
+        S3fsMultiSuccessCallback   SuccessCallback;
+        S3fsMultiNotFoundCallback  NotFoundCallback;
+        S3fsMultiRetryCallback     RetryCallback;
+        void*                      pSuccessCallbackParam;
+        void*                      pNotFoundCallbackParam;
 
         pthread_mutex_t completed_tids_lock;
         std::vector<pthread_t> completed_tids;
@@ -62,8 +65,10 @@ class S3fsMultiCurl
         int GetMaxParallelism() { return maxParallelism; }
 
         S3fsMultiSuccessCallback SetSuccessCallback(S3fsMultiSuccessCallback function);
+        S3fsMultiNotFoundCallback SetNotFoundCallback(S3fsMultiNotFoundCallback function);
         S3fsMultiRetryCallback SetRetryCallback(S3fsMultiRetryCallback function);
         void* SetSuccessCallbackParam(void* param);
+        void* SetNotFoundCallbackParam(void* param);
         bool Clear() { return ClearEx(true); }
         bool SetS3fsCurlObject(S3fsCurl* s3fscurl);
         int Request();


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2022 

### Details
About #2022
If user uploads a file that includes a non-existent directory path from the aws command, etc., the stat information(`dir/` object) of the intermediate directory does not exist.
So s3fs can not list those directories.
However, user can access files by specifying a file path that includes a directory.
Specifying `compat_dir` does not change this phenomenon.

This fixes:
Fixed so that when `compat_dir` is specified, the directory can be listed even if the stat information(`dir/` object) of the intermediate directory does not exist.
I have added the test code, but a part of test has not been run because `compat_dir` is not included in the s3fs boot options(on the test).
However, my manual testing has been performed and it was succeed.
