### PR TITLE
Added make check for src directory for Linux OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
 
       - name: Test suite
         run: |
+          make check -C src
           make ALL_TESTS=1 check -C test || (test/filter-suite-log.sh test/test-suite.log; exit 1)
 
   # [NOTE]


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
`make check -C src` (test of src directory) was missing in the Linux OS test, so I added it.
I'm not sure why this test is missing, but I added it because it's necessary.

