### PR TITLE
Fixed a bug in the re-upload part of Streamupload

### DIFF
--- a/src/fdcache_fdinfo.h
+++ b/src/fdcache_fdinfo.h
@@ -85,7 +85,6 @@ class PseudoFdInfo
         bool CompleteInstruction(int result, AutoLock::Type type = AutoLock::NONE);
         bool ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy, AutoLock::Type type = AutoLock::NONE);
         bool InsertUploadPart(off_t start, off_t size, int part_num, bool is_copy, etagpair** ppetag, AutoLock::Type type = AutoLock::NONE);
-        int WaitAllThreadsExit();
         bool CancelAllThreads();
         bool ExtractUploadPartsFromUntreatedArea(off_t& untreated_start, off_t& untreated_size, mp_part_list_t& to_upload_list, filepart_list_t& cancel_upload_list, off_t max_mp_size);
 
@@ -115,8 +114,9 @@ class PseudoFdInfo
 
         bool ParallelMultipartUploadAll(const char* path, const mp_part_list_t& to_upload_list, const mp_part_list_t& copy_list, int& result);
 
+        int WaitAllThreadsExit();
         ssize_t UploadBoundaryLastUntreatedArea(const char* path, headers_t& meta, FdEntity* pfdent);
-        bool ExtractUploadPartsFromAllArea(UntreatedParts& untreated_list, mp_part_list_t& to_upload_list, mp_part_list_t& to_copy_list, mp_part_list_t& to_download_list, filepart_list_t& cancel_upload_list, off_t max_mp_size, off_t file_size, bool use_copy);
+        bool ExtractUploadPartsFromAllArea(UntreatedParts& untreated_list, mp_part_list_t& to_upload_list, mp_part_list_t& to_copy_list, mp_part_list_t& to_download_list, filepart_list_t& cancel_upload_list, bool& wait_upload_complete, off_t max_mp_size, off_t file_size, bool use_copy);
 };
 
 typedef std::map<int, std::unique_ptr<PseudoFdInfo>> fdinfo_map_t;


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
#### Problem phenomenon
The CI test was failing in rare cases in the `test_multipart_mix` test of StreamUpload.
(It seemed to happen more often on `macos` than on `linux`)

#### StreamUpload logic
In StreamUpload, if the part range of each multipart is filled with updates, that part will be uploaded first without waiting for `flush`.
This StreamUpload logic allows for re-uploads of the same part if there are updates(written) to the same part range after the first upload for the same part.
In this case, when flushed the file, this part will be re-uploaded and the previous upload will be overwritten(cancelled).
This is the usual expected StreamUpload's logic.

#### Behavior in case of error
The error detected this time occurred in a case where Flush was called and a re-upload was started when the previously uploaded part had not yet finished uploading.
It means that uploads of the same part range were running at the same time.
Normally, the upload that started first will complete first, and the ETag value will be overwritten by the update caused by the re-upload.
However, on this error case, the re-upload process completed first, and the earlier upload process completed later, resulting in an invalid (cancelled) ETag value.

#### Fixed bug
In order to avoid this, we have modified it so that if it is detected that the part to be re-uploaded is still being uploaded, the re-upload will start after the upload including that part is completed.
