### PR TITLE
Fixed error reports of failure in cppcheck 2.14.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,7 @@ cppcheck:
             --suppress=unmatchedSuppression \
             --suppress=useStlAlgorithm \
             --suppress=checkLevelNormal \
+            --suppress=normalCheckLevelMaxBranches \
             src/ test/
 
 #

--- a/src/curl.h
+++ b/src/curl.h
@@ -385,11 +385,11 @@ class S3fsCurl
 
         // methods(variables)
         CURL* GetCurlHandle() const { return hCurl; }
-        std::string GetPath() const { return path; }
-        std::string GetBasePath() const { return base_path; }
-        std::string GetSpecialSavedPath() const { return saved_path; }
-        std::string GetUrl() const { return url; }
-        std::string GetOp() const { return op; }
+        const std::string& GetPath() const { return path; }
+        const std::string& GetBasePath() const { return base_path; }
+        const std::string& GetSpecialSavedPath() const { return saved_path; }
+        const std::string& GetUrl() const { return url; }
+        const std::string& GetOp() const { return op; }
         const headers_t* GetResponseHeaders() const { return &responseHeaders; }
         const std::string* GetBodyData() const { return &bodydata; }
         const std::string* GetHeadData() const { return &headdata; }

--- a/src/test_curl_util.cpp
+++ b/src/test_curl_util.cpp
@@ -150,7 +150,7 @@ void test_slist_remove()
     curl_slist_free_all(list);
 }
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
     test_sort_insert();
     test_slist_remove();

--- a/src/test_page_list.cpp
+++ b/src/test_page_list.cpp
@@ -72,7 +72,7 @@ void test_compress()
   ASSERT_EQUALS(off_t(36), size);
 }
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
   test_compress();
   return 0;

--- a/src/test_string_util.cpp
+++ b/src/test_string_util.cpp
@@ -197,7 +197,7 @@ void test_cr_encoding()
     ASSERT_EQUALS(get_decoded_cr_code(get_encoded_cr_code(base_mid_crper2.c_str()).c_str()), base_mid_crper2);
 }
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
     S3fsLog singletonLog;
 

--- a/test/truncate_read_file.cc
+++ b/test/truncate_read_file.cc
@@ -31,7 +31,7 @@
 // This program truncates the file and reads the file in another process
 // between truncate and flush(close file).
 //
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
     if(argc != 3){
         fprintf(stderr, "[ERROR] Wrong paraemters\n");


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
In the MacOS CI test, cppcheck now uses 2.14.0 and an error was output, so this PR fixed it.
