### PR TITLE
Replace some raw pointers with `std::unique_ptr`

### DIFF
--- a/src/addhead.h
+++ b/src/addhead.h
@@ -21,6 +21,7 @@
 #ifndef S3FS_ADDHEAD_H_
 #define S3FS_ADDHEAD_H_
 
+#include <memory>
 #include <regex.h>
 
 #include "metaheader.h"
@@ -29,13 +30,19 @@
 // Structure / Typedef
 //----------------------------------------------
 typedef struct add_header{
-    regex_t*      pregex;         // not NULL means using regex, NULL means comparing suffix directly.
+    ~add_header() {
+        if(pregex){
+            regfree(pregex.get());
+        }
+    }
+
+    std::unique_ptr<regex_t> pregex;         // not NULL means using regex, NULL means comparing suffix directly.
     std::string   basestring;
     std::string   headkey;
     std::string   headvalue;
 }ADDHEAD;
 
-typedef std::vector<ADDHEAD *> addheadlist_t;
+typedef std::vector<std::unique_ptr<ADDHEAD>> addheadlist_t;
 
 //----------------------------------------------
 // Class AdditionalHeader

--- a/src/curl.h
+++ b/src/curl.h
@@ -24,6 +24,7 @@
 #include <curl/curl.h>
 #include <list>
 #include <map>
+#include <memory>
 #include <vector>
 
 #include "autolock.h"
@@ -268,7 +269,7 @@ class S3fsCurl
         static bool InitCredentialObject(S3fsCred* pcredobj);
         static bool InitMimeType(const std::string& strFile);
         static bool DestroyS3fsCurl();
-        static S3fsCurl* CreateParallelS3fsCurl(const char* tpath, int fd, off_t start, off_t size, int part_num, bool is_copy, etagpair* petag, const std::string& upload_id, int& result);
+        static std::unique_ptr<S3fsCurl> CreateParallelS3fsCurl(const char* tpath, int fd, off_t start, off_t size, int part_num, bool is_copy, etagpair* petag, const std::string& upload_id, int& result);
         static int ParallelMultipartUploadRequest(const char* tpath, headers_t& meta, int fd);
         static int ParallelMixMultipartUploadRequest(const char* tpath, headers_t& meta, int fd, const fdpage_list_t& mixuppages);
         static int ParallelGetObjectRequest(const char* tpath, int fd, off_t start, off_t size);

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -60,19 +60,17 @@ bool S3fsMultiCurl::ClearEx(bool is_all)
 {
     s3fscurllist_t::iterator iter;
     for(iter = clist_req.begin(); iter != clist_req.end(); ++iter){
-        S3fsCurl* s3fscurl = *iter;
+        S3fsCurl* s3fscurl = iter->get();
         if(s3fscurl){
             s3fscurl->DestroyCurlHandle();
-            delete s3fscurl;  // with destroy curl handle.
         }
     }
     clist_req.clear();
 
     if(is_all){
         for(iter = clist_all.begin(); iter != clist_all.end(); ++iter){
-            S3fsCurl* s3fscurl = *iter;
+            S3fsCurl* s3fscurl = iter->get();
             s3fscurl->DestroyCurlHandle();
-            delete s3fscurl;
         }
         clist_all.clear();
     }
@@ -117,12 +115,12 @@ void* S3fsMultiCurl::SetNotFoundCallbackParam(void* param)
     return old;
 }
 
-bool S3fsMultiCurl::SetS3fsCurlObject(S3fsCurl* s3fscurl)
+bool S3fsMultiCurl::SetS3fsCurlObject(std::unique_ptr<S3fsCurl>&& s3fscurl)
 {
     if(!s3fscurl){
         return false;
     }
-    clist_all.push_back(s3fscurl);
+    clist_all.push_back(std::move(s3fscurl));
 
     return true;
 }
