### PR TITLE
s3fs_cred: print detailed error message when stat file fails

### DIFF
--- a/src/s3fs_cred.cpp
+++ b/src/s3fs_cred.cpp
@@ -627,7 +627,7 @@ bool S3fsCred::CheckS3fsPasswdFilePerms()
 
     // let's get the file info
     if(stat(passwd_file.c_str(), &info) != 0){
-        S3FS_PRN_EXIT("unexpected error from stat(%s).", passwd_file.c_str());
+        S3FS_PRN_EXIT("unexpected error from stat(%s): %s", passwd_file.c_str(), strerror(errno));
         return false;
     }
 


### PR DESCRIPTION
<!-- --------------------------------------------------------------------------
 Please describe the purpose of the pull request(such as resolving the issue)
 and what the fix/update is.
--------------------------------------------------------------------------- -->

### Relevant Issue (if applicable)
n/a

### Details
When the password file does not exist, now only the error "s3fs: unexpected error from stat" will be reported, which is not convenient for locating the problem.

In order to fix this problem, this patch adds detailed error message printing.

