### PR TITLE
Fix junk_data for 32-bit platforms

### DIFF
--- a/test/junk_data.cc
+++ b/test/junk_data.cc
@@ -21,6 +21,7 @@
 // Generate junk data at high speed.  An alternative to dd if=/dev/urandom.
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 int main(int argc, const char *argv[])
@@ -28,11 +29,11 @@ int main(int argc, const char *argv[])
     if (argc != 2) {
         return 1;
     }
-    unsigned long long count = strtoull(argv[1], nullptr, 10);
+    uint64_t count = strtoull(argv[1], nullptr, 10);
     char buf[128 * 1024];
-    for (size_t i = 0; i < count; i += sizeof(buf)) {
-        for (size_t j = 0; j < sizeof(buf) / sizeof(i); ++j) {
-            *(reinterpret_cast<long long *>(buf) + j) = i / sizeof(i) + j;
+    for (uint64_t i = 0; i < count; i += sizeof(buf)) {
+        for (uint64_t j = 0; j < sizeof(buf) / sizeof(i); ++j) {
+            *(reinterpret_cast<uint64_t *>(buf) + j) = i / sizeof(i) + j;
         }
         fwrite(buf, 1, sizeof(buf) > count - i ? count - i : sizeof(buf), stdout);
     }


### PR DESCRIPTION
Previously this had a mismatch between `size_t` and `unsigned long long`.