### PR TITLE
Set exit code for Valgrind

### DIFF
--- a/test/run_tests_using_sanitizers.sh
+++ b/test/run_tests_using_sanitizers.sh
@@ -61,7 +61,7 @@ make check -C test/
 make clean
 ./configure CXXFLAGS="$COMMON_FLAGS"
 make
-RETRIES=100 VALGRIND="--leak-check=full" make check -C test/
+RETRIES=100 VALGRIND="--leak-check=full --error-exitcode=1" make check -C test/
 
 #
 # Local variables:


### PR DESCRIPTION
Otherwise errors can be ignored for successful tests with memory errors.