### PR TITLE
Fixed segmentation fault caused by file write failure

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -449,7 +449,7 @@ bool StatCache::UpdateMetaStats(const std::string& key, headers_t& meta)
     SetStatCacheTime(ent->cache_date);
 
     // Update only mode
-    ent->stbuf.st_mode = get_mode(meta);
+    ent->stbuf.st_mode = get_mode(meta, key);
 
     return true;
 }

--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -125,7 +125,7 @@ mode_t get_mode(const char *s, int base)
     return static_cast<mode_t>(cvt_strtoofft(s, base));
 }
 
-mode_t get_mode(const headers_t& meta, const char* path, bool checkdir, bool forcedir)
+mode_t get_mode(const headers_t& meta, const std::string& strpath, bool checkdir, bool forcedir)
 {
     mode_t mode     = 0;
     bool   isS3sync = false;
@@ -141,7 +141,7 @@ mode_t get_mode(const headers_t& meta, const char* path, bool checkdir, bool for
     }else{
         // If another tool creates an object without permissions, default to owner
         // read-write and group readable.
-        mode = path[strlen(path) - 1] == '/' ? 0750 : 0640;
+        mode = (!strpath.empty() && '/' == *strpath.rbegin()) ? 0750 : 0640;
     }
 
     // Checking the bitmask, if the last 3 bits are all zero then process as a regular
@@ -163,7 +163,7 @@ mode_t get_mode(const headers_t& meta, const char* path, bool checkdir, bool for
                         if(strConType == "application/x-directory" || strConType == "httpd/unix-directory"){
                             // Nextcloud uses this MIME type for directory objects when mounting bucket as external Storage
                             mode |= S_IFDIR;
-                        }else if(path && 0 < strlen(path) && '/' == path[strlen(path) - 1]){
+                        }else if(!strpath.empty() && '/' == *strpath.rbegin()){
                             if(strConType == "binary/octet-stream" || strConType == "application/octet-stream"){
                                 mode |= S_IFDIR;
                             }else{

--- a/src/metaheader.h
+++ b/src/metaheader.h
@@ -46,7 +46,7 @@ struct timespec get_atime(const headers_t& meta, bool overcheck = true);
 off_t get_size(const char *s);
 off_t get_size(const headers_t& meta);
 mode_t get_mode(const char *s, int base = 0);
-mode_t get_mode(const headers_t& meta, const char* path = NULL, bool checkdir = false, bool forcedir = false);
+mode_t get_mode(const headers_t& meta, const std::string& strpath, bool checkdir = false, bool forcedir = false);
 uid_t get_uid(const char *s);
 uid_t get_uid(const headers_t& meta);
 gid_t get_gid(const char *s);


### PR DESCRIPTION
<!-- --------------------------------------------------------------------------
 Please describe the purpose of the pull request(such as resolving the issue)
 and what the fix/update is.
--------------------------------------------------------------------------- -->

### Relevant Issue (if applicable)
<!-- If there are Issues related to this PullRequest, please list it. -->

### Details
<!-- Please describe the details of PullRequest. -->
I am currently using  s3fs with minio. When I try to write a file with a name greater than 255 in s3fs, s3fs exit with segmentation fault. Because minio uses an xfs file system that limits filename length to 255.

```
#0  0x00007f3ee1fbff4f in __strlen_sse42 () from /lib64/libc.so.6
Python Exception <type 'exceptions.ValueError'> Cannot find type const headers_t::_Rep_type:
#1  0x00000000004218a7 in get_mode (meta=std::map with 5 elements, path=path@entry=0x0, checkdir=checkdir@entry=false,
    forcedir=forcedir@entry=false) at metaheader.cpp:144
#2  0x000000000043ec11 in StatCache::UpdateMetaStats (this=<optimized out>,
    key="/host_e8b47009f661-host_diskio_used_percent_az_id_6fcabee9_f323_4904_9799_073ad3e552a3_cloud_id_6398743040_cluster_id_6398730244_device_sda1_instance_7009f65e_e8b4_b14f_eb11_5087b07a8c47_region_id_84c"..., meta=std::map with 5 elements = {...})
    at cache.cpp:452
#3  0x000000000041713a in s3fs_utimens (_path=<optimized out>, ts=<optimized out>) at s3fs.cpp:2215
#4  0x00007f3ee36cac2f in fuse_fs_utimens () from /lib64/libfuse.so.2
#5  0x00007f3ee36ccc1d in fuse_lib_setattr () from /lib64/libfuse.so.2
#6  0x00007f3ee36d142e in do_setattr () from /lib64/libfuse.so.2
#7  0x00007f3ee36d1bcb in fuse_ll_process_buf () from /lib64/libfuse.so.2
#8  0x00007f3ee36ce461 in fuse_do_work () from /lib64/libfuse.so.2
#9  0x00007f3ee224eea5 in start_thread () from /lib64/libpthread.so.0
#10 0x00007f3ee1f77b0d in clone () from /lib64/libc.so.6
```
