### PR TITLE
Fixed configure.ac by autoupdate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,11 +19,11 @@
 ######################################################################
 dnl Process this file with autoconf to produce a configure script.
 
-AC_PREREQ(2.59)
-AC_INIT(s3fs, 1.91)
+AC_PREREQ([2.69])
+AC_INIT([s3fs],[1.91])
 AC_CONFIG_HEADER([config.h])
 
-AC_CANONICAL_SYSTEM
+AC_CANONICAL_TARGET
 AM_INIT_AUTOMAKE([foreign])
 
 AC_PROG_CXX


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2116 

### Details
We added `autoupdate` command to `autogen.sh` by #2116.
`autoupdate` will update `configure.ac` at build time if needed, but currently it always updates.
Therefore, this PR updates `configure.ac` as same as updating it by `autoupdate`.