@@ -137,7 +135,7 @@ int S3fsMultiCurl::MultiPerform()
 
     for(s3fscurllist_t::iterator iter = clist_req.begin(); iter != clist_req.end(); ++iter) {
         pthread_t   thread;
-        S3fsCurl*   s3fscurl = *iter;
+        S3fsCurl*   s3fscurl = iter->get();
         if(!s3fscurl){
             continue;
         }
@@ -206,7 +204,7 @@ int S3fsMultiCurl::MultiRead()
     int result = 0;
 
     for(s3fscurllist_t::iterator iter = clist_req.begin(); iter != clist_req.end(); ){
-        S3fsCurl* s3fscurl = *iter;
+        std::unique_ptr<S3fsCurl> s3fscurl(std::move(*iter));
 
         bool isRetry = false;
         bool isPostpone = false;
@@ -220,7 +218,7 @@ int S3fsMultiCurl::MultiRead()
                 isPostpone = true;
             }else if(400 > responseCode){
                 // add into stat cache
-                if(SuccessCallback && !SuccessCallback(s3fscurl, pSuccessCallbackParam)){
+                if(SuccessCallback && !SuccessCallback(s3fscurl.get(), pSuccessCallbackParam)){
                     S3FS_PRN_WARN("error from success callback function(%s).", s3fscurl->url.c_str());
                 }
             }else if(400 == responseCode){
@@ -234,7 +232,7 @@ int S3fsMultiCurl::MultiRead()
                     S3FS_PRN_WARN("failed a request(%ld: %s)", responseCode, s3fscurl->url.c_str());
                 }
 				// Call callback function
-                if(NotFoundCallback && !NotFoundCallback(s3fscurl, pNotFoundCallbackParam)){
+                if(NotFoundCallback && !NotFoundCallback(s3fscurl.get(), pNotFoundCallbackParam)){
                     S3FS_PRN_WARN("error from not found callback function(%s).", s3fscurl->url.c_str());
                 }
             }else if(500 == responseCode){
@@ -271,35 +269,35 @@ int S3fsMultiCurl::MultiRead()
 
         if(isPostpone){
             clist_req.erase(iter);
-            clist_req.push_back(s3fscurl);    // Re-evaluate at the end
+            clist_req.push_back(std::move(s3fscurl));    // Re-evaluate at the end
             iter = clist_req.begin();
         }else{
             if(!isRetry || 0 != result){
                 // If an EIO error has already occurred, it will be terminated
                 // immediately even if retry processing is required. 
                 s3fscurl->DestroyCurlHandle();
-                delete s3fscurl;
             }else{
-                S3fsCurl* retrycurl = NULL;
+                std::unique_ptr<S3fsCurl> retrycurl;
 
                 // Reset offset
                 if(isNeedResetOffset){
-                    S3fsCurl::ResetOffset(s3fscurl);
+                    S3fsCurl::ResetOffset(s3fscurl.get());
                 }
 
                 // For retry
+                S3fsCurl* retry_ptr = nullptr;
                 if(RetryCallback){
-                    retrycurl = RetryCallback(s3fscurl);
-                    if(NULL != retrycurl){
-                        clist_all.push_back(retrycurl);
+                    retry_ptr = RetryCallback(s3fscurl.get());
+                    retrycurl.reset(retry_ptr);
+                    if(NULL != retry_ptr){
+                        clist_all.push_back(std::move(retrycurl));
                     }else{
                         // set EIO and wait for other parts.
                         result = -EIO;
                     }
                 }
-                if(s3fscurl != retrycurl){
+                if(s3fscurl.get() != retry_ptr){
                     s3fscurl->DestroyCurlHandle();
-                    delete s3fscurl;
                 }
             }
             iter = clist_req.erase(iter);
@@ -310,9 +308,8 @@ int S3fsMultiCurl::MultiRead()
     if(0 != result){
         // If an EIO error has already occurred, clear all retry objects.
         for(s3fscurllist_t::iterator iter = clist_all.begin(); iter != clist_all.end(); ++iter){
-            S3fsCurl* s3fscurl = *iter;
+            S3fsCurl* s3fscurl = iter->get();
             s3fscurl->DestroyCurlHandle();
-            delete s3fscurl;
         }
         clist_all.clear();
     }
@@ -333,8 +330,7 @@ int S3fsMultiCurl::Request()
         int                      result;
         s3fscurllist_t::iterator iter;
         for(iter = clist_all.begin(); iter != clist_all.end(); ++iter){
-            S3fsCurl* s3fscurl = *iter;
-            clist_req.push_back(s3fscurl);
+            clist_req.push_back(std::move(*iter));
         }
         clist_all.clear();
 

--- a/src/curl_multi.h
+++ b/src/curl_multi.h
@@ -21,12 +21,14 @@
 #ifndef S3FS_CURL_MULTI_H_
 #define S3FS_CURL_MULTI_H_
 
+#include <memory>
+
 //----------------------------------------------
 // Typedef
 //----------------------------------------------
 class S3fsCurl;
 
-typedef std::vector<S3fsCurl*>       s3fscurllist_t;
+typedef std::vector<std::unique_ptr<S3fsCurl>> s3fscurllist_t;
 typedef bool (*S3fsMultiSuccessCallback)(S3fsCurl* s3fscurl, void* param);  // callback for succeed multi request
 typedef bool (*S3fsMultiNotFoundCallback)(S3fsCurl* s3fscurl, void* param); // callback for succeed multi request
 typedef S3fsCurl* (*S3fsMultiRetryCallback)(S3fsCurl* s3fscurl);            // callback for failure and retrying
@@ -70,7 +72,7 @@ class S3fsMultiCurl
         void* SetSuccessCallbackParam(void* param);
         void* SetNotFoundCallbackParam(void* param);
         bool Clear() { return ClearEx(true); }
-        bool SetS3fsCurlObject(S3fsCurl* s3fscurl);
+        bool SetS3fsCurlObject(std::unique_ptr<S3fsCurl>&& s3fscurl);
         int Request();
 };
 

--- a/src/fdcache_fdinfo.h
+++ b/src/fdcache_fdinfo.h
@@ -21,6 +21,8 @@
 #ifndef S3FS_FDCACHE_FDINFO_H_
 #define S3FS_FDCACHE_FDINFO_H_
 
+#include <memory>
+
 #include "psemaphore.h"
 #include "metaheader.h"
 #include "autolock.h"
@@ -113,7 +115,7 @@ class PseudoFdInfo
         bool ExtractUploadPartsFromAllArea(UntreatedParts& untreated_list, mp_part_list_t& to_upload_list, mp_part_list_t& to_copy_list, mp_part_list_t& to_download_list, filepart_list_t& cancel_upload_list, off_t max_mp_size, off_t file_size, bool use_copy);
 };
 
-typedef std::map<int, class PseudoFdInfo*> fdinfo_map_t;
+typedef std::map<int, std::unique_ptr<PseudoFdInfo>> fdinfo_map_t;
 
 #endif // S3FS_FDCACHE_FDINFO_H_
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <errno.h>
+#include <memory>
 #include <set>
 #include <unistd.h>
 #include <dirent.h>
@@ -3300,16 +3301,14 @@ static int readdir_multi_head(const char* path, const S3ObjList& head, void* buf
 
         // First check for directory, start checking "not SSE-C".
         // If checking failed, retry to check with "SSE-C" by retry callback func when SSE-C mode.
-        S3fsCurl* s3fscurl = new S3fsCurl();
+        std::unique_ptr<S3fsCurl> s3fscurl(new S3fsCurl());
         if(!s3fscurl->PreHeadRequest(disppath, (*iter), disppath)){  // target path = cache key path.(ex "dir/")
             S3FS_PRN_WARN("Could not make curl object for head request(%s).", disppath.c_str());
-            delete s3fscurl;
             continue;
         }
 
-        if(!curlmulti.SetS3fsCurlObject(s3fscurl)){
+        if(!curlmulti.SetS3fsCurlObject(std::move(s3fscurl))){
             S3FS_PRN_WARN("Could not make curl object into multi curl(%s).", disppath.c_str());
-            delete s3fscurl;
             continue;
         }
     }

--- a/src/s3fs_logger.cpp
+++ b/src/s3fs_logger.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdlib>
 #include <iomanip>
+#include <memory>
 #include <sstream>
 #include <string>
 
@@ -264,21 +265,19 @@ void s3fs_low_logprn(S3fsLog::s3fs_log_level level, const char* file, const char
         size_t len = vsnprintf(NULL, 0, fmt, va) + 1;
         va_end(va);
 
-        char *message = new char[len];
+        std::unique_ptr<char[]> message(new char[len]);
         va_start(va, fmt);
-        vsnprintf(message, len, fmt, va);
+        vsnprintf(message.get(), len, fmt, va);
         va_end(va);
 
         if(foreground || S3fsLog::IsSetLogFile()){
             S3fsLog::SeekEnd();
-            fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), file, func, line, message);
+            fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), file, func, line, message.get());
             S3fsLog::Flush();
         }else{
             // TODO: why does this differ from s3fs_low_logprn2?
-            syslog(S3fsLog::GetSyslogLevel(level), "%s%s:%s(%d): %s", instance_name.c_str(), file, func, line, message);
+            syslog(S3fsLog::GetSyslogLevel(level), "%s%s:%s(%d): %s", instance_name.c_str(), file, func, line, message.get());
         }
-
-        delete[] message;
     }
 }
 
