### PR TITLE
Improved updating of temporary stat cache while creating a file

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2563,6 +2563,21 @@ static int s3fs_utimens(const char* _path, const struct timespec ts[2])
                 // If there is data in the Stats cache, update the Stats cache.
                 StatCache::getStatCacheData()->UpdateMetaStats(strpath, updatemeta);
 
+                // [NOTE]
+                // There are cases where this function is called during the process of
+                // creating a new file (before uploading).
+                // In this case, a temporary cache exists in the Stat cache.(see s3fs_create)
+                // So we need to update the cache, if it exists.
+                //
+                // Previously, the process of creating a new file was to update the
+                // file content after first uploading the file, but now the file is
+                // not created until flushing.
+                // So we need to create a temporary Stat cache for it.
+                //
+                if(!StatCache::getStatCacheData()->AddStat(strpath, updatemeta, false, true)){
+                    return -EIO;
+                }
+
             }else{
                 S3FS_PRN_INFO("meta is not pending, but need to keep current mtime.");
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2332

### Details
Fixed a cause for the `test_mtime_file` and `test_update_time_cp_p` tests to fail on Alpine 3.18.

The problem is that the stat information is read before updating a/c/mtime due to a change in the calling order (timing) of the fuse handler when creating a new file.

First, some background:
In previous versions of current s3fs, the process of creating a new file would first create an empty file.
In the current version, this unnecessary process has been simplified and the file is created for the first time when the file content is uploaded.

This simplification causes problems when file stat information is read between the time a new file is created and the time the file is uploaded.
To avoid this, the stat information is retained as a cache even though the file does not yet exist(before uploading).

In Alpine 3.18, when this file does not yet exist, a call to utimens updates the file's timestamp and immediately reads the Stat information.
In the current s3fs, the stat information read at this time is cached stat information at creating a file, and is a timestamp whose utimens have not been updated.
In Alpine3.17(and other OS), the stat information was not read at this timing.

Therefore, when the timestamp is updated in utimens, if there is temporary Stat cache information, we solved this problem by updating that cache information.

