### PR TITLE
Convert fixed-size allocations to C++11 std::array

### DIFF
--- a/src/common_auth.cpp
+++ b/src/common_auth.cpp
@@ -29,18 +29,16 @@
 //-------------------------------------------------------------------
 std::string s3fs_get_content_md5(int fd)
 {
-    unsigned char* md5;
+    md5_t md5;
     char* base64;
     std::string Signature;
 
-    if(nullptr == (md5 = s3fs_md5_fd(fd, 0, -1))){
+    if(!s3fs_md5_fd(fd, 0, -1, &md5)){
         return std::string("");
     }
-    if(nullptr == (base64 = s3fs_base64(md5, get_md5_digest_length()))){
-        delete[] md5;
+    if(nullptr == (base64 = s3fs_base64(md5.data(), md5.size()))){
         return std::string("");  // ENOMEM
     }
-    delete[] md5;
 
     Signature = base64;
     delete[] base64;
@@ -50,15 +48,13 @@ std::string s3fs_get_content_md5(int fd)
 
 std::string s3fs_sha256_hex_fd(int fd, off_t start, off_t size)
 {
-    size_t digestlen = get_sha256_digest_length();
-    unsigned char* sha256;
+    sha256_t sha256;
 
-    if(nullptr == (sha256 = s3fs_sha256_fd(fd, start, size))){
+    if(!s3fs_sha256_fd(fd, start, size, &sha256)){
         return std::string("");
     }
 
-    std::string sha256hex = s3fs_hex_lower(sha256, digestlen);
-    delete[] sha256;
+    std::string sha256hex = s3fs_hex_lower(sha256.data(), sha256.size());
 
     return sha256hex;
 }

--- a/src/nss_auth.cpp
+++ b/src/nss_auth.cpp
@@ -146,22 +146,16 @@ bool s3fs_HMAC256(const void* key, size_t keylen, const unsigned char* data, siz
 //-------------------------------------------------------------------
 // Utility Function for MD5
 //-------------------------------------------------------------------
-size_t get_md5_digest_length()
-{
-    return MD5_LENGTH;
-}
-
-unsigned char* s3fs_md5_fd(int fd, off_t start, off_t size)
+bool s3fs_md5_fd(int fd, off_t start, off_t size, md5_t* result)
 {
     PK11Context*   md5ctx;
     off_t          bytes;
-    unsigned char* result;
     unsigned int   md5outlen;
 
     if(-1 == size){
         struct stat st;
         if(-1 == fstat(fd, &st)){
-            return nullptr;
+            return false;
         }
         size = st.st_size;
     }
@@ -180,53 +174,42 @@ unsigned char* s3fs_md5_fd(int fd, off_t start, off_t size)
             // error
             S3FS_PRN_ERR("file read error(%d)", errno);
             PK11_DestroyContext(md5ctx, PR_TRUE);
-            return nullptr;
+            return false;
         }
         PK11_DigestOp(md5ctx, buf, bytes);
     }
-    result = new unsigned char[get_md5_digest_length()];
-    PK11_DigestFinal(md5ctx, result, &md5outlen, get_md5_digest_length());
+    PK11_DigestFinal(md5ctx, result->data(), &md5outlen, result->size());
     PK11_DestroyContext(md5ctx, PR_TRUE);
 
-    return result;
+    return false;
 }
 
 //-------------------------------------------------------------------
 // Utility Function for SHA256
 //-------------------------------------------------------------------
-size_t get_sha256_digest_length()
+bool s3fs_sha256(const unsigned char* data, size_t datalen, sha256_t* digest)
 {
-    return SHA256_LENGTH;
-}
-
-bool s3fs_sha256(const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen)
-{
-    (*digestlen) = static_cast<unsigned int>(get_sha256_digest_length());
-    *digest      = new unsigned char[*digestlen];
-
     PK11Context*   sha256ctx;
     unsigned int   sha256outlen;
     sha256ctx = PK11_CreateDigestContext(SEC_OID_SHA256);
 
     PK11_DigestOp(sha256ctx, data, datalen);
-    PK11_DigestFinal(sha256ctx, *digest, &sha256outlen, *digestlen);
+    PK11_DigestFinal(sha256ctx, digest->data(), &sha256outlen, digest->size());
     PK11_DestroyContext(sha256ctx, PR_TRUE);
-    *digestlen = sha256outlen;
 
     return true;
 }
 
-unsigned char* s3fs_sha256_fd(int fd, off_t start, off_t size)
+bool s3fs_sha256_fd(int fd, off_t start, off_t size, sha256_t* result)
 {
     PK11Context*   sha256ctx;
     off_t          bytes;
-    unsigned char* result;
     unsigned int   sha256outlen;
 
     if(-1 == size){
         struct stat st;
         if(-1 == fstat(fd, &st)){
-            return nullptr;
+            return false;
         }
         size = st.st_size;
     }
@@ -245,15 +228,14 @@ unsigned char* s3fs_sha256_fd(int fd, off_t start, off_t size)
             // error
             S3FS_PRN_ERR("file read error(%d)", errno);
             PK11_DestroyContext(sha256ctx, PR_TRUE);
-            return nullptr;
+            return false;
         }
         PK11_DigestOp(sha256ctx, buf, bytes);
     }
-    result = new unsigned char[get_sha256_digest_length()];
-    PK11_DigestFinal(sha256ctx, result, &sha256outlen, get_sha256_digest_length());
+    PK11_DigestFinal(sha256ctx, result->data(), &sha256outlen, result->size());
     PK11_DestroyContext(sha256ctx, PR_TRUE);
 
-    return result;
+    return true;
 }
 
 /*

--- a/src/s3fs_auth.h
+++ b/src/s3fs_auth.h
@@ -21,8 +21,12 @@
 #ifndef S3FS_AUTH_H_
 #define S3FS_AUTH_H_
 
+#include <array>
 #include <string>
 #include <sys/types.h>
+
+typedef std::array<unsigned char, 16> md5_t;
+typedef std::array<unsigned char, 32> sha256_t;
 
 //-------------------------------------------------------------------
 // Utility functions for Authentication
@@ -43,11 +47,9 @@ bool s3fs_init_crypt_mutex();
 bool s3fs_destroy_crypt_mutex();
 bool s3fs_HMAC(const void* key, size_t keylen, const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen);
 bool s3fs_HMAC256(const void* key, size_t keylen, const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen);
-size_t get_md5_digest_length();
-unsigned char* s3fs_md5_fd(int fd, off_t start, off_t size);
-bool s3fs_sha256(const unsigned char* data, size_t datalen, unsigned char** digest, unsigned int* digestlen);
-size_t get_sha256_digest_length();
-unsigned char* s3fs_sha256_fd(int fd, off_t start, off_t size);
+bool s3fs_md5_fd(int fd, off_t start, off_t size, md5_t* result);
+bool s3fs_sha256(const unsigned char* data, size_t datalen, sha256_t* digest);
+bool s3fs_sha256_fd(int fd, off_t start, off_t size, sha256_t* result);
 
 #endif // S3FS_AUTH_H_
 


### PR DESCRIPTION
This is safer and more efficient.