### PR TITLE
s3fs: make dir size not zero

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -804,7 +804,11 @@ bool convert_header_to_stat(const char* path, const headers_t& meta, struct stat
     }
 
     // size
-    pst->st_size = get_size(meta);
+    if(S_ISDIR(pst->st_mode)){
+        pst->st_size = 4096;
+    }else{
+        pst->st_size = get_size(meta);
+    }
 
     // uid/gid
     pst->st_uid = get_uid(meta);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1059,6 +1059,9 @@ static int s3fs_getattr(const char* _path, struct stat* stbuf)
                 stbuf->st_size = tmpstbuf.st_size;
             }
         }
+        if(0 == strcmp(path, "/")){
+            stbuf->st_size = 4096;
+        }
         stbuf->st_blksize = 4096;
         stbuf->st_blocks  = get_blocks(stbuf->st_size);
 


### PR DESCRIPTION
Directory has size 0, which looks weired and may confuse users. So fake dir size as 4k.

