### PR TITLE
Supported cppcheck 2.10(and changed std from c++03 to c++11 for RHEL7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Cppcheck
         run: |
           # specify the version range to run cppcheck (cppcheck version number is x.y or x.y.z)
-          if cppcheck --version | sed -e 's/\./ /g' | awk '{if (($2 * 1000 + $3) <= 1086 || ($2 * 1000 + $3) >= 2010) { exit(1) } }'; then
+          if cppcheck --version | sed -e 's/\./ /g' | awk '{if ($2 * 1000 + $3) <= 1086) { exit(1) } }'; then
             make cppcheck
           fi
 
@@ -160,13 +160,13 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          PKG_CONFIG_PATH=/usr/local/opt/curl/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig ./configure CXXFLAGS='-std=c++03 -DS3FS_PTHREAD_ERRORCHECK=1'
+          PKG_CONFIG_PATH=/usr/local/opt/curl/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig ./configure CXXFLAGS='-std=c++11 -DS3FS_PTHREAD_ERRORCHECK=1'
           make --jobs=$(sysctl -n hw.ncpu)
 
       - name: Cppcheck
         run: |
           # specify the version range to run cppcheck (cppcheck version number is x.y or x.y.z)
-          if cppcheck --version | sed -e 's/\./ /g' | awk '{if (($2 * 1000 + $3) <= 1086 || ($2 * 1000 + $3) >= 2010) { exit(1) } }'; then
+          if cppcheck --version | sed -e 's/\./ /g' | awk '{if ($2 * 1000 + $3) <= 1086) { exit(1) } }'; then
             make cppcheck
           fi
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ release : dist ../utils/release.sh
 cppcheck:
 	cppcheck --quiet --error-exitcode=1 \
             --inline-suppr \
-            --std=c++03 \
+            --std=c++11 \
             --xml \
             -D HAVE_ATTR_XATTR_H \
             -D HAVE_SYS_EXTATTR_H \
@@ -81,6 +81,6 @@ shellcheck:
 # tab-width: 4
 # c-basic-offset: 4
 # End:
-# vim600: expandtab sw=4 ts= fdm=marker
+# vim600: expandtab sw=4 ts=4 fdm=marker
 # vim<600: expandtab sw=4 ts=4
 #

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_CHECK_HEADERS([attr/xattr.h])
 AC_CHECK_HEADERS([sys/extattr.h])
 AC_CHECK_FUNCS([fallocate])
 
-CXXFLAGS="$CXXFLAGS -Wall -fno-exceptions -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=3"
+CXXFLAGS="$CXXFLAGS -Wall -fno-exceptions -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=3 -std=c++11"
 
 dnl ----------------------------------------------
 dnl For macOS

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -410,7 +410,7 @@ bool S3fsCurl::InitMimeType(const std::string& strFile)
     if(MT.good()){
         S3FS_PRN_DBG("The old mime types are cleared to load new mime types.");
         S3fsCurl::mimeTypes.clear();
-	    std::string line;
+        std::string line;
 
         while(getline(MT, line)){
             if(line.empty()){

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -415,7 +415,7 @@ int FdManager::GetOpenFdCount(const char* path)
 {
     AutoLock auto_lock(&FdManager::fd_manager_lock);
 
-	return FdManager::singleton.GetPseudoFdCount(path);
+    return FdManager::singleton.GetPseudoFdCount(path);
 }
 
 //------------------------------------------------

--- a/src/fdcache_page.cpp
+++ b/src/fdcache_page.cpp
@@ -959,11 +959,18 @@ bool PageList::Serialize(CacheFileStat& file, bool is_output, ino_t inode)
                 is_modified = (1 == cvt_strtoofft(part.c_str(), /* base= */10) ? true : false);
             }
             // add new area
-            PageList::page_status pstatus = 
-              ( is_loaded && is_modified  ? PageList::PAGE_LOAD_MODIFIED : 
-                !is_loaded && is_modified ? PageList::PAGE_MODIFIED      : 
-                is_loaded && !is_modified ? PageList::PAGE_LOADED        : PageList::PAGE_NOT_LOAD_MODIFIED );
-
+            PageList::page_status pstatus = PageList::PAGE_NOT_LOAD_MODIFIED;
+            if(is_loaded){
+                if(is_modified){
+                    pstatus = PageList::PAGE_LOAD_MODIFIED;
+                }else{
+                    pstatus = PageList::PAGE_LOADED;
+                }
+            }else{
+                if(is_modified){
+                    pstatus = PageList::PAGE_MODIFIED;
+                }
+            }
             SetPageLoadedStatus(offset, size, pstatus);
         }
         delete[] ptmp;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2163
#2162 
#2179

### Details
Fixed errors detected by `cppcheck v2.10 (SUSE leap:15)`.

This reverts the setting that was temporarily disabled(`v2.10` and `useStlAlgorithm`) in #2163.
With this fix, cppcheck checks can be done on all OSs.

Support for `CentOS7`(which was discussed in #2195) is resolved by adding the `-std=c++11` CXXFLAGS.