### PR TITLE
Changed the display format of the Git commit hash in the version display

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -21,11 +21,15 @@
 
 echo "--- Make commit hash file -------"
 
-SHORTHASH="unknown"
+SHORTHASH=""
 if command -v git > /dev/null 2>&1 && test -d .git; then
-	if RESULT=$(git rev-parse --short HEAD); then
-		SHORTHASH="${RESULT}"
-	fi
+    if SHORTHASH=$(git rev-parse --short HEAD); then
+        echo " -> Git commit hash : ${SHORTHASH}"
+    else
+        echo " -> Not get git commit hash"
+    fi
+else
+    echo " -> Not found git command or .git directory"
 fi
 echo "${SHORTHASH}" > default_commit_hash
 

--- a/configure.ac
+++ b/configure.ac
@@ -367,11 +367,22 @@ AS_IF([test -d .git], [DOTGITDIR=yes], [DOTGITDIR=no])
 
 AC_MSG_CHECKING([github short commit hash])
 if test "x${GITCMD}" = "xyes" -a "x${DOTGITDIR}" = "xyes"; then
-    GITCOMMITHASH=`git rev-parse --short HEAD`
+    TMP_GITCOMMITHASH=`git rev-parse --short HEAD`
+    UNTRACKED_FILES=`git status -s --untracked-files=no`
+    if test -n "${UNTRACKED_FILES}"; then
+       GITCOMMITHASH="(commit:${TMP_GITCOMMITHASH} +untracked files)"
+    else
+       GITCOMMITHASH="(commit:${TMP_GITCOMMITHASH})"
+    fi
 elif test -f default_commit_hash; then
-    GITCOMMITHASH=`cat default_commit_hash`
+    TMP_GITCOMMITHASH=`cat default_commit_hash`
+    if test -n "${TMP_GITCOMMITHASH}"; then
+       GITCOMMITHASH="(base commit:${TMP_GITCOMMITHASH})"
+    else
+       GITCOMMITHASH=""
+    fi
 else
-    GITCOMMITHASH="unknown"
+    GITCOMMITHASH=""
 fi
 AC_MSG_RESULT([${GITCOMMITHASH}])
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4270,7 +4270,7 @@ static void s3fs_exit_fuseloop(int exit_status)
 
 static void* s3fs_init(struct fuse_conn_info* conn)
 {
-    S3FS_PRN_INIT_INFO("init v%s(commit:%s) with %s, credential-library(%s)", VERSION, COMMIT_HASH_VAL, s3fs_crypt_lib_name(), ps3fscred->GetCredFuncVersion(false));
+    S3FS_PRN_INIT_INFO("init v%s%s with %s, credential-library(%s)", VERSION, COMMIT_HASH_VAL, s3fs_crypt_lib_name(), ps3fscred->GetCredFuncVersion(false));
 
     // cache(remove cache dirs at first)
     if(is_remove_cache && (!CacheFileStat::DeleteCacheFileStatDirectory() || !FdManager::DeleteCacheDirectory())){

--- a/src/s3fs_help.cpp
+++ b/src/s3fs_help.cpp
@@ -653,7 +653,7 @@ void show_help()
 void show_version()
 {
     printf(
-    "Amazon Simple Storage Service File System V%s (commit:%s) with %s\n"
+    "Amazon Simple Storage Service File System V%s%s with %s\n"
     "Copyright (C) 2010 Randy Rizun <rrizun@gmail.com>\n"
     "License GPL2: GNU GPL version 2 <https://gnu.org/licenses/gpl.html>\n"
     "This is free software: you are free to change and redistribute it.\n"
@@ -663,7 +663,7 @@ void show_version()
 
 const char* short_version()
 {
-    static constexpr char short_ver[] = "s3fs version " VERSION "(" COMMIT_HASH_VAL ")";
+    static constexpr char short_ver[] = "s3fs version " VERSION "" COMMIT_HASH_VAL;
     return short_ver;
 }
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2457

### Details
Currently, the s3fs version display includes the git commit hash(short sha1).
However, in the s3fs distributed from the package repository, the commit hash value is `unknown`.

Because this `unknown` can be misleading, the version notation will be changed to the following depending on the environment in which s3fs was built.

#### If there is no git command or if the .git directory does not exist
The commit hash will not be displayed.
```
Amazon Simple Storage Service File System V1.94 with OpenSSL
```
#### If the git commit hash can be obtained
- If there is no untracked file:  
```
Amazon Simple Storage Service File System V1.94(commit:254d717) with OpenSSL
```
- If there is an untracked file:  
```
Amazon Simple Storage Service File System V1.94(commit:254d717 +untracked files) with OpenSSL
```

#### If the git commit hash cannot be obtained, but there is a `default_commit_hash` file
This case applies when extracting a distribution archive of source code created by `make dist`.
```
Amazon Simple Storage Service File System V1.94(base commit:254d717) with OpenSSL
```


