### PR TITLE
Added support for xattr as POSIX ACL

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -1309,6 +1309,196 @@ function test_rm_rf_dir {
    fi
 }
 
+function test_posix_acl {
+    describe "Testing posix acl function ..."
+
+    #------------------------------------------------------
+    # Directory
+    #------------------------------------------------------
+    local POSIX_ACL_TEST_DIR1="posix_acl_dir1"
+    local POSIX_ACL_TEST_DIR2="posix_acl_dir2"
+    mkdir "${POSIX_ACL_TEST_DIR1}"
+
+    #
+    # Set posix acl(not default)
+    #
+    setfacl -m "u:${USER}:rwx" "${POSIX_ACL_TEST_DIR1}"
+    if ! getfacl "${POSIX_ACL_TEST_DIR1}" | grep -q "^user:${USER}:rwx"; then
+       echo "Could not set posix acl(not default) to ${POSIX_ACL_TEST_DIR1} directory"
+       return 1
+    fi
+
+    #
+    # Set posix acl(default)
+    #
+    setfacl -d -m "u:${USER}:rwx" "${POSIX_ACL_TEST_DIR1}"
+    if ! getfacl "${POSIX_ACL_TEST_DIR1}" | grep -q "^default:user:${USER}:rwx"; then
+       echo "Could not set posix acl(default) to ${POSIX_ACL_TEST_DIR1} directory"
+       return 1
+    fi
+
+    #
+    # Rename
+    #
+    mv "${POSIX_ACL_TEST_DIR1}" "${POSIX_ACL_TEST_DIR2}"
+    if ! getfacl "${POSIX_ACL_TEST_DIR2}" | grep -q "^user:${USER}:rwx"; then
+       echo "Could not move with posix acl(not default) to ${POSIX_ACL_TEST_DIR2} directory"
+       return 1
+    fi
+    if ! getfacl "${POSIX_ACL_TEST_DIR2}" | grep -q "^default:user:${USER}:rwx"; then
+       echo "Could not move with posix acl(default) to ${POSIX_ACL_TEST_DIR2} directory"
+       return 1
+    fi
+
+    #
+    # Copy with permission
+    #
+    cp -rp "${POSIX_ACL_TEST_DIR2}" "${POSIX_ACL_TEST_DIR1}"
+    if ! getfacl "${POSIX_ACL_TEST_DIR1}" | grep -q "^user:${USER}:rwx"; then
+       echo "Could not copy with posix acl(not default) to ${POSIX_ACL_TEST_DIR1} directory"
+       return 1
+    fi
+    if ! getfacl "${POSIX_ACL_TEST_DIR1}" | grep -q "^default:user:${USER}:rwx"; then
+       echo "Could not copy with posix acl(default) to ${POSIX_ACL_TEST_DIR1} directory"
+       return 1
+    fi
+
+    #
+    # Overwrite posix acl(not default)
+    #
+    setfacl -m "u:${USER}:r-x" "${POSIX_ACL_TEST_DIR2}"
+    if ! getfacl "${POSIX_ACL_TEST_DIR2}" | grep -q "^user:${USER}:r-x"; then
+       echo "Could not set posix acl(not default) to ${POSIX_ACL_TEST_DIR2} directory"
+       return 1
+    fi
+
+    #
+    # Overwrite posix acl(default)
+    #
+    setfacl -d -m "u:${USER}:r-x" "${POSIX_ACL_TEST_DIR2}"
+    if ! getfacl "${POSIX_ACL_TEST_DIR2}" | grep -q "^default:user:${USER}:r-x"; then
+       echo "Could not set posix acl(default) to ${POSIX_ACL_TEST_DIR2} directory"
+       return 1
+    fi
+
+    #
+    # Remove posix acl(default)
+    #
+    setfacl -k "${POSIX_ACL_TEST_DIR2}"
+    if getfacl "${POSIX_ACL_TEST_DIR2}" | grep -q "^default:user:${USER}"; then
+       echo "Could not remove posix acl(default) to ${POSIX_ACL_TEST_DIR2} directory"
+       return 1
+    fi
+
+    #
+    # Remove posix acl(all)
+    #
+    setfacl -b "${POSIX_ACL_TEST_DIR2}"
+    if getfacl "${POSIX_ACL_TEST_DIR2}" | grep -q "^user:${USER}"; then
+       echo "Could not remove posix acl(all) to ${POSIX_ACL_TEST_DIR2} directory"
+       return 1
+    fi
+
+    #
+    # Copy without permission
+    #
+    rm -rf "${POSIX_ACL_TEST_DIR2}"
+    cp -r "${POSIX_ACL_TEST_DIR1}" "${POSIX_ACL_TEST_DIR2}"
+    if getfacl "${POSIX_ACL_TEST_DIR2}" | grep -q "^default:user:${USER}"; then
+       echo "Could not copy without posix acl(default) to ${POSIX_ACL_TEST_DIR2} directory"
+       return 1
+    fi
+    if getfacl "${POSIX_ACL_TEST_DIR2}" | grep -q "^user:${USER}"; then
+       echo "Could not copy without posix acl(all) to ${POSIX_ACL_TEST_DIR2} directory"
+       return 1
+    fi
+
+    #------------------------------------------------------
+    # File
+    #------------------------------------------------------
+    local POSIX_ACL_TEST_FILE1="posix_acl_dir1/posix_acl_file1"
+    local POSIX_ACL_TEST_FILE2="posix_acl_dir1/posix_acl_file2"
+    local POSIX_ACL_TEST_FILE3="posix_acl_dir2/posix_acl_file3"
+    local POSIX_ACL_TEST_FILE4="posix_acl_dir2/posix_acl_file4"
+    mkdir "${POSIX_ACL_TEST_DIR2}"
+    touch "${POSIX_ACL_TEST_FILE1}"
+
+    #
+    # Check default inherited posix acl
+    #
+    if ! getfacl "${POSIX_ACL_TEST_FILE1}" | grep -q "^user:${USER}:rwx"; then
+       echo "Could not set posix acl(inherited default) to ${POSIX_ACL_TEST_FILE1} file"
+       return 1
+    fi
+
+    #
+    # Overwrite posix acl
+    #
+    setfacl -m "u:${USER}:r-x" "${POSIX_ACL_TEST_FILE1}"
+    if ! getfacl "${POSIX_ACL_TEST_FILE1}" | grep -q "^user:${USER}:r-x"; then
+       echo "Could not overwrite posix acl to ${POSIX_ACL_TEST_FILE1} file"
+       return 1
+    fi
+
+    #
+    # Rename
+    #
+    mv "${POSIX_ACL_TEST_FILE1}" "${POSIX_ACL_TEST_FILE2}"
+    if ! getfacl "${POSIX_ACL_TEST_FILE2}" | grep -q "^user:${USER}:r-x"; then
+       echo "Could not move with posix acl to ${POSIX_ACL_TEST_FILE2} file"
+       return 1
+    fi
+
+    #
+    # Copy with permission
+    #
+    cp -p "${POSIX_ACL_TEST_FILE2}" "${POSIX_ACL_TEST_FILE1}"
+    if ! getfacl "${POSIX_ACL_TEST_FILE1}" | grep -q "^user:${USER}:r-x"; then
+       echo "Could not copy with posix acl to ${POSIX_ACL_TEST_FILE1} file"
+       return 1
+    fi
+
+    #
+    # Remove posix acl
+    #
+    setfacl -b "${POSIX_ACL_TEST_FILE2}"
+    if getfacl "${POSIX_ACL_TEST_FILE2}" | grep -q "^default:user:${USER}"; then
+       echo "Could not remove posix acl to ${POSIX_ACL_TEST_FILE2} file"
+       return 1
+    fi
+
+    #
+    # Copy without permission(set parent directory default acl)
+    #
+    rm -f "${POSIX_ACL_TEST_FILE2}"
+    cp "${POSIX_ACL_TEST_FILE1}" "${POSIX_ACL_TEST_FILE2}"
+    if ! getfacl "${POSIX_ACL_TEST_FILE2}" | grep -q "^user:${USER}:rwx"; then
+       echo "Could not copy without posix acl(inherited parent) to ${POSIX_ACL_TEST_FILE2} file"
+       return 1
+    fi
+
+    #
+    # Copy with permission(to no-acl directory)
+    #
+    cp -p "${POSIX_ACL_TEST_FILE1}" "${POSIX_ACL_TEST_FILE3}"
+    if ! getfacl "${POSIX_ACL_TEST_FILE3}" | grep -q "^user:${USER}:r-x"; then
+       echo "Could not copy with posix acl to ${POSIX_ACL_TEST_FILE3} file in no-acl directory"
+       return 1
+    fi
+
+    #
+    # Copy without permission(to no-acl directory)
+    #
+    cp "${POSIX_ACL_TEST_FILE1}" "${POSIX_ACL_TEST_FILE4}"
+    if getfacl "${POSIX_ACL_TEST_FILE4}" | grep -q "^user:${USER}"; then
+       echo "Could not copy without posix acl to ${POSIX_ACL_TEST_FILE4} file in no-acl directory"
+       return 1
+    fi
+
+    rm -rf "${POSIX_ACL_TEST_DIR1}"
+    rm -rf "${POSIX_ACL_TEST_DIR2}"
+}
+
 function test_copy_file {
    describe "Test simple copy ..."
 
@@ -1764,8 +1954,8 @@ function test_not_existed_dir_obj() {
         # with "compat_dir", found directories and files
         #
 
-		# Top directory
-		# shellcheck disable=SC2010
+        # Top directory
+        # shellcheck disable=SC2010
         if ! ls -1 | grep -q '^not_existed_dir_single$'; then
             echo "Expect to find \"not_existed_dir_single\" directory, but it is not found"
             return 1;
@@ -1776,8 +1966,8 @@ function test_not_existed_dir_obj() {
             return 1;
         fi
 
-		# Single nest directory
-		# shellcheck disable=SC2010
+        # Single nest directory
+        # shellcheck disable=SC2010
         if ! ls -d not_existed_dir_single | grep -q '^not_existed_dir_single$'; then
             echo "Expect to find \"not_existed_dir_single\" directory, but it is not found"
             return 1;
@@ -1793,8 +1983,8 @@ function test_not_existed_dir_obj() {
             return 1;
         fi
 
-		# Double nest directory
-		# shellcheck disable=SC2010
+        # Double nest directory
+        # shellcheck disable=SC2010
         if ! ls -d not_existed_dir_parent | grep -q '^not_existed_dir_parent'; then
             echo "Expect to find \"not_existed_dir_parent\" directory, but it is not found"
             return 1;
@@ -1820,8 +2010,8 @@ function test_not_existed_dir_obj() {
             return 1;
         fi
 
-	    rm -rf not_existed_dir_single
-	    rm -rf not_existed_dir_parent
+        rm -rf not_existed_dir_single
+        rm -rf not_existed_dir_parent
 
     else
         #
@@ -1832,8 +2022,8 @@ function test_not_existed_dir_obj() {
         # And if specify a file full path, it will be found.
         #
 
-		# Top directory
-		# shellcheck disable=SC2010
+        # Top directory
+        # shellcheck disable=SC2010
         if ls -1 | grep -q '^not_existed_dir_single$'; then
             echo "Expect to not find \"not_existed_dir_single\" directory, but it is found"
             return 1;
@@ -1844,8 +2034,8 @@ function test_not_existed_dir_obj() {
             return 1;
         fi
 
-		# Single nest directory
-		# shellcheck disable=SC2010
+        # Single nest directory
+        # shellcheck disable=SC2010
         if ! ls -d not_existed_dir_single | grep -q '^not_existed_dir_single$'; then
             echo "Expect to find \"not_existed_dir_single\" directory, but it is not found"
             return 1;
@@ -1861,8 +2051,8 @@ function test_not_existed_dir_obj() {
             return 1;
         fi
 
-		# Double nest directory
-		# shellcheck disable=SC2010
+        # Double nest directory
+        # shellcheck disable=SC2010
         if ! ls -d not_existed_dir_parent | grep -q '^not_existed_dir_parent'; then
             echo "Expect to find \"not_existed_dir_parent\" directory, but it is not found"
             return 1;
@@ -1888,11 +2078,11 @@ function test_not_existed_dir_obj() {
             return 1;
         fi
 
-	    rm -rf not_existed_dir_single
+        rm -rf not_existed_dir_single
 
         # [NOTE]
         # This case could not remove sub directory, then below command will be failed.
-    	#rm -rf not_existed_dir_parent
+        #rm -rf not_existed_dir_parent
     fi
 }
 
@@ -2189,6 +2379,11 @@ function add_all_tests {
     fi
     add_tests test_update_directory_time_subdir
     add_tests test_update_chmod_opened_file
+
+    # shellcheck disable=SC2009
+    if ! ps u -p "${S3FS_PID}" | grep -q use_xattr; then
+        add_tests test_posix_acl
+    fi
 
     add_tests test_rm_rf_dir
     add_tests test_copy_file

--- a/test/small-integration-test.sh
+++ b/test/small-integration-test.sh
@@ -42,7 +42,7 @@ export CACHE_DIR
 export ENSURE_DISKFREE_SIZE 
 if [ -n "${ALL_TESTS}" ]; then
     FLAGS=(
-        "use_cache=${CACHE_DIR} -o ensure_diskfree=${ENSURE_DISKFREE_SIZE} -o fake_diskfree=${FAKE_FREE_DISK_SIZE}"
+        "use_cache=${CACHE_DIR} -o ensure_diskfree=${ENSURE_DISKFREE_SIZE} -o fake_diskfree=${FAKE_FREE_DISK_SIZE} -o use_xattr"
         enable_content_md5
         disable_noobj_cache
         "max_stat_cache_size=100"


### PR DESCRIPTION
### Relevant Issue (if applicable)
#775 #2033

### Details
s3fs' xattr support only worked as Extended attributes.(such as setxattr)
We did not implement the function as `POSIX ACL` pointed out in the issues, so I implemented this.(such as setfacl)

I have also created a test script and it is passing the test without any issues.
