### PR TITLE
Fixed a deadlock in the FdManager::ChangeEntityToTempPath method call

### DIFF
--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -36,6 +36,7 @@ class FdManager
       static std::mutex      fd_manager_lock;
       static std::mutex      cache_cleanup_lock;
       static std::mutex      reserved_diskspace_lock;
+      static std::mutex      except_entmap_lock;
       static std::string     cache_dir;
       static bool            check_cache_dir_exist;
       static off_t           free_disk_space;       // limit free disk space
@@ -46,6 +47,7 @@ class FdManager
       static std::string     tmp_dir;
 
       fdent_map_t            fent;
+      fdent_direct_map_t     except_fent;           // A map of delayed deletion fdentity
 
   private:
       static off_t GetFreeDiskSpace(const char* path);
@@ -54,6 +56,7 @@ class FdManager
       static int GetVfsStat(const char* path, struct statvfs* vfsbuf);
 
       int GetPseudoFdCount(const char* path);
+      bool UpdateEntityToTempPath();
       void CleanupCacheDirInternal(const std::string &path = "");
       bool RawCheckAllCache(FILE* fp, const char* cache_stat_top_dir, const char* sub_path, int& total_file_cnt, int& err_file_cnt, int& err_dir_cnt);
 
@@ -106,7 +109,7 @@ class FdManager
       FdEntity* OpenExistFdEntity(const char* path, int& fd, int flags = O_RDONLY);
       void Rename(const std::string &from, const std::string &to);
       bool Close(FdEntity* ent, int fd);
-      bool ChangeEntityToTempPath(const FdEntity* ent, const char* path);
+      bool ChangeEntityToTempPath(FdEntity* ent, const char* path);
       void CleanupCacheDir();
 
       bool CheckAllCache();

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -219,7 +219,8 @@ class FdEntity
         bool ReplaceLastUpdateUntreatedPart(off_t front_start, off_t front_size, off_t behind_start, off_t behind_size);
 };
 
-typedef std::map<std::string, std::unique_ptr<FdEntity>> fdent_map_t;   // key=path, value=FdEntity*
+typedef std::map<std::string, std::unique_ptr<FdEntity>> fdent_map_t;           // key=path, value=unique_ptr<FdEntity>
+typedef std::map<std::string, FdEntity*>                 fdent_direct_map_t;    // key=path, value=FdEntity*
 
 #endif // S3FS_FDCACHE_ENTITY_H_
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2438 #2463

### Details
Fixed a bug that caused a deadlock during simultaneous processing such as file uploads from multiple threads when there was not enough cache space.

The FdManager class manages object paths and FdEntity in a map, but when there is not enough cache space, there is a process that changes the object path of that entry.
For this process, the FdManager object is operated from the FdEntity method.
At this time, a deadlock occurred.

As a currently solution, we delayed the operation rather than directly operating the map object when calling the process to change the object path.

@gaul
I think this is the best solution at the moment.
We are also considering adding test cases, but it may be difficult.
(Due to the issue of whether we can reliably create a timing that causes the bug to occur.)

