### PR TITLE
Fixed  ETag parsing at completing the Multipart upload part

### DIFF
--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -319,17 +319,9 @@ const char* getCurlDebugHead(curl_infotype type)
 //
 // compare ETag ignoring quotes and case
 //
-bool etag_equals(std::string s1, std::string s2)
+bool etag_equals(const std::string& s1, const std::string& s2)
 {
-    if(s1.length() > 1 && s1[0] == '\"' && *s1.rbegin() == '\"'){
-        s1.erase(s1.size() - 1);
-        s1.erase(0, 1);
-    }
-    if(s2.length() > 1 && s2[0] == '\"' && *s2.rbegin() == '\"'){
-        s2.erase(s2.size() - 1);
-        s2.erase(0, 1);
-    }
-    return 0 == strcasecmp(s1.c_str(), s2.c_str());
+    return 0 == strcasecmp(peeloff(s1).c_str(), peeloff(s2).c_str());
 }
 
 /*

--- a/src/curl_util.h
+++ b/src/curl_util.h
@@ -42,7 +42,7 @@ std::string url_to_host(const std::string &url);
 std::string get_bucket_host();
 const char* getCurlDebugHead(curl_infotype type);
 
-bool etag_equals(std::string s1, std::string s2);
+bool etag_equals(const std::string& s1, const std::string& s2);
 
 #endif // S3FS_CURL_UTIL_H_
 

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -125,6 +125,14 @@ std::string trim(std::string s, const char *t /* = SPACES */)
     return trim_left(trim_right(std::move(s), t), t);
 }
 
+std::string peeloff(std::string s)
+{
+    if(s.size() < 2 || *s.begin() != '"' || *s.rbegin() != '"'){
+        return s;
+    }
+    return s.substr(1, s.size() - 2);
+}
+
 //
 // Three url encode functions
 //

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -79,6 +79,7 @@ std::string trim_left(std::string s, const char *t = SPACES);
 std::string trim_right(std::string s, const char *t = SPACES);
 std::string trim(std::string s, const char *t = SPACES);
 std::string lower(std::string s);
+std::string peeloff(std::string s);
 
 //
 // Date string

--- a/src/test_string_util.cpp
+++ b/src/test_string_util.cpp
@@ -49,6 +49,15 @@ void test_trim()
     ASSERT_EQUALS(std::string("1234"), trim_right("1234  "));
     ASSERT_EQUALS(std::string("  1234"), trim_right("  1234"));
     ASSERT_EQUALS(std::string("1234"), trim_right("1234"));
+
+    ASSERT_EQUALS(std::string("1234"), peeloff("\"1234\""));            // "1234"   -> 1234
+    ASSERT_EQUALS(std::string("\"1234\""), peeloff("\"\"1234\"\""));    // ""1234"" -> "1234"
+    ASSERT_EQUALS(std::string("\"1234"), peeloff("\"\"1234\""));        // ""1234"  ->  "1234
+    ASSERT_EQUALS(std::string("1234\""), peeloff("\"1234\"\""));        // "1234""  -> 1234"
+    ASSERT_EQUALS(std::string("\"1234"), peeloff("\"1234"));            // "1234    -> "1234
+    ASSERT_EQUALS(std::string("1234\""), peeloff("1234\""));            // 1234"    -> 1234"
+    ASSERT_EQUALS(std::string(" \"1234\""), peeloff(" \"1234\""));      // _"1234"  -> _"1234"
+    ASSERT_EQUALS(std::string("\"1234\" "), peeloff("\"1234\" "));      // "1234"_  -> "1234"_
 }
 
 void test_base64()


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
When completing a multipart upload(in the `UploadMultipartPostComplete` method) it was not possible to remove double quotes from the response ETag string.
But it was deleted in the similar `CopyMultipartPostComplete`, then mixed Etags(with/without double quotes) for Mix Multipart Upload.
So far, this doesn't cause uploads to fail, but I'd like to keep the specs the same.

