### PR TITLE
Use cache to improve readdir performance

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_CHECK_HEADERS([attr/xattr.h])
 AC_CHECK_HEADERS([sys/extattr.h])
 AC_CHECK_FUNCS([fallocate])
 
-CXXFLAGS="$CXXFLAGS -Wall -fno-exceptions -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2"
+CXXFLAGS="$CXXFLAGS -Wall -fno-exceptions -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -std=c++11"
 
 dnl ----------------------------------------------
 dnl For macOS


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2051

### Details
When a directory has a lot of files, `s3fs_readdir` will take a lot of time because of `list_bucket` and `readdir_multi_head` is time-consuming. One possible solution is that we maintain a map of the path and files under that path, and files stat information should also be cached. When we `readdir` from a certain path, we can get data from the map instead of sending request to s3.

However, there are two defects. Firstly, files should only be modified via `s3fs`, any modification on s3 server will not change the map. In other words, files are read only on s3. Secondly, map is not the best way because when we reboot the server, data will disappear, maybe we could use a database to store it.
