### PR TITLE
Use man-page date instead of build date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -313,7 +313,7 @@ AC_COMPILE_IFELSE(
 dnl ----------------------------------------------
 dnl build date
 dnl ----------------------------------------------
-AC_SUBST([MAN_PAGE_DATE], [$(date +"%B %Y")])
+AC_SUBST([MAN_PAGE_DATE], [$(date -r doc/man/s3fs.1.in +"%B %Y")])
 
 dnl ----------------------------------------------
 dnl output files


### PR DESCRIPTION
### Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

### Details
Use man-page date instead of build date
to allow for reproducible builds of `s3fs.1`

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).