### PR TITLE
Set SSE headers when checking bucket

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3660,6 +3660,14 @@ int S3fsCurl::CheckBucket(const char* check_path, bool compat_dir)
     responseHeaders.clear();
     bodydata.clear();
 
+    // SSE
+    if(S3fsCurl::GetSseType() != sse_type_t::SSE_DISABLE){
+        std::string ssevalue;
+        if(!AddSseRequestHead(S3fsCurl::GetSseType(), ssevalue, false)){
+            S3FS_PRN_WARN("Failed to set SSE header, but continue...");
+        }
+    }
+    
     op = "GET";
     type = REQTYPE::CHKBUCKET;
 


### PR DESCRIPTION
<!-- --------------------------------------------------------------------------
 Please describe the purpose of the pull request(such as resolving the issue)
 and what the fix/update is.
--------------------------------------------------------------------------- -->

### Relevant Issue (if applicable)
Without this, the check fails when mounting a subdirectory in the bucket (for example `AWSSSECKEYS=vgXEublG7JJkhfRSZT1Ze3lefY2d7j3i s3fs -f -d -o bucket=my-bucket:/my-subdir/,complement_stat,allow_other,uid=0,gid=100,use_cache=/tmp/s3fs-cache,del_cache,ensure_diskfree=10000,curldbg,use_sse=custom /mnt/s3` when using SSE.

Before this PR, this would fail with:

```
2023-10-18T11:43:57.132Z [ERR] curl.cpp:RequestPerform(2561): HTTP response code 400, returning EIO. Body Text: <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidRequest</Code><Message>The object was stored using a form of Server Side Encryption. The correct parameters must be provided to retrieve the object.</Message><RequestId>T0X9HXZ34AMSCGB9</RequestId><HostId>dVaEyuY7JaiD3b3tqmtfPUeLfCFi0qwewT2JXRTIniJjGobA0VLiuZJbC1f+VdsppcLiqRdVdaU=</HostId></Error>
2023-10-18T11:43:57.132Z [ERR] curl.cpp:CheckBucket(3742): Check bucket failed, S3 response: <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidRequest</Code><Message>The object was stored using a form of Server Side Encryption. The correct parameters must be provided to retrieve the object.</Message><RequestId>T0X9HXZ34AMSCGB9</RequestId><HostId>dVaEyuY7JaiD3b3tqmtfPUeLfCFi0qwewT2JXRTIniJjGobA0VLiuZJbC1f+VdsppcLiqRdVdaU=</HostId></Error>
2023-10-18T11:43:57.132Z [CRT] s3fs.cpp:s3fs_check_service(4520): Failed to check bucket and directory for mount point : Bad Request(host=https://s3.amazonaws.com)
2023-10-18T11:43:57.132Z [ERR] s3fs.cpp:s3fs_exit_fuseloop(4277): Exiting FUSE event loop due to errors
```

### Details
This adds the SSE headers to the `GET` http request same as how it is done in other methods.

