### PR TITLE
Convert most `std::list` to `std::vector`

### DIFF
--- a/src/addhead.h
+++ b/src/addhead.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <regex.h>
+#include <vector>
 
 #include "metaheader.h"
 

--- a/src/curl.h
+++ b/src/curl.h
@@ -22,7 +22,6 @@
 #define S3FS_CURL_H_
 
 #include <curl/curl.h>
-#include <list>
 #include <map>
 #include <memory>
 #include <vector>
@@ -84,7 +83,7 @@ class Semaphore;
 typedef bool (*s3fscurl_lazy_setup)(S3fsCurl* s3fscurl);
 
 typedef std::map<std::string, std::string> sseckeymap_t;
-typedef std::list<sseckeymap_t>            sseckeylist_t;
+typedef std::vector<sseckeymap_t>          sseckeylist_t;
 
 // Class for lapping curl
 //

--- a/src/curl_handlerpool.h
+++ b/src/curl_handlerpool.h
@@ -23,6 +23,7 @@
 
 #include <cassert>
 #include <curl/curl.h>
+#include <list>
 
 //----------------------------------------------
 // Typedefs

--- a/src/curl_multi.h
+++ b/src/curl_multi.h
@@ -22,6 +22,7 @@
 #define S3FS_CURL_MULTI_H_
 
 #include <memory>
+#include <vector>
 
 //----------------------------------------------
 // Typedef

--- a/src/fdcache_fdinfo.cpp
+++ b/src/fdcache_fdinfo.cpp
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <errno.h>
@@ -371,7 +372,7 @@ bool PseudoFdInfo::AppendUploadPart(off_t start, off_t size, bool is_copy, etagp
 //
 static bool filepart_partnum_compare(const filepart& src1, const filepart& src2)
 {
-    return (src1.get_part_number() <= src2.get_part_number());
+    return src1.get_part_number() < src2.get_part_number();
 }
 
 bool PseudoFdInfo::InsertUploadPart(off_t start, off_t size, int part_num, bool is_copy, etagpair** ppetag, AutoLock::Type type)
@@ -394,7 +395,7 @@ bool PseudoFdInfo::InsertUploadPart(off_t start, off_t size, int part_num, bool 
     upload_list.emplace_back(false, physical_fd, start, size, is_copy, petag_entity);
 
     // sort by part number
-    upload_list.sort(filepart_partnum_compare);
+    std::sort(upload_list.begin(), upload_list.end(), filepart_partnum_compare);
 
     // set etag pointer
     *ppetag = petag_entity;

--- a/src/fdcache_page.h
+++ b/src/fdcache_page.h
@@ -21,8 +21,8 @@
 #ifndef S3FS_FDCACHE_PAGE_H_
 #define S3FS_FDCACHE_PAGE_H_
 
-#include <list>
 #include <sys/types.h>
+#include <vector>
 
 //------------------------------------------------
 // Symbols
@@ -61,7 +61,7 @@ struct fdpage
         return (0 < bytes ? offset + bytes - 1 : 0);
     }
 };
-typedef std::list<struct fdpage> fdpage_list_t;
+typedef std::vector<struct fdpage> fdpage_list_t;
 
 //------------------------------------------------
 // Class PageList

--- a/src/fdcache_pseudofd.h
+++ b/src/fdcache_pseudofd.h
@@ -21,6 +21,8 @@
 #ifndef S3FS_FDCACHE_PSEUDOFD_H_
 #define S3FS_FDCACHE_PSEUDOFD_H_
 
+#include <vector>
+
 //------------------------------------------------
 // Typdefs
 //------------------------------------------------

--- a/src/mpu_util.h
+++ b/src/mpu_util.h
@@ -22,7 +22,7 @@
 #define S3FS_MPU_UTIL_H_
 
 #include <string>
-#include <list>
+#include <vector>
 
 //-------------------------------------------------------------------
 // Structure / Typedef
@@ -34,7 +34,7 @@ typedef struct incomplete_multipart_upload_info
     std::string date;
 }INCOMP_MPU_INFO;
 
-typedef std::list<INCOMP_MPU_INFO>      incomp_mpu_list_t;
+typedef std::vector<INCOMP_MPU_INFO> incomp_mpu_list_t;
 
 //-------------------------------------------------------------------
 // enum for utility process mode

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3282,7 +3282,7 @@ static int readdir_multi_head(const char* path, const S3ObjList& head, void* buf
     }
 
     // Make single head request(with max).
