### PR TITLE
Fix two inconsistency issues between stat cache and cache file

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -519,13 +519,18 @@ int FdEntity::Open(const headers_t* pmeta, off_t size, const struct timespec& ts
                 if(-1 == size){
                     if(st.st_size != pagelist.Size()){
                         pagelist.Resize(st.st_size, false, true); // Areas with increased size are modified
-                        need_save_csf = true;     // need to update page info
+                        need_save_csf = true;                     // need to update page info
                     }
                     size = st.st_size;
                 }else{
+                    // First if the current cache file size and pagelist do not match, fix pagelist.
+                    if(st.st_size != pagelist.Size()){
+                        pagelist.Resize(st.st_size, false, true); // Areas with increased size are modified
+                        need_save_csf = true;                     // need to update page info
+                    }
                     if(size != pagelist.Size()){
                         pagelist.Resize(size, false, true);       // Areas with increased size are modified
-                        need_save_csf = true;     // need to update page info
+                        need_save_csf = true;                     // need to update page info
                     }
                     if(size != st.st_size){
                         is_truncate = true;


### PR DESCRIPTION
### Details
    Mark pagelist as unloaded if cache file has been truncated

    If cache file size doesn't match object size, the cache file might be
    corrupted, so invalidate it and save new cache stat file.

---

    Fix inconsistency between stat cache file and cache file

    We unlock stat cache file too early in FdEntity::Open(), and would
    truncate cache file and update stat cache file, so there's a window that
    stat cache doesn't reflect cache file status.

