### PR TITLE
Skip `is_uid_include_group` when GID available

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -819,8 +819,7 @@ static int check_object_access(const char* path, int mask, struct stat* pstbuf)
     }
     if(pcxt->gid == obj_gid){
         base_mask |= S_IRWXG;
-    }
-    if(1 == is_uid_include_group(pcxt->uid, obj_gid)){
+    } else if(1 == is_uid_include_group(pcxt->uid, obj_gid)){
         base_mask |= S_IRWXG;
     }
     mode &= base_mask;


### PR DESCRIPTION
This can avoid an expensive computation which is 20% of test runtime.