### PR TITLE
Call `abort` instead of `exit` in tests

### DIFF
--- a/src/test_util.h
+++ b/src/test_util.h
@@ -32,7 +32,7 @@ template <typename T> void assert_equals(const T &x, const T &y, const char *fil
     if (x != y) {
         std::cerr << x << " != " << y << " at " << file << ":" << line << std::endl;
         std::cerr << std::endl;
-        std::exit(1);
+        abort();
     }
 }
 
@@ -42,7 +42,7 @@ template <> void assert_equals(const std::string &x, const std::string &y, const
         std::cerr << x << " != " << y << " at " << file << ":" << line << std::endl;
         std::cerr << s3fs_hex_lower(reinterpret_cast<const unsigned char *>(x.c_str()), x.size()) << std::endl;
         std::cerr << s3fs_hex_lower(reinterpret_cast<const unsigned char *>(y.c_str()), y.size()) << std::endl;
-        std::exit(1);
+        abort();
     }
 }
 
@@ -51,7 +51,7 @@ template <typename T> void assert_nequals(const T &x, const T &y, const char *fi
 {
     if (x == y) {
         std::cerr << x << " == " << y << " at " << file << ":" << line << std::endl;
-        std::exit(1);
+        abort();
     }
 }
 
@@ -61,7 +61,7 @@ template <> void assert_nequals(const std::string &x, const std::string &y, cons
         std::cerr << x << " == " << y << " at " << file << ":" << line << std::endl;
         std::cerr << s3fs_hex_lower(reinterpret_cast<const unsigned char *>(x.c_str()), x.size()) << std::endl;
         std::cerr << s3fs_hex_lower(reinterpret_cast<const unsigned char *>(y.c_str()), y.size()) << std::endl;
-        std::exit(1);
+        abort();
     }
 }
 
@@ -72,7 +72,7 @@ void assert_strequals(const char *x, const char *y, const char *file, int line)
   // cppcheck-suppress nullPointerRedundantCheck
   } else if(x == nullptr || y == nullptr || strcmp(x, y) != 0){
       std::cerr << (x ? x : "null") << " != " << (y ? y : "null") << " at " << file << ":" << line << std::endl;
-      std::exit(1);
+      abort();
   }
 }
 
@@ -83,7 +83,7 @@ void assert_bufequals(const char *x, size_t len1, const char *y, size_t len2, co
     // cppcheck-suppress nullPointerRedundantCheck
     } else if(x == nullptr || y == nullptr || len1 != len2 || memcmp(x, y, len1) != 0){
         std::cerr << (x ? std::string(x, len1) : "null") << " != " << (y ? std::string(y, len2) : "null") << " at " << file << ":" << line << std::endl;
-        std::exit(1);
+        abort();
     }
 }
 


### PR DESCRIPTION
This can give useful core dumps.