### PR TITLE
Fixed a bug about attributes of mount point

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -518,7 +518,7 @@ static int get_object_attribute(const char* path, struct stat* pstbuf, headers_t
 
     // set headers for mount point from default stat
     if(is_mountpoint){
-        if(0 != result){
+        if(0 != result || pheader->empty()){
             has_mp_stat = false;
 
             // [NOTE]


### PR DESCRIPTION
### Relevant Issue (if applicable)
A bug discovered by report #2138

### Details
In some cases, stats settings including `mp_umask`(`uid`, `gid`) for mountpoints could not be set.
This is due to the missing fix for #1964.
This problem cannot be inspected in the current test, so I checked it manually. (It is an option specified when starting s3fs, and this inspection is currently difficult.)

