### PR TITLE
Compatible with OpenSSL 3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,7 @@ dnl Choice SSL library
 dnl ----------------------------------------------
 auth_lib=na
 nettle_lib=no
+use_openssl_30=no
 
 dnl
 dnl nettle library
@@ -189,6 +190,14 @@ case "${auth_lib}" in
 openssl)
   AC_MSG_RESULT(OpenSSL)
   PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 libcrypto >= 0.9 ])
+  AC_MSG_CHECKING([openssl 3.0 or later])
+  AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([[#include <openssl/opensslv.h>
+                       #if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x30000000L
+                         #error "found openssl is 3.0 or later(so compiling is stopped with error)"
+                       #endif]], [[]])],
+    [AC_MSG_RESULT(no)],
+    [AC_MSG_RESULT(yes); use_openssl_30=yes])
   ;;
 gnutls)
   AC_MSG_RESULT(GnuTLS-gcrypt)
@@ -228,6 +237,7 @@ nss)
 esac
 
 AM_CONDITIONAL([USE_SSL_OPENSSL], [test "$auth_lib" = openssl])
+AM_CONDITIONAL([USE_SSL_OPENSSL_30], [test "$use_openssl_30" = yes])
 AM_CONDITIONAL([USE_SSL_GNUTLS], [test "$auth_lib" = gnutls -o "$auth_lib" = nettle])
 AM_CONDITIONAL([USE_GNUTLS_NETTLE], [test "$auth_lib" = nettle])
 AM_CONDITIONAL([USE_SSL_NSS], [test "$auth_lib" = nss])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,6 +23,9 @@ AM_CPPFLAGS = $(DEPS_CFLAGS)
 if USE_GNUTLS_NETTLE
     AM_CPPFLAGS += -DUSE_GNUTLS_NETTLE
 endif
+if USE_SSL_OPENSSL_30
+    AM_CPPFLAGS += -DUSE_OPENSSL_30
+endif
 
 s3fs_SOURCES = \
     s3fs.cpp \
@@ -108,6 +111,6 @@ clang-tidy:
 # tab-width: 4
 # c-basic-offset: 4
 # End:
-# vim600: expandtab sw=4 ts= fdm=marker
-# vim<600: expandtab sw=4 ts=4
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2061

### Details
Fixed the warning that appeared when building OpenSSL 3.0.
MD5_*** and etc has been deprecated and cased to use EVP.
