### PR TITLE
Refixed for cppcheck 2.1x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Cppcheck
         run: |
           # specify the version range to run cppcheck (cppcheck version number is x.y or x.y.z)
-          if cppcheck --version | sed -e 's/\./ /g' | awk '{if ($2 * 1000 + $3) <= 1086) { exit(1) } }'; then
+          if cppcheck --version | sed -e 's/\./ /g' | awk '{if (($2 * 1000 + $3) <= 1086) { exit(1) } }'; then
             make cppcheck
           fi
 
@@ -166,7 +166,7 @@ jobs:
       - name: Cppcheck
         run: |
           # specify the version range to run cppcheck (cppcheck version number is x.y or x.y.z)
-          if cppcheck --version | sed -e 's/\./ /g' | awk '{if ($2 * 1000 + $3) <= 1086) { exit(1) } }'; then
+          if cppcheck --version | sed -e 's/\./ /g' | awk '{if (($2 * 1000 + $3) <= 1086) { exit(1) } }'; then
             make cppcheck
           fi
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -45,6 +45,7 @@ cppcheck:
             --suppress=missingIncludeSystem \
             --suppress=unmatchedSuppression \
             --suppress=useStlAlgorithm \
+            --suppress=checkLevelNormal \
             src/ test/
 
 #

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -315,7 +315,7 @@ bool StatCache::IsNoObjectCache(const std::string& key, bool overcheck)
     }
 
     if(iter != stat_cache.end() && (*iter).second) {
-        stat_cache_entry* ent = (*iter).second;
+        const stat_cache_entry* ent = (*iter).second;
         if(0 < ent->notruncate || !IsExpireTime || !IsExpireStatCacheTime((*iter).second->cache_date, ExpireTime)){
             if((*iter).second->noobjcache){
                 // noobjcache = true means no object.
@@ -353,6 +353,8 @@ bool StatCache::AddStat(const std::string& key, const headers_t& meta, bool forc
         DelStat(key.c_str());
     }else{
         if(do_truncate){
+            // cppcheck-suppress unmatchedSuppression
+            // cppcheck-suppress knownConditionTrueFalse
             if(!TruncateCache()){
                 return false;
             }
@@ -476,6 +478,8 @@ bool StatCache::AddNoObjectCache(const std::string& key)
         DelStat(key.c_str());
     }else{
         if(do_truncate){
+            // cppcheck-suppress unmatchedSuppression
+            // cppcheck-suppress knownConditionTrueFalse
             if(!TruncateCache()){
                 return false;
             }
@@ -559,7 +563,7 @@ bool StatCache::TruncateCache()
     statiterlist_t    erase_iters;
     for(stat_cache_t::iterator iter = stat_cache.begin(); iter != stat_cache.end() && 0 < erase_count; ++iter){
         // check no truncate
-        stat_cache_entry* ent = iter->second;
+        const stat_cache_entry* ent = iter->second;
         if(ent && 0L < ent->notruncate){
             // skip for no truncate entry and keep extra counts for this entity.
             if(0 < erase_count){
@@ -674,6 +678,8 @@ bool StatCache::AddSymlink(const std::string& key, const std::string& value)
         DelSymlink(key.c_str());
     }else{
         if(do_truncate){
+            // cppcheck-suppress unmatchedSuppression
+            // cppcheck-suppress knownConditionTrueFalse
             if(!TruncateSymlink()){
                 return false;
             }

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -948,7 +948,7 @@ bool S3fsCurl::LoadEnvSseCKeys()
 
 bool S3fsCurl::LoadEnvSseKmsid()
 {
-    char* envkmsid = getenv("AWSSSEKMSID");
+    const char* envkmsid = getenv("AWSSSEKMSID");
     if(NULL == envkmsid){
         // nothing to do
         return true;
@@ -1186,6 +1186,7 @@ bool S3fsCurl::SetProxyUserPwd(const char* file)
 
 // cppcheck-suppress unmatchedSuppression
 // cppcheck-suppress constParameter
+// cppcheck-suppress constParameterCallback
 bool S3fsCurl::UploadMultipartPostCallback(S3fsCurl* s3fscurl, void* param)
 {
     if(!s3fscurl || param){     // this callback does not need a parameter
@@ -1197,6 +1198,7 @@ bool S3fsCurl::UploadMultipartPostCallback(S3fsCurl* s3fscurl, void* param)
 
 // cppcheck-suppress unmatchedSuppression
 // cppcheck-suppress constParameter
+// cppcheck-suppress constParameterCallback
 bool S3fsCurl::MixMultipartPostCallback(S3fsCurl* s3fscurl, void* param)
 {
     if(!s3fscurl || param){     // this callback does not need a parameter
@@ -1698,13 +1700,13 @@ bool S3fsCurl::UploadMultipartPostSetCurlOpts(S3fsCurl* s3fscurl)
     if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_UPLOAD, true)){              // HTTP PUT
         return false;
     }
-    if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_WRITEDATA, (void*)(&s3fscurl->bodydata))){
+    if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&s3fscurl->bodydata))){
         return false;
     }
     if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
         return false;
     }
-    if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_HEADERDATA, (void*)&(s3fscurl->responseHeaders))){
+    if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_HEADERDATA, reinterpret_cast<void*>(&s3fscurl->responseHeaders))){
         return false;
     }
     if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_HEADERFUNCTION, HeaderCallback)){
@@ -1741,13 +1743,13 @@ bool S3fsCurl::CopyMultipartPostSetCurlOpts(S3fsCurl* s3fscurl)
     if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_UPLOAD, true)){                // HTTP PUT
         return false;
     }
-    if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_WRITEDATA, (void*)(&s3fscurl->bodydata))){
+    if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&s3fscurl->bodydata))){
         return false;
     }
     if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
         return false;
     }
