### PR TITLE
Added Fedora:37 and RockyLinux:9 to Github Actions target OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,10 @@ jobs:
           - ubuntu:18.04
           - debian:bullseye
           - debian:buster
+          - rockylinux:9
           - rockylinux:8
           - centos:centos7
+          - fedora:37
           - fedora:36
           - opensuse/leap:15
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Added `Fedora:37` and `RockyLinux:9` to Github Actions runner OS.
Also, since ShellCheck was not implemented(unused) in `RockyLinux:8`, I made it possible to run it on both RockyLinux 8 and 9.