### PR TITLE
Fixed a bug when reading a reduced file without flushing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ config.status
 config.sub
 configure
 configure.scan
+configure.ac~
 depcomp
 install-sh
 libtool
@@ -86,6 +87,7 @@ test/junk_data
 test/s3proxy-*
 test/write_multiblock
 test/mknod_test
+test/truncate_read_file
 
 #
 # Windows ports

--- a/src/fdcache_page.cpp
+++ b/src/fdcache_page.cpp
@@ -456,7 +456,13 @@ bool PageList::Resize(off_t size, bool is_loaded, bool is_modified)
     off_t total = Size();
 
     if(0 == total){
+        // [NOTE]
+        // The is_shrink flag remains unchanged in this function.
+        //
+        bool backup_is_shrink = is_shrink;
+
         Init(size, is_loaded, is_modified);
+        is_shrink = backup_is_shrink;
 
     }else if(total < size){
         // add new area

--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -245,7 +245,7 @@ gid_t get_gid(const headers_t& meta)
 
 blkcnt_t get_blocks(off_t size)
 {
-    return size / 512 + 1;
+    return (size / 512) + (0 == (size % 512) ? 0 : 1);
 }
 
 time_t cvtIAMExpireStringToTime(const char* s)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -32,11 +32,13 @@ testdir = test
 noinst_PROGRAMS = \
     junk_data \
     write_multiblock \
-    mknod_test
+    mknod_test \
+    truncate_read_file
 
-junk_data_SOURCES = junk_data.c
-write_multiblock_SOURCES = write_multiblock.cc
-mknod_test_SOURCES = mknod_test.c
+junk_data_SOURCES          = junk_data.c
+write_multiblock_SOURCES   = write_multiblock.cc
+mknod_test_SOURCES         = mknod_test.c
+truncate_read_file_SOURCES = truncate_read_file.c
 
 #
 # Local variables:

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -112,6 +112,28 @@ function test_truncate_shrink_file {
     rm_test_file "${BIG_TRUNCATE_TEST_FILE}"
 }
 
+function test_truncate_shrink_read_file {
+    describe "Testing truncate(shrink) and read file ..."
+
+    # Initiate file size is 1024, and shrink file size is 512
+    local init_size=1024
+    local shrink_size=512
+
+    # create file
+    dd if=/dev/urandom of="${TEST_TEXT_FILE}" bs="${init_size}" count=1
+
+    # truncate(shrink) file and read it before flusing
+    ../../truncate_read_file "${TEST_TEXT_FILE}" "${shrink_size}"
+
+    # check file size
+    check_file_size "${TEST_TEXT_FILE}" "${shrink_size}"
+
+    # Truncate the file to 1024 length
+    local t_size=1024
+
+    rm_test_file
+}
+
 function test_mv_file {
     describe "Testing mv file function ..."
     # if the rename file exists, delete it
@@ -2610,6 +2632,7 @@ function add_all_tests {
     add_tests test_truncate_upload
     add_tests test_truncate_empty_file
     add_tests test_truncate_shrink_file
+    add_tests test_truncate_shrink_read_file
     add_tests test_mv_file
     add_tests test_mv_to_exist_file
     add_tests test_mv_empty_directory

--- a/test/truncate_read_file.c
+++ b/test/truncate_read_file.c
@@ -1,0 +1,81 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2021 Andrew Gaul <andrew@gaul.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+// [NOTE]
+// This is a program used for file size inspection.
+// File size checking should be done by the caller of this program.
+// This program truncates the file and reads the file in another process
+// between truncate and flush(close file).
+//
+int main(int argc, char *argv[])
+{
+    if(argc != 3){
+        fprintf(stderr, "[ERROR] Wrong paraemters\n");
+        fprintf(stdout, "[Usage] truncate_read_file <file path> <truncate size(bytes)>\n");
+        exit(EXIT_FAILURE);
+    }
+
+    const char* filepath = argv[1];
+    off_t       size     = (off_t)strtoull(argv[2], NULL, 10);
+    int         fd;
+
+    // open file
+    if(-1 == (fd = open(filepath, O_RDWR))){
+        fprintf(stderr, "[ERROR] Could not open file(%s)\n", filepath);
+        exit(EXIT_FAILURE);
+    }
+
+    // truncate
+    if(0 != ftruncate(fd, size)){
+        fprintf(stderr, "[ERROR] Could not truncate file(%s) to %lld byte.\n", filepath, (long long)size);
+        close(fd);
+        exit(EXIT_FAILURE);
+    }
+
+    // run sub-process for reading file(cat)
+    char szCommand[1024];
+    sprintf(szCommand, "cat %s >/dev/null 2>&1", filepath);
+    if(0 != system(szCommand)){
+        fprintf(stderr, "[ERROR] Failed to run sub-process(cat).\n");
+        close(fd);
+        exit(EXIT_FAILURE);
+    }
+
+    // close file(flush)
+    close(fd);
+
+    exit(EXIT_SUCCESS);
+}
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2107 #2131
_This PR changed the fix method because #2131 was not enough fix._

### Bug details
There was a bug in trauncate, which shrinks files.

This bug occurs under the following conditions:
- Open the file and shrink the file.
- After shrinking, do read before flushing(do not close or sync).

At this time, it got the old size before shrinking from the server(Content-Length) and set old size again.
So that the read data from the reduced size to the original size padded as 0x00, and read it.
When read all of file, the read size is old length before reduction.

### Fixes
Changed so that when opening a file that has already been opened and resized(without flushing), it is opened as the modified file size instead of the file size on the server side.

When reading(loading) a file, there was a problem that the modifying(shrink) flag was cleared after reading even though the file was reduced.
Therefore, there was a problem that flush(upload) of file size change did not occur, so it has been fixed.

Although it is not directly related to this case, there was a bug in the number of blocks used in the stat information, so it has been corrected.

I added C source code to test the condition that caused the failure and included it in this PR.
(Because it is difficult to realize with a shell script, I wrote it in C source)