### PR TITLE
Replace `memset` with C++11 value initialization

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -476,8 +476,7 @@ bool StatCache::AddNoObjectCache(const std::string& key)
     }
 
     // make new
-    stat_cache_entry ent;
-    memset(&ent.stbuf, 0, sizeof(struct stat));
+    stat_cache_entry ent{};
     ent.hit_count  = 0;
     ent.isforce    = false;
     ent.noobjcache = true;
@@ -847,7 +846,7 @@ bool convert_header_to_stat(const char* path, const headers_t& meta, struct stat
     if(!path || !pst){
         return false;
     }
-    memset(pst, 0, sizeof(struct stat));
+    *pst = {};
 
     pst->st_nlink = 1; // see fuse FAQ
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -37,18 +37,13 @@
 // Struct for stats cache
 //
 struct stat_cache_entry {
-    struct stat       stbuf;
+    struct stat       stbuf = {};
     unsigned long     hit_count = 0;
     struct timespec   cache_date = {0, 0};
     headers_t         meta;
     bool              isforce = false;
     bool              noobjcache = false;  // Flag: cache is no object for no listing.
     unsigned long     notruncate = 0L;  // 0<:   not remove automatically at checking truncate
-
-    stat_cache_entry()
-    {
-        memset(&stbuf, 0, sizeof(stbuf));
-    }
 };
 
 typedef std::map<std::string, stat_cache_entry> stat_cache_t; // key=path

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -485,7 +485,7 @@ int FdEntity::Open(const headers_t* pmeta, off_t size, const struct timespec& ts
                 pagelist.Serialize(*pcfstat, false, inode)            )
             {
                 // succeed to open cache file and to load stats data
-                memset(&st, 0, sizeof(struct stat));
+                st = {};
                 if(-1 == fstat(physical_fd, &st)){
                     S3FS_PRN_ERR("fstat is failed. errno(%d)", errno);
                     physical_fd = -1;
@@ -767,7 +767,7 @@ bool FdEntity::GetStatsHasLock(struct stat& st) const
         return false;
     }
 
-    memset(&st, 0, sizeof(struct stat)); 
+    st = {};
     if(-1 == fstat(physical_fd, &st)){
         S3FS_PRN_ERR("fstat failed. errno(%d)", errno);
         return false;
@@ -1031,8 +1031,7 @@ bool FdEntity::SetAllStatus(bool is_loaded)
     //AutoLock auto_lock(&fdent_lock);
 
     // get file size
-    struct stat st;
-    memset(&st, 0, sizeof(struct stat));
+    struct stat st{};
     if(-1 == fstat(physical_fd, &st)){
         S3FS_PRN_ERR("fstat is failed. errno(%d)", errno);
         return false;
@@ -1481,8 +1480,7 @@ int FdEntity::RowFlushNoMultipart(const PseudoFdInfo* pseudo_obj, const char* tp
     }
 
     // backup upload file size
-    struct stat st;
-    memset(&st, 0, sizeof(struct stat));
+    struct stat st{};
     if(-1 == fstat(physical_fd, &st)){
         S3FS_PRN_ERR("fstat is failed by errno(%d), but continue...", errno);
     }
@@ -1548,8 +1546,7 @@ int FdEntity::RowFlushMultipart(PseudoFdInfo* pseudo_obj, const char* tpath)
             }
 
             // backup upload file size
-            struct stat st;
-            memset(&st, 0, sizeof(struct stat));
+            struct stat st{};
             if(-1 == fstat(physical_fd, &st)){
                 S3FS_PRN_ERR("fstat is failed by errno(%d), but continue...", errno);
             }
@@ -1649,8 +1646,7 @@ int FdEntity::RowFlushMixMultipart(PseudoFdInfo* pseudo_obj, const char* tpath)
             FdManager::FreeReservedDiskSpace(restsize);
 
             // backup upload file size
-            struct stat st;
-            memset(&st, 0, sizeof(struct stat));
+            struct stat st{};
             if(-1 == fstat(physical_fd, &st)){
                 S3FS_PRN_ERR("fstat is failed by errno(%d), but continue...", errno);
             }
@@ -1755,8 +1751,7 @@ int FdEntity::RowFlushStreamMultipart(PseudoFdInfo* pseudo_obj, const char* tpat
         //
 
         // backup upload file size
-        struct stat st;
-        memset(&st, 0, sizeof(struct stat));
+        struct stat st{};
         if(-1 == fstat(physical_fd, &st)){
             S3FS_PRN_ERR("fstat is failed by errno(%d), but continue...", errno);
         }

--- a/src/fdcache_page.cpp
+++ b/src/fdcache_page.cpp
@@ -849,8 +849,7 @@ bool PageList::Serialize(CacheFileStat& file, bool is_output, ino_t inode)
         //
         // loading from file
         //
-        struct stat st;
-        memset(&st, 0, sizeof(struct stat));
+        struct stat st{};
         if(-1 == fstat(file.GetFd(), &st)){
             S3FS_PRN_ERR("fstat is failed. errno(%d)", errno);
             return false;

--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -250,22 +250,20 @@ blkcnt_t get_blocks(off_t size)
 
 time_t cvtIAMExpireStringToTime(const char* s)
 {
-    struct tm tm;
+    struct tm tm{};
     if(!s){
         return 0L;
     }
-    memset(&tm, 0, sizeof(struct tm));
     strptime(s, "%Y-%m-%dT%H:%M:%S", &tm);
     return timegm(&tm); // GMT
 }
 
 time_t get_lastmodified(const char* s)
 {
-    struct tm tm;
+    struct tm tm{};
     if(!s){
         return -1;
     }
-    memset(&tm, 0, sizeof(struct tm));
     strptime(s, "%a, %d %b %Y %H:%M:%S %Z", &tm);
     return timegm(&tm); // GMT
 }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -519,7 +519,7 @@ static int get_object_attribute(const char* path, struct stat* pstbuf, headers_t
         return -ENOENT;
     }
 
-    memset(pstat, 0, sizeof(struct stat));
+    *pstat = {};
 
     // check mount point
     if(0 == strcmp(path, "/") || 0 == strcmp(path, ".")){
@@ -4805,7 +4805,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
 // In MSYS2 environment with WinFsp, it is not needed to create the mount point before mounting.
 // Also it causes a conflict with WinFsp's validation, so disabling it.
 #ifdef __MSYS__
-            memset(&stbuf, 0, sizeof stbuf);
+            stbuf = {};
             set_mountpoint_attribute(stbuf);
 #else
             if(stat(arg, &stbuf) == -1){
@@ -5581,7 +5581,7 @@ int main(int argc, char* argv[])
     int ch;
     int fuse_res;
     int option_index = 0; 
-    struct fuse_operations s3fs_oper;
+    struct fuse_operations s3fs_oper{};
     time_t incomp_abort_time = (24 * 60 * 60);
     S3fsLog singletonLog;
 
@@ -5726,9 +5726,6 @@ int main(int argc, char* argv[])
         destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
-
-    // clear this structure
-    memset(&s3fs_oper, 0, sizeof(s3fs_oper));
 
     // This is the fuse-style parser for the arguments
     // after which the bucket name and mountpoint names

--- a/src/sighandlers.cpp
+++ b/src/sighandlers.cpp
@@ -131,9 +131,7 @@ void S3fsSignals::HandlerUSR2(int sig)
 
 bool S3fsSignals::InitUsr2Handler()
 {
-    struct sigaction sa;
-
-    memset(&sa, 0, sizeof(struct sigaction));
+    struct sigaction sa{};
     sa.sa_handler = S3fsSignals::HandlerUSR2;
     sa.sa_flags   = SA_RESTART;
     if(0 != sigaction(SIGUSR2, &sa, nullptr)){
@@ -153,9 +151,7 @@ void S3fsSignals::HandlerHUP(int sig)
 
 bool S3fsSignals::InitHupHandler()
 {
-    struct sigaction sa;
-
-    memset(&sa, 0, sizeof(struct sigaction));
+    struct sigaction sa{};
     sa.sa_handler = S3fsSignals::HandlerHUP;
     sa.sa_flags   = SA_RESTART;
     if(0 != sigaction(SIGHUP, &sa, nullptr)){
@@ -210,8 +206,7 @@ bool S3fsSignals::InitUsr1Handler()
     pThreadUsr1 = std::move(pThreadUsr1_tmp);
 
     // set handler
-    struct sigaction sa;
-    memset(&sa, 0, sizeof(struct sigaction));
+    struct sigaction sa{};
     sa.sa_handler = S3fsSignals::HandlerUSR1;
     sa.sa_flags   = SA_RESTART;
     if(0 != sigaction(SIGUSR1, &sa, nullptr)){


### PR DESCRIPTION
This generates the same code but is safer due to using an implicit length and allowing member initialization.