-    if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_HEADERDATA, (void*)(&s3fscurl->headdata))){
+    if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_HEADERDATA, reinterpret_cast<void*>(&s3fscurl->headdata))){
         return false;
     }
     if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_HEADERFUNCTION, WriteMemoryCallback)){
@@ -1808,7 +1810,7 @@ bool S3fsCurl::PreHeadRequestSetCurlOpts(S3fsCurl* s3fscurl)
     }
 
     // responseHeaders
-    if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_HEADERDATA, (void*)&(s3fscurl->responseHeaders))){
+    if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_HEADERDATA, reinterpret_cast<void*>(&s3fscurl->responseHeaders))){
         return false;
     }
     if(CURLE_OK != curl_easy_setopt(s3fscurl->hCurl, CURLOPT_HEADERFUNCTION, HeaderCallback)){
@@ -2219,7 +2221,7 @@ bool S3fsCurl::RemakeHandle()
                 return false;
             }
             // responseHeaders
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_HEADERDATA, (void*)&responseHeaders)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_HEADERDATA, reinterpret_cast<void*>(&responseHeaders))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_HEADERFUNCTION, HeaderCallback)){
@@ -2234,7 +2236,7 @@ bool S3fsCurl::RemakeHandle()
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_UPLOAD, true)){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -2252,7 +2254,7 @@ bool S3fsCurl::RemakeHandle()
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_UPLOAD, true)){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -2288,7 +2290,7 @@ bool S3fsCurl::RemakeHandle()
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -2300,7 +2302,7 @@ bool S3fsCurl::RemakeHandle()
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -2315,7 +2317,7 @@ bool S3fsCurl::RemakeHandle()
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_POST, true)){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -2333,7 +2335,7 @@ bool S3fsCurl::RemakeHandle()
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_POST, true)){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -2357,13 +2359,13 @@ bool S3fsCurl::RemakeHandle()
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_UPLOAD, true)){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_HEADERDATA, (void*)&responseHeaders)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_HEADERDATA, reinterpret_cast<void*>(&responseHeaders))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_HEADERFUNCTION, HeaderCallback)){
@@ -2387,13 +2389,13 @@ bool S3fsCurl::RemakeHandle()
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_UPLOAD, true)){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_HEADERDATA, (void*)&headdata)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_HEADERDATA, reinterpret_cast<void*>(&headdata))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_HEADERFUNCTION, WriteMemoryCallback)){
@@ -2408,7 +2410,7 @@ bool S3fsCurl::RemakeHandle()
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -2420,7 +2422,7 @@ bool S3fsCurl::RemakeHandle()
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -2455,7 +2457,7 @@ bool S3fsCurl::RemakeHandle()
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
                 return false;
             }
-            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+            if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
                 return false;
             }
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -3030,7 +3032,7 @@ int S3fsCurl::GetIAMv2ApiToken(const char* token_url, int token_ttl, const char*
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
         return -EIO;
     }
