### PR TITLE
Remove uses of `AutoLock::ALREADY_LOCKED`

### DIFF
--- a/src/autolock.h
+++ b/src/autolock.h
@@ -23,6 +23,9 @@
 
 #include <pthread.h>
 
+// empty annotation to indicate lock requirement
+#define REQUIRES(...)
+
 //-------------------------------------------------------------------
 // AutoLock Class
 //-------------------------------------------------------------------

--- a/src/curl.h
+++ b/src/curl.h
@@ -258,7 +258,7 @@ class S3fsCurl
         static int RawCurlDebugFunc(const CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr, curl_infotype datatype);
 
         // methods
-        bool ResetHandle(AutoLock::Type locktype = AutoLock::NONE);
+        bool ResetHandle() REQUIRES(&S3fsCurl::curl_handles_lock);
         bool RemakeHandle();
         bool ClearInternalData();
         void insertV4Headers(const std::string& access_key_id, const std::string& secret_access_key, const std::string& access_token);
@@ -354,7 +354,8 @@ class S3fsCurl
 
         // methods
         bool CreateCurlHandle(bool only_pool = false, bool remake = false);
-        bool DestroyCurlHandle(bool restore_pool = true, bool clear_internal_data = true, AutoLock::Type locktype = AutoLock::NONE);
+        bool DestroyCurlHandle(bool restore_pool = true, bool clear_internal_data = true);
+        bool DestroyCurlHandleHasLock(bool restore_pool = true, bool clear_internal_data = true) REQUIRES(S3fsCurl::curl_handles_lock);
 
         bool GetIAMCredentials(const char* cred_url, const char* iam_v2_token, const char* ibm_secret_access_key, std::string& response);
         bool GetIAMRoleFromMetaData(const char* cred_url, const char* iam_v2_token, std::string& token);

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -94,8 +94,12 @@ class FdManager
       static off_t GetTotalDiskSpaceByRatio(int ratio);
 
       // Return FdEntity associated with path, returning nullptr on error.  This operation increments the reference count; callers must decrement via Close after use.
-      FdEntity* GetFdEntity(const char* path, int& existfd, bool newfd = true, AutoLock::Type locktype = AutoLock::NONE);
-      FdEntity* Open(int& fd, const char* path, const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type);
+      FdEntity* GetFdEntity(const char* path, int& existfd, bool newfd = true) {
+          AutoLock auto_lock(&FdManager::fd_manager_lock);
+          return GetFdEntityHasLock(path, existfd, newfd);
+      }
+      FdEntity* GetFdEntityHasLock(const char* path, int& existfd, bool newfd = true) REQUIRES(FdManager::fd_manager_lock);
+      FdEntity* Open(int& fd, const char* path, const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify) REQUIRES(FdManager::fd_manager_lock);
       FdEntity* GetExistFdEntity(const char* path, int existfd = -1);
       FdEntity* OpenExistFdEntity(const char* path, int& fd, int flags = O_RDONLY);
       void Rename(const std::string &from, const std::string &to);

--- a/src/fdcache_auto.cpp
+++ b/src/fdcache_auto.cpp
@@ -78,11 +78,11 @@ FdEntity* AutoFdEntity::Attach(const char* path, int existfd)
     return pFdEntity;
 }
 
