### PR TITLE
Fixed a bug when end of path for mount point is multi slash

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4179,10 +4179,8 @@ static int set_bucket(const char* arg)
                 return -1;
             }
             mount_prefix = pmount_prefix;
-            // remove trailing slash
-            if(mount_prefix[mount_prefix.size() - 1] == '/'){
-                mount_prefix.erase(mount_prefix.size() - 1);
-            }
+            // Trim the last consecutive '/'
+            mount_prefix = trim_right(mount_prefix, "/");
         }
     }else{
         if(!S3fsCred::SetBucket(arg)){


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2016

### Details
s3fs expects that the last character of the path is not `/` when the mount point is specified by `<bucket name> + <path(ex. /path)>`.
If a charactor `/` terminated path(ex. '/path/') will be specified, it will be excluded during option parsing.
But  there was a bug that multiple `/` terminated path(ex. `/path//`).
This PR fixed this bug.

- Impact of this bug
If `/path//` and a mount point were specified, the files under the mount point were invisible.  
(Because it searches the path `<bucket>/path//`)  
Also, although files can be manipulated, a file with a path that s3fs cannot recognize has been created.  
For example, creating a file named `sample` with this mount point created a file named /path//sample`.  

In addition, I think that there were very few cases where the mount point was specified as `path//`, so I imagine that there is almost no impact on users.
