### PR TITLE
Use `xmlFreeNsList` to deallocate `xmlNsPtr`

### DIFF
--- a/src/s3fs.h
+++ b/src/s3fs.h
@@ -64,11 +64,6 @@
           xmlFreeDoc(doc); \
           S3FS_MALLOCTRIM(0); \
         }while(0)
-#define S3FS_XMLFREE(ptr) \
-        do{ \
-          xmlFree(ptr); \
-          S3FS_MALLOCTRIM(0); \
-        }while(0)
 #define S3FS_XMLXPATHFREECONTEXT(ctx) \
         do{ \
           xmlXPathFreeContext(ctx); \

--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -73,7 +73,7 @@ static bool GetXmlNsUrl(xmlDocPtr doc, std::string& nsurl)
                             strNs = std::string(reinterpret_cast<const char*>(nslist[0]->href), len);
                         }
                     }
-                    S3FS_XMLFREE(nslist);
+                    xmlFreeNsList(*nslist);
                 }
             }
         }


### PR DESCRIPTION
Previously `xmlFree` only freed the top-level allocation and not the entire linked list.  Multiple namespaces should be rare but perhaps some S3 implementations have both a global and local namespace.  The `xmlFree(void*)` prototype hid the type mismatch.