### PR TITLE
Fixed a script of not functioning environment in Github Actions

### DIFF
--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -66,8 +66,8 @@ AWSCLI_ZIP_FILE="awscliv2.zip"
 #-----------------------------------------------------------
 # Parameters for configure(set environments)
 #-----------------------------------------------------------
-# shellcheck disable=SC2089
-CONFIGURE_OPTIONS="CXXFLAGS='-O -std=c++03 -DS3FS_PTHREAD_ERRORCHECK=1' --prefix=/usr --with-openssl"
+CXXFLAGS="-O -DS3FS_PTHREAD_ERRORCHECK=1"
+CONFIGURE_OPTIONS="--prefix=/usr --with-openssl"
 
 #-----------------------------------------------------------
 # OS dependent variables
@@ -290,8 +290,8 @@ fi
 #-----------------------------------------------------------
 echo "${PRGNAME} [INFO] Set environment for configure options"
 
-# shellcheck disable=SC2090
-export CONFIGURE_OPTIONS
+echo "CXXFLAGS=${CXXFLAGS}"                   >> "${GITHUB_ENV}"
+echo "CONFIGURE_OPTIONS=${CONFIGURE_OPTIONS}" >> "${GITHUB_ENV}"
 
 echo "${PRGNAME} [INFO] Finish Linux helper for installing packages."
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
I noticed a meaningless process in `linux-ci-helper.sh` and fixed it.
I believe this was done before the `GHTHUB_ENV` file was provided, but it is currently not working.

What isn't working are the option flags pass to `configure` and the `CXXFLAG` environment variable.
For fixing the option flag, it is written to  `GITHUB_ENV`.
The `CXXFLAG` environment variable is currently set in `Makefile.am`. (especially `-std=c++XX`)
However, there is also a flag(`S3FS_PTHREAD_ERRORCHECK=1`) that is only used by Github Actions (CI), so I also write this to `GITHUB_ENV`.

I don't think it will affect the current build, but I have modified this file so that it fulfills the required functions.

@gaul
Please let me know if you have any problems.