### PR TITLE
retry request on HTTP 429 error

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2582,6 +2582,7 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
                         result = -ENOTSUP;
                         break;
 
+                    case 429:
                     case 500:
                     case 503: {
                         S3FS_PRN_INFO3("HTTP response code %ld was returned, slowing down", responseCode);


### PR DESCRIPTION
<!-- --------------------------------------------------------------------------
 Please describe the purpose of the pull request(such as resolving the issue)
 and what the fix/update is.
--------------------------------------------------------------------------- -->

Hi,

Some non-Amazon S3 implementation have a stricter quota / rate-limiting than AWS (for example Scaleway). It means that it's quiet easy to be rate limited in case of large buckets for example. In this case, an HTTP error 429 is returned and the request fails.

This PR makes s3fs retry when an HTTP error 429 is returned, as it's already doing for 500 and 503 errors.

Thanks!

