### PR TITLE
Revert "Update curl.cpp:  reduce memory cache use when copy the big file from s3fs mount path"

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -703,12 +703,7 @@ size_t S3fsCurl::DownloadWriteCallback(void* ptr, size_t size, size_t nmemb, voi
     }
     pCurl->partdata.startpos += totalwrite;
     pCurl->partdata.size     -= totalwrite;
-    
-    // flush the file and clean the page cache
-    if (pCurl->partdata.size == 0){
-        fdatasync(pCurl->partdata.fd);
-    }
-	
+
     return totalwrite;
 }
 


### PR DESCRIPTION
Reverts s3fs-fuse/s3fs-fuse#2157