### PR TITLE
Updated actions/checkout for gha from v2 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           if [ "${{ matrix.container }}" = "opensuse/leap:15" ]; then zypper install -y tar gzip; fi
 
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # [NOTE]
       # Matters that depend on OS:VERSION are determined and executed in the following script.
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Brew tap
         run: |


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Github Actions has the following warning, so I upgraded the version of `actions/checkout.`
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout
```
