### PR TITLE
test: Exclude sys/sysmacros.h on FreeBSD

### DIFF
--- a/test/mknod_test.c
+++ b/test/mknod_test.c
@@ -28,7 +28,10 @@
 #include <string.h>
 #include <errno.h>
 #ifndef __APPLE__
+#elif
+#ifndef __FreeBSD__
 #include <sys/sysmacros.h>
+#endif
 #endif
 
 //---------------------------------------------------------


### PR DESCRIPTION
Fixes build issue on FreeBSD

