### PR TITLE
Fixed errors of cppcheck 2.12.0

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -408,7 +408,7 @@ bool StatCache::AddStat(const std::string& key, const headers_t& meta, bool forc
 // Since the file mode may change while the file is open, it is
 // updated as well.
 //
-bool StatCache::UpdateMetaStats(const std::string& key, headers_t& meta)
+bool StatCache::UpdateMetaStats(const std::string& key, const headers_t& meta)
 {
     if(CacheSize < 1){
         return true;
@@ -423,7 +423,7 @@ bool StatCache::UpdateMetaStats(const std::string& key, headers_t& meta)
     stat_cache_entry* ent = &iter->second;
 
     // update only meta keys
-    for(headers_t::iterator metaiter = meta.begin(); metaiter != meta.end(); ++metaiter){
+    for(headers_t::const_iterator metaiter = meta.begin(); metaiter != meta.end(); ++metaiter){
         std::string tag   = lower(metaiter->first);
         std::string value = metaiter->second;
         if(tag == "content-type"){

--- a/src/cache.h
+++ b/src/cache.h
@@ -166,7 +166,7 @@ class StatCache
         bool AddStat(const std::string& key, const headers_t& meta, bool forcedir = false, bool no_truncate = false);
 
         // Update meta stats
-        bool UpdateMetaStats(const std::string& key, headers_t& meta);
+        bool UpdateMetaStats(const std::string& key, const headers_t& meta);
 
         // Change no truncate flag
         void ChangeNoTruncateFlag(const std::string& key, bool no_truncate);

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -218,6 +218,8 @@ int S3fsMultiCurl::MultiRead()
                 isPostpone = true;
             }else if(400 > responseCode){
                 // add into stat cache
+                // cppcheck-suppress unmatchedSuppression
+                // cppcheck-suppress knownPointerToBool
                 if(SuccessCallback && !SuccessCallback(s3fscurl.get(), pSuccessCallbackParam)){
                     S3FS_PRN_WARN("error from success callback function(%s).", s3fscurl->url.c_str());
                 }
@@ -232,6 +234,8 @@ int S3fsMultiCurl::MultiRead()
                     S3FS_PRN_WARN("failed a request(%ld: %s)", responseCode, s3fscurl->url.c_str());
                 }
 				// Call callback function
+                // cppcheck-suppress unmatchedSuppression
+                // cppcheck-suppress knownPointerToBool
                 if(NotFoundCallback && !NotFoundCallback(s3fscurl.get(), pNotFoundCallbackParam)){
                     S3FS_PRN_WARN("error from not found callback function(%s).", s3fscurl->url.c_str());
                 }

--- a/src/mpu_util.cpp
+++ b/src/mpu_util.cpp
@@ -37,7 +37,7 @@ utility_incomp_type utility_mode = utility_incomp_type::NO_UTILITY_MODE;
 //-------------------------------------------------------------------
 // Functions
 //-------------------------------------------------------------------
-static void print_incomp_mpu_list(incomp_mpu_list_t& list)
+static void print_incomp_mpu_list(const incomp_mpu_list_t& list)
 {
     printf("\n");
     printf("Lists the parts that have been uploaded for a specific multipart upload.\n");
@@ -47,7 +47,7 @@ static void print_incomp_mpu_list(incomp_mpu_list_t& list)
         printf("---------------------------------------------------------------\n");
 
         int cnt = 0;
-        for(incomp_mpu_list_t::iterator iter = list.begin(); iter != list.end(); ++iter, ++cnt){
+        for(incomp_mpu_list_t::const_iterator iter = list.begin(); iter != list.end(); ++iter, ++cnt){
             printf(" Path     : %s\n", (*iter).key.c_str());
             printf(" UploadId : %s\n", (*iter).id.c_str());
             printf(" Date     : %s\n", (*iter).date.c_str());
@@ -60,7 +60,7 @@ static void print_incomp_mpu_list(incomp_mpu_list_t& list)
     }
 }
 
-static bool abort_incomp_mpu_list(incomp_mpu_list_t& list, time_t abort_time)
+static bool abort_incomp_mpu_list(const incomp_mpu_list_t& list, time_t abort_time)
 {
     if(list.empty()){
         return true;
@@ -70,7 +70,7 @@ static bool abort_incomp_mpu_list(incomp_mpu_list_t& list, time_t abort_time)
     // do removing.
     S3fsCurl s3fscurl;
     bool     result = true;
-    for(incomp_mpu_list_t::iterator iter = list.begin(); iter != list.end(); ++iter){
+    for(incomp_mpu_list_t::const_iterator iter = list.begin(); iter != list.end(); ++iter){
         const char* tpath     = (*iter).key.c_str();
         std::string upload_id = (*iter).id;
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
`cppcheck` on `Fedora 38` (and `macos 12`) had been upgraded to `2.12.0` and was therefore detecting errors.
I have fixed this error.
