### PR TITLE
Delete copy constructors and assignment operators

### DIFF
--- a/src/autolock.h
+++ b/src/autolock.h
@@ -40,7 +40,8 @@ class AutoLock
         bool is_lock_acquired;
 
     private:
-        AutoLock(const AutoLock&);
+        AutoLock(const AutoLock&) = delete;
+        AutoLock& operator=(const AutoLock&) = delete;
 
     public:
         explicit AutoLock(pthread_mutex_t* pmutex, Type type = NONE);

--- a/src/fdcache_auto.cpp
+++ b/src/fdcache_auto.cpp
@@ -31,24 +31,6 @@ AutoFdEntity::AutoFdEntity() : pFdEntity(nullptr), pseudo_fd(-1)
 {
 }
 
-// [NOTE]
-// The copy constructor should not be called, then this is private method.
-// Even if it is called, the consistency of the number of
-// references can be maintained, but this case is not assumed.
-//
-AutoFdEntity::AutoFdEntity(AutoFdEntity& other) : pFdEntity(nullptr), pseudo_fd(-1)
-{
-    S3FS_PRN_WARN("This method should not be called. Please check the caller.");
-
-    if(other.pFdEntity){
-        if(-1 != (pseudo_fd = other.pFdEntity->Dup(other.pseudo_fd))){
-            pFdEntity = other.pFdEntity;
-        }else{
-            S3FS_PRN_ERR("Failed duplicating fd in AutoFdEntity.");
-        }
-    }
-}
-
 AutoFdEntity::~AutoFdEntity()
 {
     Close();
@@ -129,28 +111,6 @@ FdEntity* AutoFdEntity::OpenExistFdEntity(const char* path, int flags)
         return nullptr;
     }
     return pFdEntity;
-}
-
-// [NOTE]
-// This operator should not be called, then this is private method.
-// Even if it is called, the consistency of the number of
-// references can be maintained, but this case is not assumed.
-//
-bool AutoFdEntity::operator=(AutoFdEntity& other)
-{
-    S3FS_PRN_WARN("This method should not be called. Please check the caller.");
-
-    Close();
-
-    if(other.pFdEntity){
-        if(-1 != (pseudo_fd = other.pFdEntity->Dup(other.pseudo_fd))){
-            pFdEntity = other.pFdEntity;
-        }else{
-            S3FS_PRN_ERR("Failed duplicating fd in AutoFdEntity.");
-            return false;
-        }
-    }
-    return true;
 }
 
 /*

--- a/src/fdcache_auto.h
+++ b/src/fdcache_auto.h
@@ -43,8 +43,8 @@ class AutoFdEntity
       int       pseudo_fd;
 
   private:
-      AutoFdEntity(AutoFdEntity& other);
-      bool operator=(AutoFdEntity& other);
+      AutoFdEntity(const AutoFdEntity&) = delete;
+      AutoFdEntity& operator=(const AutoFdEntity&) = delete;
 
   public:
       AutoFdEntity();

--- a/src/fdcache_page.cpp
+++ b/src/fdcache_page.cpp
@@ -358,14 +358,6 @@ PageList::PageList(off_t size, bool is_loaded, bool is_modified, bool shrinked) 
     Init(size, is_loaded, is_modified);
 }
 
-PageList::PageList(const PageList& other)
-{
-    for(fdpage_list_t::const_iterator iter = other.pages.begin(); iter != other.pages.end(); ++iter){
-        pages.push_back(*iter);
-    }
-    is_shrink = other.is_shrink;
-}
-
 PageList::~PageList()
 {
     Clear();

--- a/src/fdcache_page.h
+++ b/src/fdcache_page.h
@@ -98,7 +98,8 @@ class PageList
         static void FreeList(fdpage_list_t& list);
 
         explicit PageList(off_t size = 0, bool is_loaded = false, bool is_modified = false, bool shrinked = false);
-        explicit PageList(const PageList& other);
+        PageList(const PageList&) = delete;
+        PageList& operator=(const PageList&) = delete;
         ~PageList();
 
         bool Init(off_t size, bool is_loaded, bool is_modified);


### PR DESCRIPTION
One of these was buggy and others had the wrong parameters and return types.