### PR TITLE
Additional fix for #2276(Convert BodyData to std::string)

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -4011,7 +4011,7 @@ int S3fsCurl::MultipartListRequest(std::string& body)
     }
 
     int result;
-    if(0 == (result = RequestPerform()) && 0 < bodydata.size()){
+    if(0 == (result = RequestPerform()) && !bodydata.empty()){
         body.swap(bodydata);
     }else{
         body = "";


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2276

### Details
Since the CI addition of clang-tidy was merged first, there was an error, so I fixed it.