-FdEntity* AutoFdEntity::Open(const char* path, const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type, int* error)
+FdEntity* AutoFdEntity::Open(const char* path, const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, int* error)
 {
     Close();
 
-    if(nullptr == (pFdEntity = FdManager::get()->Open(pseudo_fd, path, pmeta, size, ts_mctime, flags, force_tmpfile, is_create, ignore_modify, type))){
+    if(nullptr == (pFdEntity = FdManager::get()->Open(pseudo_fd, path, pmeta, size, ts_mctime, flags, force_tmpfile, is_create, ignore_modify))){
         if(error){
             *error = pseudo_fd;
         }

--- a/src/fdcache_auto.h
+++ b/src/fdcache_auto.h
@@ -57,7 +57,7 @@ class AutoFdEntity
       FdEntity* Attach(const char* path, int existfd);
       int GetPseudoFd() const { return pseudo_fd; }
 
-      FdEntity* Open(const char* path, const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, AutoLock::Type type, int* error = nullptr);
+      FdEntity* Open(const char* path, const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags, bool force_tmpfile, bool is_create, bool ignore_modify, int* error = nullptr) REQUIRES(FdManager::fd_manager_lock);
       FdEntity* GetExistFdEntity(const char* path, int existfd = -1);
       FdEntity* OpenExistFdEntity(const char* path, int flags = O_RDONLY);
 };

--- a/src/fdcache_fdinfo.h
+++ b/src/fdcache_fdinfo.h
@@ -79,12 +79,12 @@ class PseudoFdInfo
 
         bool Clear();
         void CloseUploadFd();
-        bool OpenUploadFd(AutoLock::Type type = AutoLock::NONE);
-        bool ResetUploadInfo(AutoLock::Type type);
-        bool RowInitialUploadInfo(const std::string& id, bool is_cancel_mp, AutoLock::Type type);
-        bool CompleteInstruction(int result, AutoLock::Type type = AutoLock::NONE);
-        bool ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy, AutoLock::Type type = AutoLock::NONE);
-        bool InsertUploadPart(off_t start, off_t size, int part_num, bool is_copy, etagpair** ppetag, AutoLock::Type type = AutoLock::NONE);
+        bool OpenUploadFd() REQUIRES(PseudoFdInfo::upload_list_lock);
+        bool ResetUploadInfo() REQUIRES(PseudoFdInfo::upload_list_lock);
+        bool RowInitialUploadInfo(const std::string& id, bool is_cancel_mp);
+        bool CompleteInstruction(int result) REQUIRES(S3fsCurl::curl_handles_lock);
+        bool ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy) REQUIRES(PseudoFdInfo::upload_list_lock);
+        bool InsertUploadPart(off_t start, off_t size, int part_num, bool is_copy, etagpair** ppetag) REQUIRES(PseudoFdInfo::upload_list_lock);
         bool CancelAllThreads();
         bool ExtractUploadPartsFromUntreatedArea(const off_t& untreated_start, const off_t& untreated_size, mp_part_list_t& to_upload_list, filepart_list_t& cancel_upload_list, off_t max_mp_size);
 
@@ -104,7 +104,7 @@ class PseudoFdInfo
 
         bool Set(int fd, int open_flags);
         bool ClearUploadInfo(bool is_cancel_mp = false);
-        bool InitialUploadInfo(const std::string& id){ return RowInitialUploadInfo(id, true, AutoLock::NONE); }
+        bool InitialUploadInfo(const std::string& id){ return RowInitialUploadInfo(id, true); }
 
         bool IsUploading() const { return !upload_id.empty(); }
         bool GetUploadId(std::string& id) const;

--- a/src/s3fs_cred.h
+++ b/src/s3fs_cred.h
@@ -102,24 +102,24 @@ class S3fsCred
         bool SetAwsProfileName(const char* profile_name);
         bool SetIAMRoleMetadataType(bool flag);
 
-        bool SetAccessKey(const char* AccessKeyId, const char* SecretAccessKey, AutoLock::Type type);
-        bool SetAccessKeyWithSessionToken(const char* AccessKeyId, const char* SecretAccessKey, const char * SessionToken, AutoLock::Type type);
-        bool IsSetAccessKeys(AutoLock::Type type) const;
+        bool SetAccessKey(const char* AccessKeyId, const char* SecretAccessKey) REQUIRES(S3fsCred::token_lock);
+        bool SetAccessKeyWithSessionToken(const char* AccessKeyId, const char* SecretAccessKey, const char * SessionToken) REQUIRES(S3fsCred::token_lock);
+        bool IsSetAccessKeys() const REQUIRES(S3fsCred::token_lock);
 
         bool SetIsECS(bool flag);
         bool SetIsUseSessionToken(bool flag);
 
         bool SetIsIBMIAMAuth(bool flag);
 
