### PR TITLE
Fixed a deadlock bug when specifying iam role(IAMv2)

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2885,6 +2885,9 @@ int S3fsCurl::GetIAMv2ApiToken(const char* token_url, int token_ttl, const char*
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
         return -EIO;
     }
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_INFILESIZE, 0)){
+        return false;
+    }
     if(!S3fsCurl::AddUserAgent(hCurl)){                            // put User-Agent
         return -EIO;
     }


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2098 

### Details
When IAM role was specified(IAMv2), there was a deadlock in token acquisition.

This logic is communicating with the HTTP PUT method, but since `Content-Length=0` was not specified (`Transfer-Encoding: chunked` is specified), it was deadlocked while waiting for a response.

- Before fixing(deadlocked)  
```
PUT /latest/api/token HTTP/1.1
Host: 169.254.169.254
User-Agent: s3fs/1.91 (commit hash 16bc449; OpenSSL)
Accept: */*
Transfer-Encoding: chunked
X-aws-ec2-metadata-token-ttl-seconds: 21600
```

- After fixing  
```
PUT /latest/api/token HTTP/1.1
Host: 169.254.169.254
User-Agent: s3fs/1.91 (commit hash b5ffcac; OpenSSL)
Accept: */*
X-aws-ec2-metadata-token-ttl-seconds: 21600
Content-Length: 0
```


