### PR TITLE
Abort for SSE-KMS encryption type and not SSL/TLS specified

### DIFF
--- a/doc/man/s3fs.1.in
+++ b/doc/man/s3fs.1.in
@@ -110,6 +110,7 @@ You can use "k" for short "kmsid".
 If you san specify SSE-KMS type with your <kms id> in AWS KMS, you can set it after "kmsid:" (or "k:").
 If you specify only "kmsid" ("k"), you need to set AWSSSEKMSID environment which value is <kms id>.
 You must be careful about that you can not use the KMS id which is not same EC2 region.
+Additionally, if you specify SSE-KMS, your endpoints must use Secure Sockets Layer(SSL) or Transport Layer Security(TLS).
 .TP
 \fB\-o\fR load_sse_c - specify SSE-C keys
 Specify the custom-provided encryption keys file path for decrypting at downloading.

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -898,6 +898,13 @@ bool S3fsCurl::FinalCheckSse()
                 S3FS_PRN_ERR("sse type is SSE-KMS, but signature type is not v4. SSE-KMS require signature v4.");
                 return false;
             }
+
+            // SSL/TLS is required for KMS
+            //
+            if(!is_prefix(s3host.c_str(), "https://")){
+                S3FS_PRN_ERR("The sse type is SSE-KMS, but it is not configured to use SSL/TLS. SSE-KMS requires SSL/TLS communication.");
+                return false;
+            }
             return true;
     }
     S3FS_PRN_ERR("sse type is unknown(%d).", static_cast<int>(S3fsCurl::ssetype));

--- a/src/s3fs_help.cpp
+++ b/src/s3fs_help.cpp
@@ -128,6 +128,8 @@ static constexpr char help_string[] =
     "        environment which value is <kms id>. You must be careful\n"
     "        about that you can not use the KMS id which is not same EC2\n"
     "        region.\n"
+    "        Additionally, if you specify SSE-KMS, your endpoints must use\n"
+    "        Secure Sockets Layer(SSL) or Transport Layer Security(TLS).\n"
     "\n"
     "   load_sse_c - specify SSE-C keys\n"
     "        Specify the custom-provided encryption keys file path for decrypting\n"


### PR DESCRIPTION
### Relevant Issue (if applicable)
#526 ([comment](https://github.com/s3fs-fuse/s3fs-fuse/issues/526#issuecomment-279768645))

### Details
For SSE KMS, SSL/TLS communication (https) is required, but it was not checked.
If this combination of options, PUT requests, etc. will fail, but it was difficult to confirm the error details from the user's perspective.
Thus, changed so that s3fs startup fails for this combination of options.
Along with this, a man page and help option have also been added.
(Wiki page will be changed in advance)

