### PR TITLE
Reverted the macos CI process(using macos-fuse-t)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,18 +127,15 @@ jobs:
           make ALL_TESTS=1 check -C test || (test/filter-suite-log.sh test/test-suite.log; exit 1)
 
   # [NOTE]
-  # This Job does not work for macOS 11 and later because load_osxfuse returns exit code = 1.
-  # Apple states "You must be signed in as an administrator user to install new kernel
-  # extensions, and your Mac must be rebooted for the extensions to load.", so it needs
-  # to reboot OS.
-  # As of May 2023, GitHub Actions are no longer able to launch macos 10.15 as runner,
-  # so we can not run this Job.
-  # In the future, if it is found a solution, we will resume this Job execution.
+  # Using macos-fuse-t
+  #   This product(package) is a workaround for osxfuse which required an OS reboot(macos 11 and later).
+  #   see. https://github.com/macos-fuse-t/fuse-t
+  # About osxfuse
+  #   This job doesn't work with Github Actions using macOS 11+ because "load_osxfuse" returns
+  #   "exit code = 1".(requires OS reboot)
   #
-  macos10:
-    if: false
-
-    runs-on: macos-10.15
+  macos12:
+    runs-on: macos-12
 
     steps:
       - name: Checkout source code
@@ -149,14 +146,15 @@ jobs:
           TAPS="$(brew --repository)/Library/Taps";
           if [ -e "$TAPS/caskroom/homebrew-cask" ]; then rm -rf "$TAPS/caskroom/homebrew-cask"; fi;
           HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/homebrew-cask
+          HOMEBREW_NO_AUTO_UPDATE=1 brew tap macos-fuse-t/homebrew-cask
 
-      - name: Install osxfuse
+      - name: Install fuse-t
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install osxfuse
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install fuse-t
 
       - name: Install brew other packages
         run: |
-          S3FS_BREW_PACKAGES='automake cppcheck python3 coreutils gnu-sed shellcheck';
+          S3FS_BREW_PACKAGES='automake cppcheck python3 coreutils gnu-sed shellcheck jq';
           for s3fs_brew_pkg in ${S3FS_BREW_PACKAGES}; do if brew list | grep -q ${s3fs_brew_pkg}; then if brew outdated | grep -q ${s3fs_brew_pkg}; then HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade ${s3fs_brew_pkg}; fi; else HOMEBREW_NO_AUTO_UPDATE=1 brew install ${s3fs_brew_pkg}; fi; done;
 
       - name: Install awscli2
@@ -164,10 +162,6 @@ jobs:
           cd /tmp
           curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
           sudo installer -pkg AWSCLIV2.pkg -target /
-
-      - name: Check osxfuse permission
-        run: |
-          if [ -f /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ]; then sudo chmod +s /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs; elif [ -f /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ]; then sudo chmod +s /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse; else exit 1; fi
 
       - name: Build
         run: |
@@ -191,8 +185,6 @@ jobs:
       - name: Test suite
         run: |
           make check -C src
-          echo "user_allow_other" | sudo tee -a /etc/fuse.conf >/dev/null
-          if [ -f /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs ]; then /Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs; elif [ -f /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse ]; then /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse; else exit 1; fi
           make ALL_TESTS=1 check -C test || (test/filter-suite-log.sh test/test-suite.log; exit 1)
 
   MemoryTest:

--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,6 @@ CXXFLAGS="-Wall -fno-exceptions -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=3 -std=
 dnl ----------------------------------------------
 dnl For macOS
 dnl ----------------------------------------------
-found_fuse_t=no
 case "$target" in
    *-cygwin* )
       # Do something specific for windows using winfsp
@@ -58,10 +57,17 @@ case "$target" in
       ;;
 esac
 
+dnl ----------------------------------------------
+dnl Checking the FUSE library
+dnl ----------------------------------------------
+dnl Distinguish between Linux (libfuse) and macOS (FUSE-T).
+dnl
+found_fuse_t=no
 PKG_CHECK_MODULES([FUSE_T], [fuse-t >= ${min_fuse_t_version}], [found_fuse_t=yes], [found_fuse_t=no])
 
-AS_IF([test "x$found_fuse_t" = "xyes"],
-  [PKG_CHECK_MODULES([common_lib_checking], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.6 ])])
+AS_IF([test "$found_fuse_t" = "yes"],
+  [PKG_CHECK_MODULES([fuse_library_checking], [fuse-t >= ${min_fuse_t_version}])],
+  [PKG_CHECK_MODULES([fuse_library_checking], [fuse >= ${min_fuse_version}])])
 
 dnl ----------------------------------------------
 dnl Choice SSL library
