### PR TITLE
Fix DeadLock in FdManager::ChangeEntityToTempPath

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -775,7 +775,7 @@ bool FdManager::Close(FdEntity* ent, int fd)
     return false;
 }
 
-bool FdManager::ChangeEntityToTempPath(FdEntity* ent, const char* path)
+bool FdManager::ChangeEntityToTempPath(const FdEntity* ent, const char* path)
 {
     AutoLock auto_lock(&FdManager::fd_manager_lock);
 
@@ -783,8 +783,10 @@ bool FdManager::ChangeEntityToTempPath(FdEntity* ent, const char* path)
         if(iter->second.get() == ent){
             std::string tmppath;
             FdManager::MakeRandomTempPath(path, tmppath);
-            iter->second.reset(ent);
-            break;
+            // Move the entry to the new key
+            fent[tmppath] = std::move(iter->second);
+            iter = fent.erase(iter);
+            return true;
         }else{
             ++iter;
         }

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -96,7 +96,7 @@ class FdManager
       FdEntity* OpenExistFdEntity(const char* path, int& fd, int flags = O_RDONLY);
       void Rename(const std::string &from, const std::string &to);
       bool Close(FdEntity* ent, int fd);
-      bool ChangeEntityToTempPath(FdEntity* ent, const char* path);
+      bool ChangeEntityToTempPath(const FdEntity* ent, const char* path);
       void CleanupCacheDir();
 
       bool CheckAllCache();


### PR DESCRIPTION
this fix #2454 
