### PR TITLE
Fixed data race in threads found thread sanitizer

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2078,13 +2078,13 @@ bool S3fsCurl::DestroyCurlHandle(bool restore_pool, bool clear_internal_data, Au
         type = REQTYPE_UNSET;
     }
 
+    AutoLock lock(&S3fsCurl::curl_handles_lock, locktype);
+
     if(clear_internal_data){
         ClearInternalData();
     }
 
     if(hCurl){
-        AutoLock lock(&S3fsCurl::curl_handles_lock, locktype);
-  
         S3fsCurl::curl_times.erase(hCurl);
         S3fsCurl::curl_progress.erase(hCurl);
         sCurlPool->ReturnHandler(hCurl, restore_pool);

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -2533,7 +2533,7 @@ bool FdEntity::PunchHole(off_t start, size_t size)
 //
 void FdEntity::MarkDirtyNewFile()
 {
-    AutoLock auto_lock(&fdent_data_lock);
+    AutoLock auto_lock(&fdent_lock);
 
     pagelist.Init(0, false, true);
     pending_status = CREATE_FILE_PENDING;
@@ -2541,7 +2541,7 @@ void FdEntity::MarkDirtyNewFile()
 
 bool FdEntity::IsDirtyNewFile() const
 {
-    AutoLock auto_lock(&fdent_data_lock);
+    AutoLock auto_lock(&fdent_lock);
 
     return (CREATE_FILE_PENDING == pending_status);
 }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3022,7 +3022,6 @@ static int s3fs_release(const char* _path, struct fuse_file_info* fi)
 
         bool is_new_file = ent->IsDirtyNewFile();
 
-        // TODO: correct locks held?
         if(0 != (result = ent->UploadPending(static_cast<int>(fi->fh), AutoLock::NONE))){
             S3FS_PRN_ERR("could not upload pending data(meta, etc) for pseudo_fd(%llu) / path(%s)", (unsigned long long)(fi->fh), path);
             return result;


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
The following error in the ThreadSinitizer test was detected, so it was fixed.
```
WARNING: ThreadSanitizer: data race (pid=22052)
  Read of size 4 at 0x7b4c000119a8 by thread T9 (mutexes: write M0):
    #0 FdEntity::IsDirtyNewFile() const /__w/s3fs-fuse/s3fs-fuse/src/fdcache_entity.cpp:2546 (s3fs+0x5dc836) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #1 s3fs_release(char const*, fuse_file_info*) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:3023 (s3fs+0x54aae9) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #2 fuse_fs_release ??:? (libfuse.so.2+0xd345) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

  Previous write of size 4 at 0x7b4c000119a8 by thread T44 (mutexes: write M1):
    #0 FdEntity::UploadPending(int, AutoLock::Type) /__w/s3fs-fuse/s3fs-fuse/src/fdcache_entity.cpp:2450 (s3fs+0x5d983b) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #1 s3fs_release(char const*, fuse_file_info*) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:3026 (s3fs+0x54ab2b) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #2 fuse_fs_release ??:? (libfuse.so.2+0xd345) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

  Location is heap block of size 448 at 0x7b4c00011800 allocated by thread T1:
    #0 operator new(unsigned long) ??:? (s3fs+0x53747b) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #1 FdManager::Open(int&, char const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >*, long, timespec const&, int, bool, bool, bool, AutoLock::Type) /__w/s3fs-fuse/s3fs-fuse/src/fdcache.cpp:593 (s3fs+0x5c7df3) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #2 AutoFdEntity::Open(char const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >*, long, timespec const&, int, bool, bool, bool, AutoLock::Type) /__w/s3fs-fuse/s3fs-fuse/src/fdcache_auto.cpp:103 (s3fs+0x5e9413) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #3 s3fs_create(char const*, unsigned int, fuse_file_info*) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:1135 (s3fs+0x54c193) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #4 fuse_fs_create ??:? (libfuse.so.2+0xddff) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

  Mutex M0 (0x7b4c00011920) created at:
    #0 pthread_mutex_init ??:? (s3fs+0x4b0354) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #1 FdEntity /__w/s3fs-fuse/s3fs-fuse/src/fdcache_entity.cpp:124 (s3fs+0x5ce9c4) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #2 FdManager::Open(int&, char const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >*, long, timespec const&, int, bool, bool, bool, AutoLock::Type) /__w/s3fs-fuse/s3fs-fuse/src/fdcache.cpp:593 (s3fs+0x5c7e27) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #3 AutoFdEntity::Open(char const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >*, long, timespec const&, int, bool, bool, bool, AutoLock::Type) /__w/s3fs-fuse/s3fs-fuse/src/fdcache_auto.cpp:103 (s3fs+0x5e9413) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #4 s3fs_create(char const*, unsigned int, fuse_file_info*) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:1135 (s3fs+0x54c193) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #5 fuse_fs_create ??:? (libfuse.so.2+0xddff) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

  Mutex M1 (0x7b4c00011800) created at:
    #0 pthread_mutex_init ??:? (s3fs+0x4b0354) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #1 FdEntity /__w/s3fs-fuse/s3fs-fuse/src/fdcache_entity.cpp:120 (s3fs+0x5ce967) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #2 FdManager::Open(int&, char const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >*, long, timespec const&, int, bool, bool, bool, AutoLock::Type) /__w/s3fs-fuse/s3fs-fuse/src/fdcache.cpp:593 (s3fs+0x5c7e27) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #3 AutoFdEntity::Open(char const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >*, long, timespec const&, int, bool, bool, bool, AutoLock::Type) /__w/s3fs-fuse/s3fs-fuse/src/fdcache_auto.cpp:103 (s3fs+0x5e9413) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #4 s3fs_create(char const*, unsigned int, fuse_file_info*) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:1135 (s3fs+0x54c193) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #5 fuse_fs_create ??:? (libfuse.so.2+0xddff) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

  Thread T9 (tid=22089, running) created by thread T1 at:
    #0 pthread_create ??:? (s3fs+0x4ae98f) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #1 <null> <null> (libfuse.so.2+0xc4e0) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

  Thread T44 (tid=23204, running) created by thread T38 at:
    #0 pthread_create ??:? (s3fs+0x4ae98f) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #1 <null> <null> (libfuse.so.2+0xc4e0) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

  Thread T1 (tid=22054, running) created by main thread at:
    #0 pthread_create ??:? (s3fs+0x4ae98f) (BuildId: ab83e9890914b4c6d66a0fd5ea48fdf43707afe7)
    #1 <null> <null> (libfuse.so.2+0xc4e0) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)
    #2 __libc_start_call_main ??:? (libc.so.6+0x27b49) (BuildId: 245240a31888ad5c11bbc55b18e02d87388f59a9)

SUMMARY: ThreadSanitizer: data race /__w/s3fs-fuse/s3fs-fuse/src/fdcache_entity.cpp:2546 in FdEntity::IsDirtyNewFile() const
```

This is because some methods that deal with the `pending_status` variable use different locking variables than others.
These methods used `fdent_data_lock` and should have used `fdent_lock`.
(`FdEntity::UploadPending` calls the `Flush` method, so `fdent_data_lock` doesn't work)

Also, the comments in `s3fs.cpp` were confirmed by this fix and have been removed.
