### PR TITLE
Enable Valgrind in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,6 @@ jobs:
       # [NOTE]
       # Currently following test is not supported:
       #    - sanitize_memory   : Future support planned
-      #    - valgrind          : Requires more than an hour of testing time
       #
       matrix:
         checktype:
@@ -216,6 +215,7 @@ jobs:
           - sanitize_address
           - sanitize_others
           - sanitize_thread
+          - valgrind
 
     container:
       image: fedora:38
@@ -263,6 +263,7 @@ jobs:
               echo "CXXFLAGS=${COMMON_CXXFLAGS} -O1"                   >> $GITHUB_ENV
               echo 'VALGRIND=--leak-check=full'                        >> $GITHUB_ENV
               echo 'RETRIES=100'                                       >> $GITHUB_ENV
+              echo 'S3_URL=http://127.0.0.1:8081'                      >> $GITHUB_ENV
           fi
 
       - name: Build

--- a/test/run_tests_using_sanitizers.sh
+++ b/test/run_tests_using_sanitizers.sh
@@ -61,7 +61,7 @@ ALL_TESTS=1 make check -C test/
 make clean
 ./configure CXXFLAGS="$COMMON_FLAGS"
 make --jobs="$(nproc)"
-ALL_TESTS=1 RETRIES=100 VALGRIND="--leak-check=full --error-exitcode=1" make check -C test/
+ALL_TESTS=1 RETRIES=100 VALGRIND="--leak-check=full --error-exitcode=1" S3_URL=http://127.0.0.1:8081 make check -C test/
 
 #
 # Local variables:

--- a/test/s3proxy.conf
+++ b/test/s3proxy.conf
@@ -1,3 +1,4 @@
+s3proxy.endpoint=http://127.0.0.1:8081
 s3proxy.secure-endpoint=https://127.0.0.1:8080
 s3proxy.authorization=aws-v2-or-v4
 s3proxy.identity=local-identity


### PR DESCRIPTION
Using HTTP instead of HTTPS and
82107f4b6c4cf455c2f3dd63e0ade29f042c1b0f improve test run-time so that this is now feasible.