### PR TITLE
Fixed test_not_existed_dir_obj test condition

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -2664,7 +2664,7 @@ function add_all_tests {
     add_tests test_upload_sparsefile
     add_tests test_mix_upload_entities
     # TODO: investigate why only Alpine cannot see the implicit directory objects.
-    if grep -q -i -e 'ID="alpine"' /etc/os-release; then
+    if ! test -f /etc/os-release || ! grep -q -i -e 'ID=alpine' -e 'ID="alpine"' /etc/os-release; then
         add_tests test_not_existed_dir_obj
     fi
     add_tests test_ut_ossfs


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2319 

### Details
Fixed the execution condition of the `test_not_existed_dir_obj` test added in #2319.
It was correct that the conditions to run on `not Alpine` were correct, but wrong to run on `Alpine only`.
Also, since the `/etc/os-release` file does not exist on `macos` (although it is currently unnecessary), I added that condition as well.