### PR TITLE
Run tests with HTTP instead of HTTPS

### DIFF
--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -72,11 +72,7 @@ S3FS=../src/s3fs
 # [NOTE]
 # CHAOS HTTP PROXY does not support HTTPS.
 #
-if [ -z "${CHAOS_HTTP_PROXY}" ] && [ -z "${CHAOS_HTTP_PROXY_OPT}" ]; then
-    : "${S3_URL:="https://127.0.0.1:8080"}"
-else
-    : "${S3_URL:="http://127.0.0.1:8080"}"
-fi
+: "${S3_URL:="http://127.0.0.1:8080"}"
 : "${S3_ENDPOINT:="us-east-1"}"
 : "${S3FS_CREDENTIALS_FILE:="passwd-s3fs"}"
 : "${TEST_BUCKET_1:="s3fs-integration-test"}"

--- a/test/s3proxy.conf
+++ b/test/s3proxy.conf
@@ -1,4 +1,4 @@
-s3proxy.secure-endpoint=https://127.0.0.1:8080
+s3proxy.endpoint=http://127.0.0.1:8080
 s3proxy.authorization=aws-v2-or-v4
 s3proxy.identity=local-identity
 s3proxy.credential=local-credential


### PR DESCRIPTION
This reduces the s3fs CPU run-time dramatically.