### PR TITLE
Fixed a bug that mounting with ksmid specified to fail

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3611,7 +3611,7 @@ int S3fsCurl::GetObjectRequest(const char* tpath, int fd, off_t start, off_t siz
     return result;
 }
 
-int S3fsCurl::CheckBucket(const char* check_path, bool compat_dir)
+int S3fsCurl::CheckBucket(const char* check_path, bool compat_dir, bool force_no_sse)
 {
     S3FS_PRN_INFO3("check a bucket path(%s)%s.", (check_path && 0 < strlen(check_path)) ? check_path : "", compat_dir ? " containing compatible directory paths" : "");
 
@@ -3661,7 +3661,7 @@ int S3fsCurl::CheckBucket(const char* check_path, bool compat_dir)
     bodydata.clear();
 
     // SSE
-    if(S3fsCurl::GetSseType() != sse_type_t::SSE_DISABLE){
+    if(!force_no_sse && S3fsCurl::GetSseType() != sse_type_t::SSE_DISABLE){
         std::string ssevalue;
         if(!AddSseRequestHead(S3fsCurl::GetSseType(), ssevalue, false)){
             S3FS_PRN_WARN("Failed to set SSE header, but continue...");

--- a/src/curl.h
+++ b/src/curl.h
@@ -360,7 +360,7 @@ class S3fsCurl
         int PutRequest(const char* tpath, headers_t& meta, int fd);
         int PreGetObjectRequest(const char* tpath, int fd, off_t start, off_t size, sse_type_t ssetype, const std::string& ssevalue);
         int GetObjectRequest(const char* tpath, int fd, off_t start = -1, off_t size = -1);
-        int CheckBucket(const char* check_path, bool compat_dir);
+        int CheckBucket(const char* check_path, bool compat_dir, bool force_no_sse);
         int ListBucketRequest(const char* tpath, const char* query);
         int PreMultipartPostRequest(const char* tpath, headers_t& meta, std::string& upload_id, bool is_copy);
         int CompleteMultipartPostRequest(const char* tpath, const std::string& upload_id, etaglist_t& parts);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2401

### Details
If the bucket(or directory under the bucket) user attempt to mount is not created as SSE, a GET request(with the `x-amz-server-side-encryption` header) to check the mount point will return an error(InvalidArgument: `x-amz-server-side-encryption` header is not supported for this operation).

Thus, if the bucket did not have SSE settings(get error response), I changed that s3fs retried to send the GET request without `x-amz-server-side-encryption` header to check the mount point.

@gaul
If there are multiple causes for an error when making a GET request to check a mount point, the error details will be returned in order on each attempt, so the trial processing has been changed to a loop and refactored.
(I have added this recovering code, but the basic logic has not changed.)

This is a PR that fixes a bug reported by @aczire.

