### PR TITLE
Changed to rename cache files when renaming large files

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1518,11 +1518,14 @@ static int rename_large_object(const char* from, const char* to)
     }
     s3fscurl.DestroyCurlHandle();
 
+    // Rename cache file
+    FdManager::get()->Rename(from, to);
+
     // Remove file
     result = s3fs_unlink(from);
 
+    // Stats
     StatCache::getStatCacheData()->DelStat(to);
-    FdManager::DeleteCacheFile(to);
 
     return result;
 }


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2128 #2130

### Details
Always deleted cache files when renaming large files(these files use multipart uploading).
The cache file for these files should have been renamed in the same way as for non-large files, so this PR changed it to rename the cache file.

This was revealed by the bug reported by #2128.

FUSE temporarily changes the file name to `/.fuse_hiddenXXXYYY` if the opened file is deleted by another process etc.
When the opened file is closed, this temporarily file is also deleted.
In #2128, the cache file was deleted without being renamed after renaming, so the cache filewhich under the mirror directory remained.
(Files under the mirror directory are for file descriptors used when opening files.)