-    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
         return -EIO;
     }
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -3118,7 +3120,7 @@ bool S3fsCurl::GetIAMCredentials(const char* cred_url, const char* iam_v2_token,
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
         return false;
     }
-    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
         return false;
     }
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -3176,7 +3178,7 @@ bool S3fsCurl::GetIAMRoleFromMetaData(const char* cred_url, const char* iam_v2_t
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
         return false;
     }
-    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
         return false;
     }
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -3419,7 +3421,7 @@ int S3fsCurl::PutHeadRequest(const char* tpath, headers_t& meta, bool is_copy)
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_UPLOAD, true)){                // HTTP PUT
         return -EIO;
     }
-    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
         return -EIO;
     }
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -3552,7 +3554,7 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_UPLOAD, true)){                // HTTP PUT
         return -EIO;
     }
-    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
         return -EIO;
     }
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -3724,7 +3726,7 @@ int S3fsCurl::CheckBucket(const char* check_path, bool compat_dir)
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
         return -EIO;
     }
-    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
         return -EIO;
     }
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -3776,7 +3778,7 @@ int S3fsCurl::ListBucketRequest(const char* tpath, const char* query)
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
         return -EIO;
     }
-    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
         return -EIO;
     }
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -3874,7 +3876,7 @@ int S3fsCurl::PreMultipartPostRequest(const char* tpath, headers_t& meta, std::s
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_POST, true)){              // POST
         return -EIO;
     }
-    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
         return -EIO;
     }
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -3977,7 +3979,7 @@ int S3fsCurl::CompleteMultipartPostRequest(const char* tpath, const std::string&
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_POST, true)){              // POST
         return -EIO;
     }
-    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
         return -EIO;
     }
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -4038,7 +4040,7 @@ int S3fsCurl::MultipartListRequest(std::string& body)
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
         return -EIO;
     }
-    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, (void*)&bodydata)){
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEDATA, reinterpret_cast<void*>(&bodydata))){
         return -EIO;
     }
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
@@ -4298,12 +4300,15 @@ bool S3fsCurl::UploadMultipartPostComplete()
 
 // cppcheck-suppress unmatchedSuppression
 // cppcheck-suppress constParameter
+// cppcheck-suppress constParameterCallback
 bool S3fsCurl::CopyMultipartPostCallback(S3fsCurl* s3fscurl, void* param)
 {
     if(!s3fscurl || param){     // this callback does not need a parameter
         return false;
     }
 
+    // cppcheck-suppress unmatchedSuppression
+    // cppcheck-suppress knownConditionTrueFalse
     return s3fscurl->CopyMultipartPostComplete();
 }
 

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -532,7 +532,7 @@ FdEntity* FdManager::GetFdEntity(const char* path, int& existfd, bool newfd, Aut
     return NULL;
 }
 
-FdEntity* FdManager::Open(int& fd, const char* path, headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type)
+FdEntity* FdManager::Open(int& fd, const char* path, const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type)
 {
     S3FS_PRN_DBG("[path=%s][size=%lld][ts_mctime=%s][flags=0x%x][force_tmpfile=%s][create=%s][ignore_modify=%s]", SAFESTRPTR(path), static_cast<long long>(size), str(ts_mctime).c_str(), flags, (force_tmpfile ? "yes" : "no"), (is_create ? "yes" : "no"), (ignore_modify ? "yes" : "no"));
 

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -87,7 +87,7 @@ class FdManager
 
       // Return FdEntity associated with path, returning NULL on error.  This operation increments the reference count; callers must decrement via Close after use.
       FdEntity* GetFdEntity(const char* path, int& existfd, bool newfd = true, AutoLock::Type locktype = AutoLock::NONE);
-      FdEntity* Open(int& fd, const char* path, headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);
+      FdEntity* Open(int& fd, const char* path, const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);
       FdEntity* GetExistFdEntity(const char* path, int existfd = -1);
       FdEntity* OpenExistFdEntity(const char* path, int& fd, int flags = O_RDONLY);
       void Rename(const std::string &from, const std::string &to);

--- a/src/fdcache_auto.cpp
+++ b/src/fdcache_auto.cpp
@@ -96,7 +96,7 @@ FdEntity* AutoFdEntity::Attach(const char* path, int existfd)
     return pFdEntity;
 }
 