@@ -290,20 +289,18 @@ void s3fs_low_logprn2(S3fsLog::s3fs_log_level level, int nest, const char* file,
         size_t len = vsnprintf(NULL, 0, fmt, va) + 1;
         va_end(va);
 
-        char *message = new char[len];
+        std::unique_ptr<char[]> message(new char[len]);
         va_start(va, fmt);
-        vsnprintf(message, len, fmt, va);
+        vsnprintf(message.get(), len, fmt, va);
         va_end(va);
 
         if(foreground || S3fsLog::IsSetLogFile()){
             S3fsLog::SeekEnd();
-            fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), S3fsLog::GetS3fsLogNest(nest), file, func, line, message);
+            fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), S3fsLog::GetS3fsLogNest(nest), file, func, line, message.get());
             S3fsLog::Flush();
         }else{
-            syslog(S3fsLog::GetSyslogLevel(level), "%s%s%s", instance_name.c_str(), S3fsLog::GetS3fsLogNest(nest), message);
+            syslog(S3fsLog::GetSyslogLevel(level), "%s%s%s", instance_name.c_str(), S3fsLog::GetS3fsLogNest(nest), message.get());
         }
-
-        delete[] message;
     }
 }
 

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -107,6 +107,7 @@ bool get_keyword_value(const std::string& target, const char* keyword, std::stri
 //
 std::string s3fs_hex_lower(const unsigned char* input, size_t length);
 std::string s3fs_hex_upper(const unsigned char* input, size_t length);
+// TODO: return std::string
 char* s3fs_base64(const unsigned char* input, size_t length);
 unsigned char* s3fs_decode64(const char* input, size_t input_len, size_t* plength);
 

--- a/src/types.h
+++ b/src/types.h
@@ -200,7 +200,7 @@ typedef std::list<etagpair> etaglist_t;
 
 struct petagpool
 {
-    std::list<etagpair*> petaglist;
+    std::list<etagpair> petaglist;
 
     ~petagpool()
     {
@@ -209,19 +209,13 @@ struct petagpool
 
     void clear()
     {
-        for(std::list<etagpair*>::iterator it = petaglist.begin(); petaglist.end() != it; ++it){
-            if(*it){
-                delete (*it);
-            }
-        }
         petaglist.clear();
     }
 
     etagpair* add(const etagpair& etag_entity)
     {
-        etagpair* petag = new etagpair(etag_entity);
-        petaglist.push_back(petag);
-        return petag;
+        petaglist.push_back(etag_entity);
+        return &petaglist.back();
     }
 };
 


### PR DESCRIPTION
This simplifies code paths and makes memory leaks less likely.  It also makes memory ownership more explicit by requiring `std::move`. This commit requires C++11.  References #2179.