@@ -188,17 +194,13 @@ AS_IF(
 
 dnl
 dnl For PKG_CONFIG before checking nss/gnutls.
-dnl this is redundant checking, but we need checking before following.
 dnl
-AS_IF([test "x$found_fuse_t" = "xyes"],
-  [PKG_CHECK_MODULES([common_lib_checking], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.6 ])],
-  [PKG_CHECK_MODULES([common_lib_checking], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 ])])
 
 AC_MSG_CHECKING([compile s3fs with])
 case "${auth_lib}" in
 openssl)
   AC_MSG_RESULT(OpenSSL)
-  AS_IF([test "x$found_fuse_t" = "xyes"],
+  AS_IF([test "$found_fuse_t" = "yes"],
     [PKG_CHECK_MODULES([DEPS], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.6 libcrypto >= 0.9 ])],
     [PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 libcrypto >= 0.9 ])])
 
@@ -218,7 +220,7 @@ gnutls)
   AS_IF([test "$gnutls_nettle" = ""], [AC_CHECK_LIB(gcrypt, gcry_control, [gnutls_nettle=0])])
   AS_IF([test $gnutls_nettle = 0],
     [
-      AS_IF([test "x$found_fuse_t" = "xyes"],
+      AS_IF([test "$found_fuse_t" = "yes"],
         [PKG_CHECK_MODULES([DEPS], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.6 gnutls >= 2.12.0 ])],
         [PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 gnutls >= 2.12.0 ])])
       LIBS="-lgnutls -lgcrypt $LIBS"
@@ -234,7 +236,7 @@ nettle)
   AS_IF([test "$gnutls_nettle" = ""], [AC_CHECK_LIB(nettle, nettle_MD5Init, [gnutls_nettle=1])])
   AS_IF([test $gnutls_nettle = 1],
     [
-      AS_IF([test "x$found_fuse_t" = "xyes"],
+      AS_IF([test "$found_fuse_t" = "yes"],
         [PKG_CHECK_MODULES([DEPS], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.6 nettle >= 2.7.1 ])],
         [PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 nettle >= 2.7.1 ])])
       LIBS="-lgnutls -lnettle $LIBS"
@@ -245,7 +247,7 @@ nettle)
   ;;
 nss)
   AC_MSG_RESULT(NSS)
-  AS_IF([test "x$found_fuse_t" = "xyes"],
+  AS_IF([test "$found_fuse_t" = "yes"],
         [PKG_CHECK_MODULES([DEPS], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.6 nss >= 3.15.0 ])],
         [PKG_CHECK_MODULES([DEPS], [fuse >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.6 nss >= 3.15.0 ])])
   ;;

--- a/src/curl_multi.h
+++ b/src/curl_multi.h
@@ -44,6 +44,7 @@ class S3fsMultiCurl
 
         s3fscurllist_t clist_all;  // all of curl requests
         s3fscurllist_t clist_req;  // curl requests are sent
+        bool           not_abort;  // complete all requests without aborting on errors
 
         S3fsMultiSuccessCallback   SuccessCallback;
         S3fsMultiNotFoundCallback  NotFoundCallback;
@@ -62,7 +63,7 @@ class S3fsMultiCurl
         static void* RequestPerformWrapper(void* arg);
 
     public:
-        explicit S3fsMultiCurl(int maxParallelism);
+        explicit S3fsMultiCurl(int maxParallelism, bool not_abort = false);
         ~S3fsMultiCurl();
 
         int GetMaxParallelism() const { return maxParallelism; }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3294,7 +3294,7 @@ static std::unique_ptr<S3fsCurl> multi_head_retry_callback(S3fsCurl* s3fscurl)
 
 static int readdir_multi_head(const char* path, const S3ObjList& head, void* buf, fuse_fill_dir_t filler)
 {
-    S3fsMultiCurl curlmulti(S3fsCurl::GetMaxMultiRequest());
+    S3fsMultiCurl curlmulti(S3fsCurl::GetMaxMultiRequest(), true);      // [NOTE] run all requests to completion even if some requests fail.
     s3obj_list_t  headlist;
     int           result = 0;
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2154
#2191

### Details
By using `macos-fuse-t`, CI process can support macos11 or later.
(Thanks to @macos-fuse-t.)

CI processing(until just before the test) has been confirmed on both macos11/12. 
But the macos CI processing is macos12 only.
_(If necessary, macos11 can also be added.)_

Part of the patch #2197 is applied to pass the cppcheck2.10 test.
_(I will rebase after merged #2197.)_

#### NOTE
This PR has not passed some parts of tests yet, so it is marked as a `Draft`.