-FdEntity* AutoFdEntity::Open(const char* path, headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type)
+FdEntity* AutoFdEntity::Open(const char* path, const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type)
 {
     Close();
 

--- a/src/fdcache_auto.h
+++ b/src/fdcache_auto.h
@@ -55,7 +55,7 @@ class AutoFdEntity
       FdEntity* Attach(const char* path, int existfd);
       int GetPseudoFd() const { return pseudo_fd; }
 
-      FdEntity* Open(const char* path, headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);
+      FdEntity* Open(const char* path, const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);
       FdEntity* GetExistFdEntity(const char* path, int existfd = -1);
       FdEntity* OpenExistFdEntity(const char* path, int flags = O_RDONLY);
 };

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -275,10 +275,10 @@ int FdEntity::Dup(int fd, AutoLock::Type locktype)
         S3FS_PRN_ERR("Not found pseudo_fd(%d) in entity object(%s) for physical_fd(%d)", fd, path.c_str(), physical_fd);
         return -1;
     }
-    PseudoFdInfo*   org_pseudoinfo = iter->second;
-    PseudoFdInfo*   ppseudoinfo    = new PseudoFdInfo(physical_fd, (org_pseudoinfo ? org_pseudoinfo->GetFlags() : 0));
-    int             pseudo_fd      = ppseudoinfo->GetPseudoFd();
-    pseudo_fd_map[pseudo_fd]       = ppseudoinfo;
+    const PseudoFdInfo* org_pseudoinfo = iter->second;
+    PseudoFdInfo*       ppseudoinfo    = new PseudoFdInfo(physical_fd, (org_pseudoinfo ? org_pseudoinfo->GetFlags() : 0));
+    int                 pseudo_fd      = ppseudoinfo->GetPseudoFd();
+    pseudo_fd_map[pseudo_fd]           = ppseudoinfo;
 
     return pseudo_fd;
 }
