### PR TITLE
Pass `std::unique_ptr` by value

### DIFF
--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -115,7 +115,7 @@ void* S3fsMultiCurl::SetNotFoundCallbackParam(void* param)
     return old;
 }
 
-bool S3fsMultiCurl::SetS3fsCurlObject(std::unique_ptr<S3fsCurl>&& s3fscurl)
+bool S3fsMultiCurl::SetS3fsCurlObject(std::unique_ptr<S3fsCurl> s3fscurl)
 {
     if(!s3fscurl){
         return false;

--- a/src/curl_multi.h
+++ b/src/curl_multi.h
@@ -74,7 +74,7 @@ class S3fsMultiCurl
         void* SetSuccessCallbackParam(void* param);
         void* SetNotFoundCallbackParam(void* param);
         bool Clear() { return ClearEx(true); }
-        bool SetS3fsCurlObject(std::unique_ptr<S3fsCurl>&& s3fscurl);
+        bool SetS3fsCurlObject(std::unique_ptr<S3fsCurl> s3fscurl);
         int Request();
 };
 


### PR DESCRIPTION
This ensures that the parameter is moved.