-        int SetIMDSVersion(int version, AutoLock::Type type);
-        int GetIMDSVersion(AutoLock::Type type) const;
+        int SetIMDSVersion(int version) REQUIRES(S3fsCred::token_lock);
+        int GetIMDSVersion() const REQUIRES(S3fsCred::token_lock);
 
-        bool SetIAMv2APIToken(const std::string& token, AutoLock::Type type);
-        std::string GetIAMv2APIToken(AutoLock::Type type) const;
+        bool SetIAMv2APIToken(const std::string& token) REQUIRES(S3fsCred::token_lock);
+        const std::string& GetIAMv2APIToken() const REQUIRES(S3fsCred::token_lock);
 
-        bool SetIAMRole(const char* role, AutoLock::Type type);
-        std::string GetIAMRole(AutoLock::Type type) const;
-        bool IsSetIAMRole(AutoLock::Type type) const;
+        bool SetIAMRole(const char* role) REQUIRES(S3fsCred::token_lock);
+        const std::string& GetIAMRole() const REQUIRES(S3fsCred::token_lock);
+        bool IsSetIAMRole() const REQUIRES(S3fsCred::token_lock);
         size_t SetIAMFieldCount(size_t field_count);
         std::string SetIAMCredentialsURL(const char* url);
         std::string SetIAMTokenField(const char* token_field);
@@ -128,18 +128,18 @@ class S3fsCred
         bool IsReadableS3fsPasswdFile() const;
         bool CheckS3fsPasswdFilePerms();
         bool ParseS3fsPasswdFile(bucketkvmap_t& resmap);
-        bool ReadS3fsPasswdFile(AutoLock::Type type);
+        bool ReadS3fsPasswdFile() REQUIRES(S3fsCred::token_lock);
 
         static int CheckS3fsCredentialAwsFormat(const kvmap_t& kvmap, std::string& access_key_id, std::string& secret_access_key);
-        bool ReadAwsCredentialFile(const std::string &filename, AutoLock::Type type);
+        bool ReadAwsCredentialFile(const std::string &filename) REQUIRES(S3fsCred::token_lock);
 
-        bool InitialS3fsCredentials();
+        bool InitialS3fsCredentials() REQUIRES(S3fsCred::token_lock);
         bool ParseIAMCredentialResponse(const char* response, iamcredmap_t& keyval);
 
-        bool GetIAMCredentialsURL(std::string& url, bool check_iam_role, AutoLock::Type type);
-        bool LoadIAMCredentials(AutoLock::Type type);
-        bool SetIAMCredentials(const char* response, AutoLock::Type type);
-        bool SetIAMRoleFromMetaData(const char* response, AutoLock::Type type);
+        bool GetIAMCredentialsURL(std::string& url, bool check_iam_role) REQUIRES(S3fsCred::token_lock);
+        bool LoadIAMCredentials() REQUIRES(S3fsCred::token_lock);
+        bool SetIAMCredentials(const char* response) REQUIRES(S3fsCred::token_lock);
+        bool SetIAMRoleFromMetaData(const char* response) REQUIRES(S3fsCred::token_lock);
 
         bool SetExtCredLib(const char* arg);
         bool IsSetExtCredLib() const;
@@ -149,7 +149,7 @@ class S3fsCred
         bool InitExtCredLib();
         bool LoadExtCredLib();
         bool UnloadExtCredLib();
-        bool UpdateExtCredentials(AutoLock::Type type);
+        bool UpdateExtCredentials() REQUIRES(S3fsCred::token_lock);
 
         static bool CheckForbiddenBucketParams();
 


### PR DESCRIPTION
Instead annotate the methods with `REQUIRES` so that the caller knows if they should lock.  For public interfaces, introduce `HasLock` wrappers.  This simplifies control flow, allows migration to `std::mutex`, and eventually will enable use of static lock checking.