@@ -404,7 +404,7 @@ bool FdEntity::IsUploading(AutoLock::Type locktype)
     AutoLock auto_lock(&fdent_lock, locktype);
 
     for(fdinfo_map_t::const_iterator iter = pseudo_fd_map.begin(); iter != pseudo_fd_map.end(); ++iter){
-        PseudoFdInfo* ppseudoinfo = iter->second;
+        const PseudoFdInfo* ppseudoinfo = iter->second;
         if(ppseudoinfo && ppseudoinfo->IsUploading()){
             return true;
         }
@@ -1467,7 +1467,7 @@ int FdEntity::RowFlush(int fd, const char* tpath, AutoLock::Type type, bool forc
 // [NOTE]
 // Both fdent_lock and fdent_data_lock must be locked before calling.
 //
-int FdEntity::RowFlushNoMultipart(PseudoFdInfo* pseudo_obj, const char* tpath)
+int FdEntity::RowFlushNoMultipart(const PseudoFdInfo* pseudo_obj, const char* tpath)
 {
     S3FS_PRN_INFO3("[tpath=%s][path=%s][pseudo_fd=%d][physical_fd=%d]", SAFESTRPTR(tpath), path.c_str(), (pseudo_obj ? pseudo_obj->GetPseudoFd() : -1), physical_fd);
 
@@ -2088,7 +2088,7 @@ ssize_t FdEntity::Write(int fd, const char* bytes, off_t start, size_t size)
 // [NOTE]
 // Both fdent_lock and fdent_data_lock must be locked before calling.
 //
-ssize_t FdEntity::WriteNoMultipart(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size)
+ssize_t FdEntity::WriteNoMultipart(const PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size)
 {
     S3FS_PRN_DBG("[path=%s][pseudo_fd=%d][physical_fd=%d][offset=%lld][size=%zu]", path.c_str(), (pseudo_obj ? pseudo_obj->GetPseudoFd() : -1), physical_fd, static_cast<long long int>(start), size);
 

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -83,11 +83,11 @@ class FdEntity
         int NoCachePreMultipartPost(PseudoFdInfo* pseudo_obj);
         int NoCacheMultipartPost(PseudoFdInfo* pseudo_obj, int tgfd, off_t start, off_t size);
         int NoCacheCompleteMultipartPost(PseudoFdInfo* pseudo_obj);
-        int RowFlushNoMultipart(PseudoFdInfo* pseudo_obj, const char* tpath);
+        int RowFlushNoMultipart(const PseudoFdInfo* pseudo_obj, const char* tpath);
         int RowFlushMultipart(PseudoFdInfo* pseudo_obj, const char* tpath);
         int RowFlushMixMultipart(PseudoFdInfo* pseudo_obj, const char* tpath);
         int RowFlushStreamMultipart(PseudoFdInfo* pseudo_obj, const char* tpath);
-        ssize_t WriteNoMultipart(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size);
+        ssize_t WriteNoMultipart(const PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size);
         ssize_t WriteMultipart(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size);
         ssize_t WriteMixMultipart(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size);
         ssize_t WriteStreamUpload(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size);

--- a/src/fdcache_fdinfo.cpp
+++ b/src/fdcache_fdinfo.cpp
@@ -143,6 +143,8 @@ PseudoFdInfo::~PseudoFdInfo()
 
 bool PseudoFdInfo::Clear()
 {
+    // cppcheck-suppress unmatchedSuppression
+    // cppcheck-suppress knownConditionTrueFalse
     if(!CancelAllThreads() || !ResetUploadInfo(AutoLock::NONE)){
         return false;
     }
@@ -232,6 +234,8 @@ bool PseudoFdInfo::Readable() const
 bool PseudoFdInfo::ClearUploadInfo(bool is_cancel_mp)
 {
     if(is_cancel_mp){
+        // cppcheck-suppress unmatchedSuppression
+        // cppcheck-suppress knownConditionTrueFalse
         if(!CancelAllThreads()){
             return false;
         }
@@ -260,10 +264,14 @@ bool PseudoFdInfo::RowInitialUploadInfo(const std::string& id, bool is_cancel_mp
     }
 
     if(is_cancel_mp){
+        // cppcheck-suppress unmatchedSuppression
+        // cppcheck-suppress knownConditionTrueFalse
         if(!ClearUploadInfo(is_cancel_mp)){
             return false;
         }
     }else{
+        // cppcheck-suppress unmatchedSuppression
+        // cppcheck-suppress knownConditionTrueFalse
         if(!ResetUploadInfo(type)){
             return false;
         }

--- a/src/fdcache_page.cpp
+++ b/src/fdcache_page.cpp
@@ -657,9 +657,7 @@ size_t PageList::GetUnloadedPages(fdpage_list_t& unloaded_list, off_t start, off
 bool PageList::GetPageListsForMultipartUpload(fdpage_list_t& dlpages, fdpage_list_t& mixuppages, off_t max_partsize)
 {
     // compress before this processing
-    if(!Compress()){
-        return false;
-    }
+    Compress();         // always true
 
     // make a list by modified flag
     fdpage_list_t modified_pages;
@@ -760,9 +758,7 @@ bool PageList::GetPageListsForMultipartUpload(fdpage_list_t& dlpages, fdpage_lis
 bool PageList::GetNoDataPageLists(fdpage_list_t& nodata_pages, off_t start, size_t size)
 {
     // compress before this processing
-    if(!Compress()){
-        return false;
-    }
+    Compress();         // always true
 
     // extract areas without data
     fdpage_list_t tmp_pagelist;

--- a/src/openssl_auth.cpp
+++ b/src/openssl_auth.cpp
@@ -161,6 +161,9 @@ bool s3fs_init_crypt_mutex()
 {
     if(s3fs_crypt_mutex){
         S3FS_PRN_DBG("s3fs_crypt_mutex is not NULL, destroy it.");
+
+        // cppcheck-suppress unmatchedSuppression
+        // cppcheck-suppress knownConditionTrueFalse
         if(!s3fs_destroy_crypt_mutex()){
             S3FS_PRN_ERR("Failed to s3fs_crypt_mutex");
             return false;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3146,6 +3146,8 @@ static int s3fs_opendir(const char* _path, struct fuse_file_info* fi)
     return result;
 }
 
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameterCallback
 static bool multi_head_callback(S3fsCurl* s3fscurl, void* param)
 {
     if(!s3fscurl){
@@ -3949,6 +3951,8 @@ static int s3fs_setxattr(const char* path, const char* name, const char* value, 
             // This requires the key to be present in order to add xattr.
             ent->SetXattr(strxattr);
         }
+        // cppcheck-suppress unmatchedSuppression
+        // cppcheck-suppress knownConditionTrueFalse
         if(0 != (result = set_xattrs_to_header(updatemeta, name, value, size, flags))){
             return result;
         }
@@ -3965,6 +3969,8 @@ static int s3fs_setxattr(const char* path, const char* name, const char* value, 
     }
     if(need_put_header){
         // not found opened file.
+        // cppcheck-suppress unmatchedSuppression
+        // cppcheck-suppress knownConditionTrueFalse
         if(0 != (result = set_xattrs_to_header(meta, name, value, size, flags))){
             return result;
         }
@@ -4684,6 +4690,7 @@ static fsblkcnt_t parse_bucket_size(char* max_size)
 //
 // if the key is equal to FUSE_OPT_KEY_NONOPT, it's either the bucket name 
 //  or the mountpoint. The bucket name will always come before the mountpoint
+//
 static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_args* outargs)
 {
     int ret;

--- a/src/s3fs_cred.cpp
+++ b/src/s3fs_cred.cpp
@@ -995,9 +995,9 @@ bool S3fsCred::InitialS3fsCredentials()
     }
 
     // 3  - environment variables
-    char* AWSACCESSKEYID     = getenv("AWS_ACCESS_KEY_ID") ?     getenv("AWS_ACCESS_KEY_ID") :     getenv("AWSACCESSKEYID");
-    char* AWSSECRETACCESSKEY = getenv("AWS_SECRET_ACCESS_KEY") ? getenv("AWS_SECRET_ACCESS_KEY") : getenv("AWSSECRETACCESSKEY");
-    char* AWSSESSIONTOKEN    = getenv("AWS_SESSION_TOKEN") ?     getenv("AWS_SESSION_TOKEN") :     getenv("AWSSESSIONTOKEN");
+    const char* AWSACCESSKEYID     = getenv("AWS_ACCESS_KEY_ID") ?     getenv("AWS_ACCESS_KEY_ID") :     getenv("AWSACCESSKEYID");
+    const char* AWSSECRETACCESSKEY = getenv("AWS_SECRET_ACCESS_KEY") ? getenv("AWS_SECRET_ACCESS_KEY") : getenv("AWSSECRETACCESSKEY");
+    const char* AWSSESSIONTOKEN    = getenv("AWS_SESSION_TOKEN") ?     getenv("AWS_SESSION_TOKEN") :     getenv("AWSSESSIONTOKEN");
 
     if(AWSACCESSKEYID != NULL || AWSSECRETACCESSKEY != NULL){
         if( (AWSACCESSKEYID == NULL && AWSSECRETACCESSKEY != NULL) ||

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -310,7 +310,7 @@ bool get_unixtime_from_iso8601(const char* pdate, time_t& unixtime)
     }
 
     struct tm tm;
-    char*     prest = strptime(pdate, "%Y-%m-%dT%T", &tm);
+    const char* prest = strptime(pdate, "%Y-%m-%dT%T", &tm);
     if(prest == pdate){
         // wrong format
         return false;

--- a/src/threadpoolman.cpp
+++ b/src/threadpoolman.cpp
@@ -236,6 +236,8 @@ bool ThreadPoolMan::StartThreads(int count)
     }
 
     // stop all thread if they are running.
+    // cppcheck-suppress unmatchedSuppression
+    // cppcheck-suppress knownConditionTrueFalse
     if(!StopThreads()){
         S3FS_PRN_ERR("Failed to stop existed threads.");
         return false;

--- a/test/cr_filename.c
+++ b/test/cr_filename.c
@@ -31,7 +31,7 @@
 // This program truncates the file and reads the file in another process
 // between truncate and flush(close file).
 //
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
     if(argc != 2){
         fprintf(stderr, "[ERROR] Wrong paraemters\n");

--- a/test/junk_data.c
+++ b/test/junk_data.c
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
     if (argc != 2) {
         return 1;

--- a/test/mknod_test.c
+++ b/test/mknod_test.c
@@ -134,7 +134,7 @@ bool TestMknod(const char* basepath, mode_t mode)
 //---------------------------------------------------------
 // Main
 //---------------------------------------------------------
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
     // Parse parameters
     if(2 != argc){


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2197 

### Details
Fixed a description error in ci.yml in #2197.
(Due to this description error, current code cannot be executed cppcheck.)
Also, #2197 was in the process of supporting cppcheck 2.1x, so I fixed it to support it correctly.
(verified with cppcheck 2.11.1)

The following parts have not been modified. (avoided by `suppress` inline comment)
- Make arguments of Callback function to const
- Judgment statements for functions that return only true