### PR TITLE
Specify C++03 when configuring

### DIFF
--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -67,7 +67,7 @@ AWSCLI_ZIP_FILE="awscliv2.zip"
 # Parameters for configure(set environments)
 #-----------------------------------------------------------
 # shellcheck disable=SC2089
-CONFIGURE_OPTIONS="CXXFLAGS='-O -std=c++03 -DS3FS_PTHREAD_ERRORCHECK=1' --prefix=/usr --with-openssl"
+CONFIGURE_OPTIONS="CXXFLAGS='-O -DS3FS_PTHREAD_ERRORCHECK=1' --prefix=/usr --with-openssl"
 
 #-----------------------------------------------------------
 # OS dependent variables

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_CHECK_HEADERS([attr/xattr.h])
 AC_CHECK_HEADERS([sys/extattr.h])
 AC_CHECK_FUNCS([fallocate])
 
-CXXFLAGS="$CXXFLAGS -Wall -fno-exceptions -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=3"
+CXXFLAGS="$CXXFLAGS -Wall -std=c++03 -fno-exceptions -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=3"
 
 dnl ----------------------------------------------
 dnl For macOS


### PR DESCRIPTION
This prevents a std::auto_ptr warning about not using std::unique_ptr. Remove similar setting from CI configuration.  References #2177.