### PR TITLE
Remove unneeded explicit `std::string` constructors

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -588,7 +588,7 @@ bool StatCache::DelStat(const char* key, AutoLock::Type locktype)
     AutoLock lock(&StatCache::stat_cache_lock, locktype);
 
     stat_cache_t::iterator iter;
-    if(stat_cache.end() != (iter = stat_cache.find(std::string(key)))){
+    if(stat_cache.end() != (iter = stat_cache.find(key))){
         stat_cache.erase(iter);
     }
     if(0 < strlen(key) && 0 != strcmp(key, "/")){
@@ -740,7 +740,7 @@ bool StatCache::DelSymlink(const char* key, AutoLock::Type locktype)
     AutoLock lock(&StatCache::stat_cache_lock, locktype);
 
     symlink_cache_t::iterator iter;
-    if(symlink_cache.end() != (iter = symlink_cache.find(std::string(key)))){
+    if(symlink_cache.end() != (iter = symlink_cache.find(key))){
         symlink_cache.erase(iter);
     }
     S3FS_MALLOCTRIM(0);

--- a/src/common_auth.cpp
+++ b/src/common_auth.cpp
@@ -32,7 +32,7 @@ std::string s3fs_get_content_md5(int fd)
     md5_t md5;
     if(!s3fs_md5_fd(fd, 0, -1, &md5)){
         // TODO: better return value?
-        return std::string("");
+        return "";
     }
     return s3fs_base64(md5.data(), md5.size());
 }
@@ -42,7 +42,8 @@ std::string s3fs_sha256_hex_fd(int fd, off_t start, off_t size)
     sha256_t sha256;
 
     if(!s3fs_sha256_fd(fd, start, size, &sha256)){
-        return std::string("");
+        // TODO: better return value?
+        return "";
     }
 
     std::string sha256hex = s3fs_hex_lower(sha256.data(), sha256.size());

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1496,7 +1496,7 @@ int S3fsCurl::ParallelMixMultipartUploadRequest(const char* tpath, headers_t& me
     std::string srcresource;
     std::string srcurl;
     MakeUrlResource(get_realpath(tpath).c_str(), srcresource, srcurl);
-    meta["Content-Type"]      = S3fsCurl::LookupMimeType(std::string(tpath));
+    meta["Content-Type"]      = S3fsCurl::LookupMimeType(tpath);
     meta["x-amz-copy-source"] = srcresource;
 
     // Initialize S3fsMultiCurl
@@ -2902,7 +2902,7 @@ void S3fsCurl::insertV2Headers(const std::string& access_key_id, const std::stri
 
     if(!S3fsCurl::IsPublicBucket()){
         std::string Signature = CalcSignatureV2(op, get_header_value(requestHeaders, "Content-MD5"), get_header_value(requestHeaders, "Content-Type"), date, resource, secret_access_key, access_token);
-        requestHeaders   = curl_slist_sort_insert(requestHeaders, "Authorization", std::string("AWS " + access_key_id + ":" + Signature).c_str());
+        requestHeaders   = curl_slist_sort_insert(requestHeaders, "Authorization", ("AWS " + access_key_id + ":" + Signature).c_str());
     }
 }
 
@@ -2979,7 +2979,7 @@ int S3fsCurl::GetIAMv2ApiToken(const char* token_url, int token_ttl, const char*
         return -EIO;
     }
     response.erase();
-    url = std::string(token_url);
+    url = token_url;
     if(!CreateCurlHandle()){
         return -EIO;
     }
@@ -3058,7 +3058,8 @@ bool S3fsCurl::GetIAMCredentials(const char* cred_url, const char* iam_v2_token,
         // make contents
         postContent += "grant_type=urn:ibm:params:oauth:grant-type:apikey";
         postContent += "&response_type=cloud_iam";
-        postContent += "&apikey=" + std::string(ibm_secret_access_key);
+        postContent += "&apikey=";
+        postContent += ibm_secret_access_key;
 
         // set postdata
         postdata             = reinterpret_cast<const unsigned char*>(postContent.c_str());
@@ -3334,7 +3335,7 @@ int S3fsCurl::PutHeadRequest(const char* tpath, headers_t& meta, bool is_copy)
     responseHeaders.clear();
     bodydata.Clear();
 
-    std::string contype = S3fsCurl::LookupMimeType(std::string(tpath));
+    std::string contype = S3fsCurl::LookupMimeType(tpath);
     requestHeaders      = curl_slist_sort_insert(requestHeaders, "Content-Type", contype.c_str());
 
     // Make request headers
@@ -3475,7 +3476,7 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
         requestHeaders = curl_slist_sort_insert(requestHeaders, "Content-MD5", strMD5.c_str());
     }
 
-    std::string contype = S3fsCurl::LookupMimeType(std::string(tpath));
+    std::string contype = S3fsCurl::LookupMimeType(tpath);
     requestHeaders = curl_slist_sort_insert(requestHeaders, "Content-Type", contype.c_str());
 
     for(headers_t::iterator iter = meta.begin(); iter != meta.end(); ++iter){
@@ -3796,7 +3797,7 @@ int S3fsCurl::PreMultipartPostRequest(const char* tpath, headers_t& meta, std::s
     bodydata.Clear();
     responseHeaders.clear();
 
-    std::string contype = S3fsCurl::LookupMimeType(std::string(tpath));
+    std::string contype = S3fsCurl::LookupMimeType(tpath);
 
     for(headers_t::iterator iter = meta.begin(); iter != meta.end(); ++iter){
         std::string key   = lower(iter->first);
@@ -4199,7 +4200,7 @@ int S3fsCurl::CopyMultipartPostSetup(const char* from, const char* to, int part_
     bodydata.Clear();
     headdata.Clear();
 
-    std::string contype = S3fsCurl::LookupMimeType(std::string(to));
+    std::string contype = S3fsCurl::LookupMimeType(to);
     requestHeaders = curl_slist_sort_insert(requestHeaders, "Content-Type", contype.c_str());
 
     // Make request headers
@@ -4408,7 +4409,7 @@ int S3fsCurl::MultipartRenameRequest(const char* from, const char* to, headers_t
     std::string srcurl;
     MakeUrlResource(get_realpath(from).c_str(), srcresource, srcurl);
 
-    meta["Content-Type"]      = S3fsCurl::LookupMimeType(std::string(to));
+    meta["Content-Type"]      = S3fsCurl::LookupMimeType(to);
     meta["x-amz-copy-source"] = srcresource;
 
     if(0 != (result = PreMultipartPostRequest(to, meta, upload_id, true))){

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -61,8 +61,8 @@ struct curl_slist* curl_slist_sort_insert(struct curl_slist* list, const char* k
     }
 
     // key & value are trimmed and lower (only key)
-    std::string strkey = trim(std::string(key));
-    std::string strval = value ? trim(std::string(value)) : "";
+    std::string strkey = trim(key);
+    std::string strval = value ? trim(value) : "";
     std::string strnew = key + std::string(": ") + strval;
     char* data;
     if(nullptr == (data = strdup(strnew.c_str()))){
@@ -107,7 +107,7 @@ struct curl_slist* curl_slist_remove(struct curl_slist* list, const char* key)
         return list;
     }
 
-    std::string strkey = trim(std::string(key));
+    std::string strkey = trim(key);
     struct curl_slist **p = &list;
     while(*p){
         std::string strcur = (*p)->data;
@@ -259,8 +259,8 @@ std::string prepare_url(const char* url)
     std::string uri;
     std::string hostname;
     std::string path;
-    std::string url_str = std::string(url);
-    std::string token = std::string("/") + S3fsCred::GetBucket();
+    std::string url_str = url;
+    std::string token = "/" + S3fsCred::GetBucket();
     size_t bucket_pos;
     size_t bucket_length = token.size();
     size_t uri_length = 0;

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -489,7 +489,7 @@ FdEntity* FdManager::GetFdEntity(const char* path, int& existfd, bool newfd, Aut
     }
     AutoLock auto_lock(&FdManager::fd_manager_lock, locktype);
 
-    fdent_map_t::iterator iter = fent.find(std::string(path));
+    fdent_map_t::iterator iter = fent.find(path);
     if(fent.end() != iter && iter->second){
         if(-1 == existfd){
             if(newfd){
@@ -544,7 +544,7 @@ FdEntity* FdManager::Open(int& fd, const char* path, const headers_t* pmeta, off
     AutoLock auto_lock(&FdManager::fd_manager_lock);
 
     // search in mapping by key(path)
-    fdent_map_t::iterator iter = fent.find(std::string(path));
+    fdent_map_t::iterator iter = fent.find(path);
     if(fent.end() == iter && !force_tmpfile && !FdManager::IsCacheDir()){
         // If the cache directory is not specified, s3fs opens a temporary file
         // when the file is opened.
@@ -602,7 +602,7 @@ FdEntity* FdManager::Open(int& fd, const char* path, const headers_t* pmeta, off
 
         if(!cache_path.empty()){
             // using cache
-            fent[std::string(path)] = ent;
+            fent[path] = ent;
         }else{
             // not using cache, so the key of fdentity is set not really existing path.
             // (but not strictly unexisting path.)

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1035,7 +1035,7 @@ bool FdEntity::SetContentType(const char* path)
         return false;
     }
     AutoLock auto_lock(&fdent_lock);
-    orgmeta["Content-Type"] = S3fsCurl::LookupMimeType(std::string(path));
+    orgmeta["Content-Type"] = S3fsCurl::LookupMimeType(path);
     return true;
 }
 

--- a/src/s3fs_cred.cpp
+++ b/src/s3fs_cred.cpp
@@ -569,8 +569,8 @@ bool S3fsCred::SetIAMCredentials(const char* response, AutoLock::Type type)
         }
         AWSAccessTokenExpire = static_cast<time_t>(tmp_expire);
     }else{
-        AWSAccessKeyId       = keyval[std::string(S3fsCred::IAMCRED_ACCESSKEYID)];
-        AWSSecretAccessKey   = keyval[std::string(S3fsCred::IAMCRED_SECRETACCESSKEY)];
+        AWSAccessKeyId       = keyval[S3fsCred::IAMCRED_ACCESSKEYID];
+        AWSSecretAccessKey   = keyval[S3fsCred::IAMCRED_SECRETACCESSKEY];
         AWSAccessTokenExpire = cvtIAMExpireStringToTime(keyval[IAM_expiry_field].c_str());
     }
     return true;

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -108,12 +108,12 @@ std::string get_username(uid_t uid)
 
     if(0 != result){
         S3FS_PRN_ERR("could not get pw information(%d).", result);
-        return std::string("");
+        return "";
     }
 
     // check pw
     if(nullptr == ppwinfo){
-        return std::string("");
+        return "";
     }
     std::string name = SAFESTRPTR(ppwinfo->pw_name);
     return name;
@@ -222,7 +222,7 @@ std::string mydirname(const std::string& path)
 std::string mydirname(const char* path)
 {
     if(!path || '\0' == path[0]){
-        return std::string("");
+        return "";
     }
 
     char *buf = strdup(path);
@@ -243,7 +243,7 @@ std::string mybasename(const std::string& path)
 std::string mybasename(const char* path)
 {
     if(!path || '\0' == path[0]){
-        return std::string("");
+        return "";
     }
 
     char *buf = strdup(path);

--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -158,8 +158,8 @@ static char* get_object_name(xmlDocPtr doc, xmlNodePtr node, const char* path)
     }
 
     // Make dir path and filename
-    std::string   strdirpath = mydirname(std::string(reinterpret_cast<char*>(fullpath)));
-    std::string   strmybpath = mybasename(std::string(reinterpret_cast<char*>(fullpath)));
+    std::string   strdirpath = mydirname(reinterpret_cast<const char*>(fullpath));
+    std::string   strmybpath = mybasename(reinterpret_cast<const char*>(fullpath));
     const char* dirpath = strdirpath.c_str();
     const char* mybname = strmybpath.c_str();
     const char* basepath= (path && '/' == path[0]) ? &path[1] : path;

--- a/src/s3objlist.cpp
+++ b/src/s3objlist.cpp
@@ -84,7 +84,7 @@ bool S3ObjList::insert(const char* name, const char* etag, bool is_dir)
         (*iter).second.orgname = orgname;
         (*iter).second.is_dir  = is_dir;
         if(etag){
-            (*iter).second.etag = std::string(etag);  // over write
+            (*iter).second.etag = etag;  // over write
         }
     }else{
         // add new object
@@ -145,10 +145,10 @@ std::string S3ObjList::GetOrgName(const char* name) const
     const s3obj_entry* ps3obj;
 
     if(!name || '\0' == name[0]){
-        return std::string("");
+        return "";
     }
     if(nullptr == (ps3obj = GetS3Obj(name))){
-        return std::string("");
+        return "";
     }
     return ps3obj->orgname;
 }
@@ -158,13 +158,13 @@ std::string S3ObjList::GetNormalizedName(const char* name) const
     const s3obj_entry* ps3obj;
 
     if(!name || '\0' == name[0]){
-        return std::string("");
+        return "";
     }
     if(nullptr == (ps3obj = GetS3Obj(name))){
-        return std::string("");
+        return "";
     }
     if(ps3obj->normalname.empty()){
-        return std::string(name);
+        return name;
     }
     return ps3obj->normalname;
 }
@@ -174,10 +174,10 @@ std::string S3ObjList::GetETag(const char* name) const
     const s3obj_entry* ps3obj;
 
     if(!name || '\0' == name[0]){
-        return std::string("");
+        return "";
     }
     if(nullptr == (ps3obj = GetS3Obj(name))){
-        return std::string("");
+        return "";
     }
     return ps3obj->etag;
 }


### PR DESCRIPTION
`std::string(const char*)` implicitly constructs these.  The remaining call sites requires string literals from C++14.