### PR TITLE
Updated actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,17 @@ jobs:
         run: |
           if [ "${{ matrix.container }}" = "opensuse/leap:15" ]; then zypper install -y tar gzip; fi
 
-      - name: Checkout source code
+      # [NOTE]
+      # actions/checkout@v3 uses nodejs v16 and will be deprecated.
+      # However, @v4 does not work on centos7 depending on the glibc version,
+      # so we will continue to use @v3.
+      #
+      - name: Checkout source code(other than centos7)
+        if: matrix.container != 'centos:centos7'
+        uses: actions/checkout@v4
+
+      - name: Checkout source code(only centos7)
+        if: matrix.container == 'centos:centos7'
         uses: actions/checkout@v3
 
       # [NOTE]
@@ -139,7 +149,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Brew tap
         run: |
@@ -221,7 +231,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install packages
         run: |


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
In CI `actions/checkout` needs to be changed from `v3` to `v4` due to the end of support for `NodeJS v16`.(Still available for use at this time)
Therefore, I changed it to use `actions/checkout@v4`.

However, `actions/checkout@v4` does not work on `CentOS 7`(depending on glibc version), so we should continue to use `@v3` for `CentOS 7`.(see. [actions/checkout issue](https://github.com/actions/checkout/issues/1487))
_At some point, we will no longer be able to support `CentOS 7`, so we will leave it as is until then._

