### PR TITLE
Suppress some message levels on macos

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1035,7 +1035,11 @@ static int s3fs_getattr(const char* _path, struct stat* stbuf)
     WTF8_ENCODE(path)
     int result;
 
+#if defined(__APPLE__)
+    FUSE_CTX_DBG("[path=%s]", path);
+#else
     FUSE_CTX_INFO("[path=%s]", path);
+#endif
 
     // check parent directory attribute.
     if(0 != (result = check_parent_object_access(path, X_OK))){
@@ -3956,7 +3960,11 @@ static int s3fs_getxattr(const char* path, const char* name, char* value, size_t
 static int s3fs_getxattr(const char* path, const char* name, char* value, size_t size)
 #endif
 {
+#if defined(__APPLE__)
+    FUSE_CTX_DBG("[path=%s][name=%s][value=%p][size=%zu]", path, name, value, size);
+#else
     FUSE_CTX_INFO("[path=%s][name=%s][value=%p][size=%zu]", path, name, value, size);
+#endif
 
     if(!path || !name){
         return -EIO;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2198 

### Details
I'm working on making it compatible with macos 12, but in CI testing I will specify `noattrcache` when starting `macos fuse-t`.
_This is an option to avoid attars caching._

As a result, CI tests can run, but there are a lot of getting `attrs` related calls.
And they will output a lot of `INFO` level messages.
Changed log message output for function calls of `s3fs_getattr` and `s3fs_setxattr` from `INFO` to `DBG` level because more messages were output than permissible.
This is only for macos.

