### PR TITLE
Return `std::string` from base64 encoding function

### DIFF
--- a/src/common_auth.cpp
+++ b/src/common_auth.cpp
@@ -30,20 +30,11 @@
 std::string s3fs_get_content_md5(int fd)
 {
     md5_t md5;
-    char* base64;
-    std::string Signature;
-
     if(!s3fs_md5_fd(fd, 0, -1, &md5)){
+        // TODO: better return value?
         return std::string("");
     }
-    if(nullptr == (base64 = s3fs_base64(md5.data(), md5.size()))){
-        return std::string("");  // ENOMEM
-    }
-
-    Signature = base64;
-    delete[] base64;
-
-    return Signature;
+    return s3fs_base64(md5.data(), md5.size());
 }
 
 std::string s3fs_sha256_hex_fd(int fd, off_t start, off_t size)

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3636,15 +3636,8 @@ static bool get_xattr_posix_key_value(const char* path, std::string& xattrvalue,
     }
 
     // convert value by base64
-    char* base64val = s3fs_base64((iter->second)->pvalue, (iter->second)->length);
-    if(!base64val){
-        free_xattrs(xattrs);
-        return false;
-    }
+    xattrvalue = s3fs_base64(iter->second->pvalue, iter->second->length);
     free_xattrs(xattrs);
-
-    xattrvalue = base64val;
-    delete[] base64val;
 
     return true;
 }
@@ -3771,11 +3764,7 @@ static std::string raw_build_xattrs(const xattrs_t& xattrs)
         strxattrs += "\":\"";
 
         if(iter->second){
-            char* base64val = s3fs_base64((iter->second)->pvalue, (iter->second)->length);
-            if(base64val){
-                strxattrs += base64val;
-                delete[] base64val;
-            }
+            strxattrs += s3fs_base64(iter->second->pvalue, iter->second->length);
         }
         strxattrs += '\"';
     }

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -373,31 +373,26 @@ std::string s3fs_hex_upper(const unsigned char* input, size_t length)
     return s3fs_hex(input, length, "0123456789ABCDEF");
 }
 
-char* s3fs_base64(const unsigned char* input, size_t length)
+std::string s3fs_base64(const unsigned char* input, size_t length)
 {
     static const char base[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-    char* result;
 
-    if(!input || 0 == length){
-        return nullptr;
-    }
-    result = new char[((length + 3 - 1) / 3) * 4 + 1];
+    std::string result;
+    result.reserve(((length + 3 - 1) / 3) * 4 + 1);
 
     unsigned char parts[4];
     size_t rpos;
-    size_t wpos;
-    for(rpos = 0, wpos = 0; rpos < length; rpos += 3){
+    for(rpos = 0; rpos < length; rpos += 3){
         parts[0] = (input[rpos] & 0xfc) >> 2;
         parts[1] = ((input[rpos] & 0x03) << 4) | ((((rpos + 1) < length ? input[rpos + 1] : 0x00) & 0xf0) >> 4);
         parts[2] = (rpos + 1) < length ? (((input[rpos + 1] & 0x0f) << 2) | ((((rpos + 2) < length ? input[rpos + 2] : 0x00) & 0xc0) >> 6)) : 0x40;
         parts[3] = (rpos + 2) < length ? (input[rpos + 2] & 0x3f) : 0x40;
 
-        result[wpos++] = base[parts[0]];
-        result[wpos++] = base[parts[1]];
-        result[wpos++] = base[parts[2]];
-        result[wpos++] = base[parts[3]];
+        result += base[parts[0]];
+        result += base[parts[1]];
+        result += base[parts[2]];
+        result += base[parts[3]];
     }
-    result[wpos] = '\0';
 
     return result;
 }

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -105,8 +105,8 @@ bool get_keyword_value(const std::string& target, const char* keyword, std::stri
 //
 std::string s3fs_hex_lower(const unsigned char* input, size_t length);
 std::string s3fs_hex_upper(const unsigned char* input, size_t length);
-// TODO: return std::string
-char* s3fs_base64(const unsigned char* input, size_t length);
+std::string s3fs_base64(const unsigned char* input, size_t length);
+// TODO: return std::unique_ptr
 unsigned char* s3fs_decode64(const char* input, size_t input_len, size_t* plength);
 
 //

--- a/src/test_string_util.cpp
+++ b/src/test_string_util.cpp
@@ -56,30 +56,30 @@ void test_base64()
     unsigned char *buf;
     size_t len;
 
-    ASSERT_STREQUALS(s3fs_base64(nullptr, 0), nullptr);
+    ASSERT_STREQUALS(s3fs_base64(nullptr, 0).c_str(), nullptr);
     buf = s3fs_decode64(nullptr, 0, &len);
     ASSERT_BUFEQUALS(reinterpret_cast<const char *>(buf), len, nullptr, 0);
 
-    ASSERT_STREQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>(""), 0), nullptr);
+    ASSERT_STREQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>(""), 0).c_str(), nullptr);
     buf = s3fs_decode64("", 0, &len);
     ASSERT_BUFEQUALS(reinterpret_cast<const char *>(buf), len, nullptr, 0);
 
-    ASSERT_STREQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>("1"), 1), "MQ==");
+    ASSERT_EQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>("1"), 1), std::string("MQ=="));
     buf = s3fs_decode64("MQ==", 4, &len);
     ASSERT_BUFEQUALS(reinterpret_cast<const char *>(buf), len, "1", 1);
     ASSERT_EQUALS(len, static_cast<size_t>(1));
 
-    ASSERT_STREQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>("12"), 2), "MTI=");
+    ASSERT_EQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>("12"), 2), std::string("MTI="));
     buf = s3fs_decode64("MTI=", 4, &len);
     ASSERT_BUFEQUALS(reinterpret_cast<const char *>(buf), len, "12", 2);
     ASSERT_EQUALS(len, static_cast<size_t>(2));
 
-    ASSERT_STREQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>("123"), 3), "MTIz");
+    ASSERT_EQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>("123"), 3), std::string("MTIz"));
     buf = s3fs_decode64("MTIz", 4, &len);
     ASSERT_BUFEQUALS(reinterpret_cast<const char *>(buf), len, "123", 3);
     ASSERT_EQUALS(len, static_cast<size_t>(3));
 
-    ASSERT_STREQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>("1234"), 4), "MTIzNA==");
+    ASSERT_EQUALS(s3fs_base64(reinterpret_cast<const unsigned char *>("1234"), 4), std::string("MTIzNA=="));
     buf = s3fs_decode64("MTIzNA==", 8, &len);
     ASSERT_BUFEQUALS(reinterpret_cast<const char *>(buf), len, "1234", 4);
     ASSERT_EQUALS(len, static_cast<size_t>(4));


### PR DESCRIPTION
This is avoids manual memory allocations.