### PR TITLE
Fixed a warning by compiling on fedora 37

### DIFF
--- a/src/s3fs_logger.cpp
+++ b/src/s3fs_logger.cpp
@@ -212,13 +212,12 @@ bool S3fsLog::LowSetLogfile(const char* pfile)
 
         // switch new log file and close old log file if it is opened
         FILE*    oldfp = S3fsLog::logfp;
-        S3fsLog::logfp = newfp;
         if(oldfp && 0 != fclose(oldfp)){
             S3FS_PRN_ERR("Could not close old log file(%s).", (S3fsLog::plogfile ? S3fsLog::plogfile->c_str() : "null"));
-            S3fsLog::logfp = oldfp;
             fclose(newfp);
             return false;
         }
+        S3fsLog::logfp = newfp;
         delete S3fsLog::plogfile;
         S3fsLog::plogfile = new std::string(pfile);
     }


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
In Fedora:37 the following warning was printed when compiling.
The logic is that after the close fails, the file descriptor that s3fs tried to close is accessed, so there should be no problem, but the warning can be eliminated by changing the description, so I fixed it.
```
s3fs_logger.cpp: In member function 'bool S3fsLog::LowSetLogfile(const char*)':
s3fs_logger.cpp:218:28: warning: pointer 'oldfp' may be used after 'int fclose(FILE*)' [-Wuse-after-free]
  218 |             S3fsLog::logfp = oldfp;
      |             ~~~~~~~~~~~~~~~^~~~~~~
s3fs_logger.cpp:216:32: note: call to 'int fclose(FILE*)' here
  216 |         if(oldfp && 0 != fclose(oldfp)){
      |                          ~~~~~~^~~~~~~
```
