### PR TITLE
Revert "Call C++11 get_time and put_time (#2375)"

### DIFF
--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -19,8 +19,6 @@
  */
 
 #include <ctime>
-#include <iomanip>
-#include <sstream>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -256,8 +254,8 @@ time_t cvtIAMExpireStringToTime(const char* s)
     if(!s){
         return 0L;
     }
-    std::istringstream ss(s);
-    ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
+    memset(&tm, 0, sizeof(struct tm));
+    strptime(s, "%Y-%m-%dT%H:%M:%S", &tm);
     return timegm(&tm); // GMT
 }
 
@@ -267,8 +265,8 @@ time_t get_lastmodified(const char* s)
     if(!s){
         return -1;
     }
-    std::istringstream ss(s);
-    ss >> std::get_time(&tm, "%a, %d %b %Y %H:%M:%S %Z");
+    memset(&tm, 0, sizeof(struct tm));
+    strptime(s, "%a, %d %b %Y %H:%M:%S %Z", &tm);
     return timegm(&tm); // GMT
 }
 

--- a/src/s3fs_logger.cpp
+++ b/src/s3fs_logger.cpp
@@ -54,14 +54,15 @@ std::string S3fsLog::GetCurrentTime()
         struct timeval  now;
         struct timespec tsnow;
         struct tm res;
+        char   tmp[32];
         if(-1 == clock_gettime(S3FS_CLOCK_MONOTONIC, &tsnow)){
             now.tv_sec  = tsnow.tv_sec;
             now.tv_usec = (tsnow.tv_nsec / 1000);
         }else{
             gettimeofday(&now, nullptr);
         }
-        current_time << std::put_time(gmtime_r(&now.tv_sec, &res), "%Y-%m-%dT%H:%M:%S")
-                     << "." << std::setfill('0') << std::setw(3) << (now.tv_usec / 1000) << "Z ";
+        strftime(tmp, sizeof(tmp), "%Y-%m-%dT%H:%M:%S", gmtime_r(&now.tv_sec, &res));
+        current_time << tmp << "." << std::setfill('0') << std::setw(3) << (now.tv_usec / 1000) << "Z ";
     }
     return current_time.str();
 }

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -55,6 +55,12 @@ static inline const char* SAFESTRPTR(const char *strptr) { return strptr ? strpt
 // TODO: rename to to_string?
 std::string str(const struct timespec value);
 
+#ifdef __MSYS__
+//
+// Polyfill for strptime function.
+//
+char* strptime(const char* s, const char* f, struct tm* tm);
+#endif
 //
 // Convert string to off_t.  Returns false on bad input.
 // Replacement for C++11 std::stoll.


### PR DESCRIPTION
This reverts commit 10a72bfd0f52bc70ad7f1dd6fbb92dbea376614c.  These commit is incompatible with older CentOS 7 libstdc++.