### PR TITLE
Updated files for support ALPINE v3.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           - fedora:37
           - fedora:36
           - opensuse/leap:15
+          - alpine:3.17
 
     container:
       image: ${{ matrix.container }}

--- a/autogen.sh
+++ b/autogen.sh
@@ -33,7 +33,8 @@ echo "--- Finished commit hash file ---"
 
 echo "--- Start autotools -------------"
 
-aclocal \
+autoupdate \
+&& aclocal \
 && autoheader \
 && automake --add-missing \
 && autoconf
@@ -47,6 +48,6 @@ exit 0
 # tab-width: 4
 # c-basic-offset: 4
 # End:
-# vim600: expandtab sw=4 ts= fdm=marker
+# vim600: expandtab sw=4 ts=4 fdm=marker
 # vim<600: expandtab sw=4 ts=4
 #

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1957,6 +1957,9 @@ bool S3fsCurl::ResetHandle(AutoLock::Type locktype)
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_NOPROGRESS, 0)){
         return false;
     }
+    // [NOTE]
+    // CURLOPT_PROGRESSFUNCTION should be changed to CURLOPT_XFERINFOFUNCTION,
+    // but CnetOS7's curl version is old, so it haven't been changed yet.
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_PROGRESSFUNCTION, S3fsCurl::CurlProgress)){
         return false;
     }
@@ -3020,7 +3023,7 @@ int S3fsCurl::GetIAMv2ApiToken(const char* token_url, int token_ttl, const char*
     // Expect header is empty before the request is sent.
     requestHeaders = curl_slist_sort_insert(requestHeaders, "Expect", "");
 
-    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_PUT, true)){
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_UPLOAD, true)){
         return -EIO;
     }
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2046 #2110

### Details
Enabled to execute Github Actions(CI) for ALPINE(v3.17).

This change includes the following changes:
#### `linux-ci-helper.sh`
Changed from `bash` to `sh`. (because the initial image of ALPINE does not include `bash`)
Created a condition for ALPINE and made modifications accordingly.

#### `autogen.sh`
ALPINE's `autoconf` is new and needs to be updated in `configure.ac`.
However, some supported older OS's don't support the new KEYWORDS in configure.ac, so I've added `autoupdated` for it.

#### `curl.cpp`
Changed `CURLOPT_PUT` to `CURLOPT_UPLOAD`.
`CURLOPT_PROGRESSFUNCTION` should be changed to `CURLOPT_XFERINFOFUNCTION`, but it was not changed because we have an OS that uses old curl.
Compiling on ALPINE will output a warning, which can be ignored.

#### integration-test-main.sh
In ALPINE, the `ENOTSUP` error is output as `Not supported` instead of `Operation not supported`, so it have been fixed.
`test_overwrite_existing_file_range` was doing file comparison with redirection, which often failed in ALPINE.
This error has been eliminated by creating a real file for this comparison, so this has been fixed.
(This fix does not affect testing.)