### PR TITLE
Changed the level of messages by the get_base_exp function

### DIFF
--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -110,7 +110,7 @@ static unique_ptr_xmlChar get_base_exp(xmlDocPtr doc, const char* exp)
         return {nullptr, xmlFree};
     }
     if(xmlXPathNodeSetIsEmpty(marker_xp->nodesetval)){
-        S3FS_PRN_ERR("marker_xp->nodesetval is empty.");
+        S3FS_PRN_INFO("marker_xp->nodesetval is empty.");
         return {nullptr, xmlFree};
     }
     xmlNodeSetPtr nodes  = marker_xp->nodesetval;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2394

### Details
`s3fs_xml.cpp: get_base_exp()` outputs the following message whose level is `ERR`, causing confusion:
```
marker_xp->nodesetval is empty.
```
Therefore, change this from `ERR` to `INFO` level.

