### PR TITLE
Update curl.cpp:  reduce memory cache use when copy the big file from s3fs mount path

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -703,7 +703,12 @@ size_t S3fsCurl::DownloadWriteCallback(void* ptr, size_t size, size_t nmemb, voi
     }
     pCurl->partdata.startpos += totalwrite;
     pCurl->partdata.size     -= totalwrite;
-
+    
+    // flush the file and clean the page cache
+    if (pCurl->partdata.size == 0){
+        fdatasync(pCurl->partdata.fd);
+    }
+	
     return totalwrite;
 }
 


### PR DESCRIPTION
flush the file and clean the page cache when filepart download done

<!-- --------------------------------------------------------------------------
 Please describe the purpose of the pull request(such as resolving the issue)
 and what the fix/update is.
--------------------------------------------------------------------------- -->

### Relevant Issue (if applicable)
<!-- If there are Issues related to this PullRequest, please list it. -->

### Details
<!-- Please describe the details of PullRequest. -->
add a fdatasync when curl download the filepart finish this to make memory cache of this file to flush to disk.

if not add fdatasync , when copy the large files  this will take many active file cache .
