### PR TITLE
Gentoo + libxml2-2.12 requires inclusion of parser.h

### DIFF
--- a/src/s3fs_xml.h
+++ b/src/s3fs_xml.h
@@ -22,6 +22,7 @@
 #define S3FS_S3FS_XML_H_
 
 #include <libxml/xpath.h>
+#include <libxml/parser.h>  // [NOTE] nessetially include this header in some environments
 #include <memory>
 #include <string>
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2405 

### Details
An issue was detected in Gentoo + libxml2-2.12.0(<2.12.3) where the libxml/parser.h header could not be included.
Therefore, I added the libxml/parser.h header to be included explicitly.
_Note that the environment other than these conditions is not affected._