-    for(s3obj_list_t::iterator iter = headlist.begin(); headlist.end() != iter; iter = headlist.erase(iter)){
+    for(s3obj_list_t::iterator iter = headlist.begin(); headlist.end() != iter; ++iter){
         std::string disppath = path + (*iter);
         std::string etag     = head.GetETag((*iter).c_str());
         struct stat st;
@@ -3312,6 +3312,7 @@ static int readdir_multi_head(const char* path, const S3ObjList& head, void* buf
             continue;
         }
     }
+    headlist.clear();
 
     // Multi request
     if(0 != (result = curlmulti.Request())){

--- a/src/s3objlist.h
+++ b/src/s3objlist.h
@@ -21,7 +21,6 @@
 #ifndef S3FS_S3OBJLIST_H_
 #define S3FS_S3OBJLIST_H_
 
-#include <list>
 #include <map>
 #include <string>
 #include <vector>
@@ -39,7 +38,7 @@ struct s3obj_entry{
 };
 
 typedef std::map<std::string, struct s3obj_entry> s3obj_t;
-typedef std::list<std::string> s3obj_list_t;
+typedef std::vector<std::string> s3obj_list_t;
 
 //-------------------------------------------------------------------
 // Class S3ObjList

--- a/src/threadpoolman.h
+++ b/src/threadpoolman.h
@@ -21,6 +21,9 @@
 #ifndef S3FS_THREADPOOLMAN_H_
 #define S3FS_THREADPOOLMAN_H_
 
+#include <list>
+#include <vector>
+
 #include "psemaphore.h"
 
 //------------------------------------------------
@@ -50,7 +53,7 @@ struct thpoolman_param
 
 typedef std::list<thpoolman_param*>  thpoolman_params_t;
 
-typedef std::list<pthread_t>  thread_list_t;
+typedef std::vector<pthread_t> thread_list_t;
 
 //------------------------------------------------
 // Class ThreadPoolMan

--- a/src/types.h
+++ b/src/types.h
@@ -172,10 +172,12 @@ struct etagpair
     }
 };
 
+// Requires pointer stability and thus must be a list not a vector
 typedef std::list<etagpair> etaglist_t;
 
 struct petagpool
 {
+    // Requires pointer stability and thus must be a list not a vector
     std::list<etagpair> petaglist;
 
     ~petagpool()
@@ -249,7 +251,7 @@ struct filepart
     }
 };
 
-typedef std::list<filepart> filepart_list_t;
+typedef std::vector<filepart> filepart_list_t;
 
 //
 // Each part information for Untreated parts
@@ -307,7 +309,7 @@ struct untreatedpart
     }
 };
 
-typedef std::list<untreatedpart> untreated_list_t;
+typedef std::vector<untreatedpart> untreated_list_t;
 
 //
 // Information on each part of multipart upload
@@ -321,7 +323,7 @@ struct mp_part
     explicit mp_part(off_t set_start = 0, off_t set_size = 0, int part = 0) : start(set_start), size(set_size), part_num(part) {}
 };
 
-typedef std::list<struct mp_part> mp_part_list_t;
+typedef std::vector<struct mp_part> mp_part_list_t;
 
 inline off_t total_mp_part_list(const mp_part_list_t& mplist)
 {
@@ -346,7 +348,7 @@ typedef std::map<std::string, std::string, case_insensitive_compare_func> mimes_
 //-------------------------------------------------------------------
 // Typedefs specialized for use
 //-------------------------------------------------------------------
-typedef std::list<std::string>             readline_t;
+typedef std::vector<std::string>           readline_t;
 typedef std::map<std::string, std::string> kvmap_t;
 typedef std::map<std::string, kvmap_t>     bucketkvmap_t;
 

--- a/test/write_multiblock.cc
+++ b/test/write_multiblock.cc
@@ -22,8 +22,9 @@
 #include <cstdlib>
 #include <iostream>
 #include <climits>
-#include <string>
 #include <list>
+#include <string>
+#include <vector>
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -41,8 +42,8 @@ struct write_block_part
     off_t size;
 };
 
-typedef std::list<write_block_part> wbpart_list_t;
-typedef std::list<std::string>      strlist_t;
+typedef std::vector<write_block_part> wbpart_list_t;
+typedef std::list<std::string>        strlist_t;
 
 //---------------------------------------------------------
 // Const


### PR DESCRIPTION
This tends to be more efficient due to fewer allocations.  Also fix `std::sort` comparator which should be strictly less than.