### PR TITLE
Fixed configure error for GHA:sanitize_thread

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,10 @@ jobs:
               echo 'CXX=clang++'                                       >> $GITHUB_ENV
               echo "CXXFLAGS=${COMMON_CXXFLAGS} -O0 -fsanitize=thread" >> $GITHUB_ENV
               echo 'TSAN_OPTIONS=halt_on_error=1'                      >> $GITHUB_ENV
+              # [NOTE]
+              # Set this to avoid following error when running configure.
+              # "FATAL: ThreadSanitizer: unexpected memory mapping"
+              sysctl vm.mmap_rnd_bits=28
           elif [ "${{ matrix.checktype }}" = "sanitize_others" ]; then
               echo 'CXX=clang++'                                       >> $GITHUB_ENV
               echo "CXXFLAGS=${COMMON_CXXFLAGS} -O1 -fsanitize=undefined,implicit-conversion,local-bounds,unsigned-integer-overflow" >> $GITHUB_ENV


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
For the past few days, an error has been occurring when running GithubActions (CI) for `MemoryTest (sanitize thread)`.
The error is an error when running `configure`, and the details are as follows:
```
FATAL: ThreadSanitizer: unexpected memory mapping 0x7d6327672000-0x7d6327b00000
```

To avoid this error, set `vm.mmap_rnd_bits` to `28` only in `MemoryTest(sanitize thread)`. (The value before change is `32`. I also set it to `30`, but the error still occurs)

- Reference  
https://stackoverflow.com/questions/77850769/fatal-threadsanitizer-unexpected-memory-mapping-when-running-on-linux-kernels

