### PR TITLE
Document support for temporary credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Otherwise consult the [compilation instructions](COMPILATION.md).
 s3fs supports the standard
 [AWS credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html)
 stored in `${HOME}/.aws/credentials`.  Alternatively, s3fs supports a custom passwd file.
-Finally s3fs recognizes the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+Finally s3fs recognizes the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`
 environment variables.
 
 The default location for the s3fs password file can be created:


### PR DESCRIPTION
Documents support for the `AWS_SESSION_TOKEN` variable. The variable is one way to support temporary credentials.

Without the documentation, the only way to know about the support is to read [s3fs_cred.cpp](https://github.com/s3fs-fuse/s3fs-fuse/blob/a83f4a48d0286062fc6837e913a523c3286974fd/src/s3fs_cred.cpp#L956-L972). 

Extends https://github.com/s3fs-fuse/s3fs-fuse/pull/2281 .