### PR TITLE
Allow mount points without directory objects by compat_dir

### DIFF
--- a/doc/man/s3fs.1.in
+++ b/doc/man/s3fs.1.in
@@ -372,6 +372,8 @@ s3fs supports two different naming schemas "dir/" and "dir" to map directory nam
 S3fs uses only the first schema "dir/" to create S3 objects for directories.
 .TP
 The support for these different naming schemas causes an increased communication effort.
+.TP
+If you do not have access permissions to the bucket and specify a directory path created by a client other than s3fs for the mount point, you cannot start because the mount point directory cannot be found by s3fs. But by specifying this option, you can avoid this error.
 .RE
 .TP
 \fB\-o\fR use_wtf8 - support arbitrary file system encoding.

--- a/src/curl.h
+++ b/src/curl.h
@@ -357,7 +357,7 @@ class S3fsCurl
         int PutRequest(const char* tpath, headers_t& meta, int fd);
         int PreGetObjectRequest(const char* tpath, int fd, off_t start, off_t size, sse_type_t ssetype, const std::string& ssevalue);
         int GetObjectRequest(const char* tpath, int fd, off_t start = -1, off_t size = -1);
-        int CheckBucket(const char* check_path);
+        int CheckBucket(const char* check_path, bool compat_dir);
         int ListBucketRequest(const char* tpath, const char* query);
         int PreMultipartPostRequest(const char* tpath, headers_t& meta, std::string& upload_id, bool is_copy);
         int CompleteMultipartPostRequest(const char* tpath, const std::string& upload_id, etaglist_t& parts);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2151
(Related: #2063 #1728 #1687 #1460 )

### Details
Checking mount point still had issue #2151 after a series of fixes.
(It's almost identical to the issue mentioned in #1460.)

I would like to support the following cases:

User specifies a directory created by a client other than s3fs as the mount point.
(It means there is no object as this directory, and there is a file object etc under that path.)
And if user has no permission to the bucket and has permission to this mount point directory, s3fs does not start with an error.

This PR is code to support the above case.

There is already a `compat_dir` option to support directories created by clients other than s3fs and directories with no existing objects.
In the above case(no directory object for mount point), this PR code make s3fs start without an error by specifying the `compat_dir` option enabled.
This means consistent with the definition and intent of the `compat_dir` option.

@nchaly
I referred to your https://github.com/nchaly/s3fs-fuse/commit/5670dd9dab9962e55ab1d3457ddf8025fecc7653 code.
Thanks for your great help!

Testing of this PR code is difficult to automate, so I checked it manually.

