### PR TITLE
Added std::map erase before calling emplace in xattrs operations

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3739,7 +3739,7 @@ static size_t parse_xattrs(const std::string& strxattrs, xattrs_t& xattrs)
             // something format error, so skip this.
             continue;
         }
-        xattrs.emplace(std::move(key), std::move(val));
+        xattrs[key] = val;
     }
     return xattrs.size();
 }
@@ -3805,8 +3805,7 @@ static int set_xattrs_to_header(headers_t& meta, const char* name, const char* v
     parse_xattrs(strxattrs, xattrs);
 
     // add name(do not care overwrite and empty name/value)
-    std::string val(value, size);
-    xattrs.emplace(name, std::move(val));
+    xattrs[name] = std::string(value, size);
 
     // build new strxattrs(not encoded) and set it to headers_t
     meta["x-amz-meta-xattr"] = build_xattrs(xattrs);

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -815,6 +815,10 @@ function test_extended_attributes {
     touch "${TEST_TEXT_FILE}"
 
     # set value
+    set_xattr key1 value0 "${TEST_TEXT_FILE}"
+    get_xattr key1 "${TEST_TEXT_FILE}" | grep -q '^value0$'
+
+    # over write value
     set_xattr key1 value1 "${TEST_TEXT_FILE}"
     get_xattr key1 "${TEST_TEXT_FILE}" | grep -q '^value1$'
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2280

### Details
`std::map emplace` will not replace the value if that key exists.
Fixed xattrs handling to call `erase` if there is a target key.

I also added a test case for the missing xattrs inspection related to this.

Check where emplace is used in the current source code, and there is no problem except for xattrs.
(In the `stat cache` process, the keys are deleted in advance, so I don't think there will be any problems.)