### PR TITLE
Corrected list_bucket to search in stat cache during creating new file

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -69,6 +69,12 @@ struct symlink_cache_entry {
 
 typedef std::map<std::string, symlink_cache_entry> symlink_cache_t;
 
+//
+// Typedefs for No truncate file name cache
+//
+typedef std::vector<std::string> notruncate_filelist_t;                    // untruncated file name list in dir
+typedef std::map<std::string, notruncate_filelist_t> notruncate_dir_map_t; // key is parent dir path
+
 //-------------------------------------------------------------------
 // Class StatCache
 //-------------------------------------------------------------------
@@ -93,6 +99,7 @@ class StatCache
         unsigned long          CacheSize;
         bool                   IsCacheNoObject;
         symlink_cache_t        symlink_cache;
+        notruncate_dir_map_t   notruncate_file_cache;
 
     private:
         StatCache();
@@ -101,9 +108,12 @@ class StatCache
         void Clear();
         bool GetStat(const std::string& key, struct stat* pst, headers_t* meta, bool overcheck, const char* petag, bool* pisforce);
         // Truncate stat cache
-        bool TruncateCache();
+        bool TruncateCache(AutoLock::Type locktype = AutoLock::NONE);
         // Truncate symbolic link cache
-        bool TruncateSymlink();
+        bool TruncateSymlink(AutoLock::Type locktype = AutoLock::NONE);
+
+        bool AddNotruncateCache(const std::string& key);
+        bool DelNotruncateCache(const std::string& key);
 
     public:
         // Reference singleton
@@ -182,6 +192,9 @@ class StatCache
         bool GetSymlink(const std::string& key, std::string& value);
         bool AddSymlink(const std::string& key, const std::string& value);
         bool DelSymlink(const char* key, AutoLock::Type locktype = AutoLock::NONE);
+
+        // Cache for Notruncate file
+        bool GetNotruncateCache(const std::string& parentdir, notruncate_filelist_t& list);
 };
 
 //-------------------------------------------------------------------

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1742,8 +1742,9 @@ static int rename_directory(const char* from, const char* to)
         S3FS_PRN_ERR("list_bucket returns error.");
         return result; 
     }
-    head.GetNameList(headlist);                       // get name without "/".
-    S3ObjList::MakeHierarchizedList(headlist, false); // add hierarchized dir.
+    head.GetNameList(headlist);                                             // get name without "/".
+    StatCache::getStatCacheData()->GetNotruncateCache(basepath, headlist);  // Add notruncate file name from stat cache
+    S3ObjList::MakeHierarchizedList(headlist, false);                       // add hierarchized dir.
 
     s3obj_list_t::const_iterator liter;
     for(liter = headlist.begin(); headlist.end() != liter; ++liter){
@@ -3271,7 +3272,8 @@ static int readdir_multi_head(const char* path, const S3ObjList& head, void* buf
     S3FS_PRN_INFO1("[path=%s][list=%zu]", path, headlist.size());
 
     // Make base path list.
-    head.GetNameList(headlist, true, false);  // get name with "/".
+    head.GetNameList(headlist, true, false);                                        // get name with "/".
+    StatCache::getStatCacheData()->GetNotruncateCache(std::string(path), headlist); // Add notruncate file name from stat cache
 
     // Initialize S3fsMultiCurl
     curlmulti.SetSuccessCallback(multi_head_callback);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2372 
#2198

### Details
#2198 supported `macos fuse-t`, but the bug in #2372 remained, so fixed it.

#### About bug
When creating a new file, s3fs does not create a `0-byte` file and delays the upload until the file is flushed.
During this delayed period, s3fs creates a temporary cache in the Stat cache to avoid `file not found` errors in case s3fs receives an instruction to get the file's stat information.

The problem in #2372 is similar to this, but the `readdir` was received during a delayed period.
Because this `readdir` (`list bucket`) is not supported, some `macos12` tests are failing as a bug.

#### Correspondence
When registering temporary cache information in the Stat cache for a new file, use the file's parent directory as a key and retain the cache information that maps the file name list.
This mapping information exists until the temporary cache is deleted.
By using this temporary cache, s3fs can support `readdir` (`list bucket`) and avoid problems.