### PR TITLE
Retry BucketCheck containing directory paths

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3529,10 +3529,13 @@ int S3fsCurl::GetObjectRequest(const char* tpath, int fd, off_t start, off_t siz
     return result;
 }
 
-int S3fsCurl::CheckBucket()
+int S3fsCurl::CheckBucket(const char* check_path)
 {
     S3FS_PRN_INFO3("check a bucket.");
 
+    if(!check_path || 0 == strlen(check_path)){
+        return -EIO;
+    }
     if(!CreateCurlHandle()){
         return -EIO;
     }
@@ -3541,13 +3544,14 @@ int S3fsCurl::CheckBucket()
         query_string = "list-type=2";
         urlargs = "?" + query_string;
     }
+
     std::string resource;
     std::string turl;
-    MakeUrlResource("/", resource, turl);
+    MakeUrlResource(check_path, resource, turl);
 
     turl           += urlargs;
     url             = prepare_url(turl.c_str());
-    path            = "/";  // Only check the presence of the bucket, not the entire virtual path.
+    path            = check_path;
     requestHeaders  = NULL;
     responseHeaders.clear();
     bodydata.Clear();

--- a/src/curl.h
+++ b/src/curl.h
@@ -352,7 +352,7 @@ class S3fsCurl
         int PutRequest(const char* tpath, headers_t& meta, int fd);
         int PreGetObjectRequest(const char* tpath, int fd, off_t start, off_t size, sse_type_t ssetype, const std::string& ssevalue);
         int GetObjectRequest(const char* tpath, int fd, off_t start = -1, off_t size = -1);
-        int CheckBucket();
+        int CheckBucket(const char* check_path);
         int ListBucketRequest(const char* tpath, const char* query);
         int PreMultipartPostRequest(const char* tpath, headers_t& meta, std::string& upload_id, bool is_copy);
         int CompleteMultipartPostRequest(const char* tpath, const std::string& upload_id, etaglist_t& parts);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2063 #1728 #1687 #1460

### Details
Fixed a bug where a bucket has no permissions and a directory has permissions, and a mount with that directory fails.
This PR is related to #1728 which was previously fixed.

#### Specification
Here's a bucket check on s3fs startup and a description of how it works in this PR.

The following patterns for mount point are supported by s3fs:

1. Mount the bucket top
2. Mount the directory(folder) under the bucket. In this case, there are the following cases:
(   2A) Directories created by clients other than s3fs
(   2B) Directory created by s3fs


At first, if user has access to the bucket, the checking access to the bucket succeeds and this function returns success.
However, if user does not have access to the bucket and has permissions to the directory, this first check will fail.
But if user specifies the directory for mount point, this function retries to check with the path containing the directory.
And it will be success.

In the case of (2A), the check will succeed if the bucket allows to access, but will fail if permissions are granted only to the directory, as it is not a directory recognized by s3fs.
This combination is not supported by s3fs, so make sure user create the directory before starting s3fs.
In case (2B), if user does not have access to bucket, the first check(to bucket) fails, but the retry check(with path) succeeds.
