### PR TITLE
Add support for FUSE-T on macos

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,7 @@ CXXFLAGS="$CXXFLAGS -Wall -fno-exceptions -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOUR
 dnl ----------------------------------------------
 dnl For macOS
 dnl ----------------------------------------------
+found_fuse_t=no
 case "$target" in
    *-cygwin* )
       # Do something specific for windows using winfsp
@@ -48,6 +49,7 @@ case "$target" in
    *-darwin* )
       # Do something specific for mac
       min_fuse_version=2.7.3
+      min_fuse_t_version=1.0.20
       ;;
    *)
       # Default Case
@@ -55,6 +57,11 @@ case "$target" in
       min_fuse_version=2.8.4
       ;;
 esac
+
+PKG_CHECK_MODULES([FUSE_T], [fuse-t >= ${min_fuse_t_version}], [found_fuse_t=yes], [found_fuse_t=no])
+
+AS_IF([test "x$found_fuse_t" = "xyes"],
+  [PKG_CHECK_MODULES([common_lib_checking], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.6 ])])
 
 dnl ----------------------------------------------
 dnl Choice SSL library
@@ -183,13 +190,18 @@ dnl
 dnl For PKG_CONFIG before checking nss/gnutls.
 dnl this is redundant checking, but we need checking before following.
 dnl
-PKG_CHECK_MODULES([common_lib_checking], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 ])
+AS_IF([test "x$found_fuse_t" = "xyes"],
+  [PKG_CHECK_MODULES([common_lib_checking], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.6 ])],
+  [PKG_CHECK_MODULES([common_lib_checking], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 ])])
 
 AC_MSG_CHECKING([compile s3fs with])
 case "${auth_lib}" in
 openssl)
   AC_MSG_RESULT(OpenSSL)
-  PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 libcrypto >= 0.9 ])
+  AS_IF([test "x$found_fuse_t" = "xyes"],
+    [PKG_CHECK_MODULES([DEPS], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.6 libcrypto >= 0.9 ])],
+    [PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 libcrypto >= 0.9 ])])
+
   AC_MSG_CHECKING([openssl 3.0 or later])
   AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM([[#include <openssl/opensslv.h>
@@ -206,7 +218,9 @@ gnutls)
   AS_IF([test "$gnutls_nettle" = ""], [AC_CHECK_LIB(gcrypt, gcry_control, [gnutls_nettle=0])])
   AS_IF([test $gnutls_nettle = 0],
     [
-      PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 gnutls >= 2.12.0 ])
+      AS_IF([test "x$found_fuse_t" = "xyes"],
+        [PKG_CHECK_MODULES([DEPS], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.6 gnutls >= 2.12.0 ])],
+        [PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 gnutls >= 2.12.0 ])])
       LIBS="-lgnutls -lgcrypt $LIBS"
       AC_MSG_CHECKING([gnutls is build with])
       AC_MSG_RESULT(gcrypt)
@@ -220,7 +234,9 @@ nettle)
   AS_IF([test "$gnutls_nettle" = ""], [AC_CHECK_LIB(nettle, nettle_MD5Init, [gnutls_nettle=1])])
   AS_IF([test $gnutls_nettle = 1],
     [
-      PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 nettle >= 2.7.1 ])
+      AS_IF([test "x$found_fuse_t" = "xyes"],
+        [PKG_CHECK_MODULES([DEPS], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.6 nettle >= 2.7.1 ])],
+        [PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 nettle >= 2.7.1 ])])
       LIBS="-lgnutls -lnettle $LIBS"
       AC_MSG_CHECKING([gnutls is build with])
       AC_MSG_RESULT(nettle)
@@ -229,7 +245,9 @@ nettle)
   ;;
 nss)
   AC_MSG_RESULT(NSS)
-  PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 nss >= 3.15.0 ])
+  AS_IF([test "x$found_fuse_t" = "xyes"],
+        [PKG_CHECK_MODULES([DEPS], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.6 nss >= 3.15.0 ])],
+        [PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 nss >= 3.15.0 ])])
   ;;
 *)
   AC_MSG_ERROR([unknown ssl library type.])


### PR DESCRIPTION
<!-- --------------------------------------------------------------------------
 Please describe the purpose of the pull request(such as resolving the issue)
 and what the fix/update is.
--------------------------------------------------------------------------- -->
Add support for user space fuse (FUSE-T) on macos. 
FUSE-T doesn't require installation of kernel extensions (KEXT) as opposed to osxfuse.
Details of the project can be found here: https://github.com/macos-fuse-t/fuse-t
To install FUSE-T use brew:
  brew tap macos-fuse-t/homebrew-cask 
  brew install fuse-t

### Relevant Issue (if applicable)
<!-- If there are Issues related to this PullRequest, please list it. -->

### Details
<!-- Please describe the details of PullRequest. -->
Change autoconf to discover and use FUSE-T if present, otherwise fallback to osxfuse
