### PR TITLE
Simplify the determination of the --cached option of the stat

### DIFF
--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -75,16 +75,10 @@ export SED_BUFFER_FLAG="--unbuffered"
 # Specifying cache disable option depending on stat(coreutils) version
 # TODO: investigate why this is necessary #2327
 #
-if grep -q -i -e 'ID=ubuntu' /etc/os-release && grep -q -i -e 'VERSION_ID="20.04"' /etc/os-release; then
-    STAT_BIN=(stat)
-elif grep -q -i -e 'ID=debian' /etc/os-release && grep -q -i -e 'VERSION_ID="10"' /etc/os-release; then
-    STAT_BIN=(stat)
-elif grep -q -i -e 'ID="centos"' /etc/os-release && grep -q -i -e 'VERSION_ID="7"' /etc/os-release; then
-    STAT_BIN=(stat)
-elif [ "$(uname)" = "Darwin" ]; then
-    STAT_BIN=(stat)
-else
+if stat --cached=never / >/dev/null 2>&1; then
     STAT_BIN=(stat --cache=never)
+else
+    STAT_BIN=(stat)
 fi
 
 function get_xattr() {


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2319 

### Details
Change the judgment statement for whether the `stat` command has the `--cached` option.

This is determined based on the `OS` and `version`, but this method may require further modifications in the future.
Therefore, I changed it to simply check the result of `stat --cached=never`.
(My comment in #2319 was not simplified, so this is a correction)

