### PR TITLE
Specify `_FORTIFY_SOURCE=3`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_CHECK_HEADERS([attr/xattr.h])
 AC_CHECK_HEADERS([sys/extattr.h])
 AC_CHECK_FUNCS([fallocate])
 
-CXXFLAGS="$CXXFLAGS -Wall -fno-exceptions -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2"
+CXXFLAGS="$CXXFLAGS -Wall -fno-exceptions -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=3"
 
 dnl ----------------------------------------------
 dnl For macOS


### PR DESCRIPTION
This can find more kinds of buffer overflows:

https://developers.redhat.com/articles/2022/09/17/gccs-new-fortification-level