### PR TITLE
Added cache clearing on upload error

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1446,6 +1446,14 @@ int FdEntity::RowFlush(int fd, const char* tpath, AutoLock::Type type, bool forc
         result = RowFlushMultipart(pseudo_obj, tpath);
     }
 
+    // [NOTE]
+    // if something went wrong, so if you are using a cache file,
+    // the cache file may not be correct. So delete cache files.
+    //
+    if(0 != result && !cachepath.empty()){
+        FdManager::DeleteCacheFile(tpath);
+    }
+
     return result;
 }
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2120

### Details
After an error occurred on the server side during file upload(Flush) processing, there are reports(#2120) that the contents of the file cannot be read correctly.

If the upload fails in an environment that uses cache, the local cache may have been updated even though the object on the server side has not been updated.
Even in this state, subsequent reading may be performed normally (maybe reloading due to inconsistency in stat information), but Issue #2120 seems to cause inconsistency.

If the upload fails, the local cache is in a correct state (not matching the server side) and cannot be repaired.
Therefore, I modified it to clear the cache if it fails.

@gaul 
Since this PR only clears the cache, I think it won't impact anything else.
So, if the tests pass, I think I'll merge this PR in no time(probably after issuer's review).
If you have any problems please let me know.
