### PR TITLE
Fixed data race at OPENSSL_sk_dup/free in libcurl

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1944,7 +1944,8 @@ bool S3fsCurl::ResetHandle(AutoLock::Type locktype)
         curl_warnings_once = true;
     }
 
-    curl_easy_reset(hCurl);
+    sCurlPool->ResetHandler(hCurl);
+
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_NOSIGNAL, 1)){
         return false;
     }

--- a/src/curl_handlerpool.h
+++ b/src/curl_handlerpool.h
@@ -45,6 +45,7 @@ class CurlHandlerPool
 
         CURL* GetHandler(bool only_pool);
         void ReturnHandler(CURL* hCurl, bool restore_pool);
+        void ResetHandler(CURL* hCurl);
 
     private:
         int             mMaxHandlers;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2209

### Details
Fixed the following data races that were not fixed in #2209.

```
WARNING: ThreadSanitizer: data race (pid=11216)
  Write of size 8 at 0x7b080002f920 by thread T170 (mutexes: write M0, write M1):
    #0 free ??:? (s3fs+0x4ad379) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #1 OPENSSL_sk_free ??:? (libcrypto.so.3+0x205cfa) (BuildId: 3273586fcac67f861ec301429787310dc38b9e7e)
    #2 S3fsCurl::HeadRequest(char const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&) /__w/s3fs-fuse/s3fs-fuse/src/curl.cpp:3301 (s3fs+0x58152e) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #3 get_object_attribute(char const*, stat*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >*, bool, bool*, bool) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:513 (s3fs+0x538f52) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #4 get_object_sse_type(char const*, sse_type_t&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:837 (s3fs+0x5386c3) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #5 S3fsCurl::ParallelGetObjectRequest(char const*, int, long, long) /__w/s3fs-fuse/s3fs-fuse/src/curl.cpp:1638 (s3fs+0x577ec9) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #6 FdEntity::Load(long, long, AutoLock::Type, bool) /__w/s3fs-fuse/s3fs-fuse/src/fdcache_entity.cpp:1107 (s3fs+0x5d2eea) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #7 FdEntity::Read(int, char*, long, unsigned long, bool) /__w/s3fs-fuse/s3fs-fuse/src/fdcache_entity.cpp:2019 (s3fs+0x5d9d29) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #8 s3fs_read(char const*, char*, unsigned long, long, fuse_file_info*) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:2831 (s3fs+0x549b07) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #9 fuse_fs_read_buf ??:? (libfuse.so.2+0xf926) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

  Previous read of size 8 at 0x7b080002f920 by thread T154:
    #0 memcpy ??:? (s3fs+0x4babd4) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #1 OPENSSL_sk_dup ??:? (libcrypto.so.3+0x207433) (BuildId: 3273586fcac67f861ec301429787310dc38b9e7e)
    #2 S3fsCurl::HeadRequest(char const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&) /__w/s3fs-fuse/s3fs-fuse/src/curl.cpp:3301 (s3fs+0x58152e) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #3 get_object_attribute(char const*, stat*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >*, bool, bool*, bool) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:513 (s3fs+0x538f52) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #4 check_object_access(char const*, int, stat*) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:694 (s3fs+0x550394) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #5 s3fs_flush(char const*, fuse_file_info*) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:2907 (s3fs+0x54a2e2) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #6 fuse_fs_write ??:? (libfuse.so.2+0x101d1) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

  Mutex M0 (0x7b4c00090ec0) created at:
    #0 pthread_mutex_init ??:? (s3fs+0x4b0354) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #1 FdEntity /__w/s3fs-fuse/s3fs-fuse/src/fdcache_entity.cpp:120 (s3fs+0x5ce977) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #2 FdManager::Open(int&, char const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >*, long, timespec const&, int, bool, bool, bool, AutoLock::Type) /__w/s3fs-fuse/s3fs-fuse/src/fdcache.cpp:593 (s3fs+0x5c7e37) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #3 AutoFdEntity::Open(char const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >*, long, timespec const&, int, bool, bool, bool, AutoLock::Type) /__w/s3fs-fuse/s3fs-fuse/src/fdcache_auto.cpp:103 (s3fs+0x5e9463) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #4 s3fs_open(char const*, fuse_file_info*) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:2787 (s3fs+0x5495e5) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #5 fuse_fs_open ??:? (libfuse.so.2+0xd720) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

  Mutex M1 (0x7b4c00090fe0) created at:
    #0 pthread_mutex_init ??:? (s3fs+0x4b0354) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #1 FdEntity /__w/s3fs-fuse/s3fs-fuse/src/fdcache_entity.cpp:124 (s3fs+0x5ce9d4) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #2 FdManager::Open(int&, char const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >*, long, timespec const&, int, bool, bool, bool, AutoLock::Type) /__w/s3fs-fuse/s3fs-fuse/src/fdcache.cpp:593 (s3fs+0x5c7e37) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #3 AutoFdEntity::Open(char const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, header_nocase_cmp, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >*, long, timespec const&, int, bool, bool, bool, AutoLock::Type) /__w/s3fs-fuse/s3fs-fuse/src/fdcache_auto.cpp:103 (s3fs+0x5e9463) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #4 s3fs_open(char const*, fuse_file_info*) /__w/s3fs-fuse/s3fs-fuse/src/s3fs.cpp:2787 (s3fs+0x5495e5) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #5 fuse_fs_open ??:? (libfuse.so.2+0xd720) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

  Thread T170 (tid=11897, running) created by thread T155 at:
    #0 pthread_create ??:? (s3fs+0x4ae98f) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #1 <null> <null> (libfuse.so.2+0xc4e0) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

  Thread T154 (tid=11872, running) created by thread T81 at:
    #0 pthread_create ??:? (s3fs+0x4ae98f) (BuildId: 227310a5f6a82ab3f004ee942adca3592e8d83e1)
    #1 <null> <null> (libfuse.so.2+0xc4e0) (BuildId: 4db3553f25db655fdcad5600bb328da5dc18736b)

SUMMARY: ThreadSanitizer: data race ??:? in __interceptor_free
```

The above log reported that there is a data race between `OPENSSL_sk_free` and `OPENSSL_sk_dup` called from `S3fsCurl::HeadRequest`.
_(this data race could occur in rare cases with the `test_concurrent_writes` CI test.)_

This fix may not be accurate as the stack beyond `S3fsCurl::HeadRequest` is not recorded.
However, I suspect that the conflict between `OPENSSL_sk_free` and `OPENSSL_sk_dup` is caused by calls to `curl_easy_init`, `curl_easy_reset` and `curl_easy_cleanup`.
_(In current master code, only `curl_easy_reset` is not exclusive control is not possible.)_
Then I implemented all these calls in the `CurlHandlerPool` class, and changed the exclusive control within the `CurlHandlerPool` class.

I've run many times of problematic CI tests and now no errors are detected.