### PR TITLE
Fixed checking cppcheck version in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,8 @@ jobs:
 
       - name: Cppcheck
         run: |
-          # work around resource leak false positives on older and newer Linux distributions
-          if cppcheck --version | awk '{if ($2 <= 1.86 || $2 >= 2.10) { exit(1) } }'; then
+          # specify the version range to run cppcheck (cppcheck version number is x.y or x.y.z)
+          if cppcheck --version | sed -e 's/\./ /g' | awk '{if (($2 * 1000 + $3) <= 1086 || ($2 * 1000 + $3) >= 2010) { exit(1) } }'; then
             make cppcheck
           fi
 
@@ -165,7 +165,10 @@ jobs:
 
       - name: Cppcheck
         run: |
-          make cppcheck
+          # specify the version range to run cppcheck (cppcheck version number is x.y or x.y.z)
+          if cppcheck --version | sed -e 's/\./ /g' | awk '{if (($2 * 1000 + $3) <= 1086 || ($2 * 1000 + $3) >= 2010) { exit(1) } }'; then
+            make cppcheck
+          fi
 
       - name: Shellcheck
         run: |


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Tighter version number checking in cppcheck.
The current decision statement bypasses the check for cases like "2.9".
This statement provides some protection against future version number format changes.(cppcheck on macOS is 3 digits)

And the same conditions were set for the CI part when supporting macOS fuse-t.