### PR TITLE
Make deleted constructors and operators public

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -58,7 +58,6 @@ Checks: '
     -modernize-return-braced-init-list,
     -modernize-use-auto,
     -modernize-use-default-member-init,
-    -modernize-use-equals-delete,
     -modernize-use-trailing-return-type,
     -modernize-use-using,
     performance-*,

--- a/src/addhead.h
+++ b/src/addhead.h
@@ -69,12 +69,13 @@ class AdditionalHeader
     protected:
         AdditionalHeader();
         ~AdditionalHeader();
+
+    public:
         AdditionalHeader(const AdditionalHeader&) = delete;
         AdditionalHeader(AdditionalHeader&&) = delete;
         AdditionalHeader& operator=(const AdditionalHeader&) = delete;
         AdditionalHeader& operator=(AdditionalHeader&&) = delete;
 
-    public:
         // Reference singleton
         static AdditionalHeader* get() { return &singleton; }
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -92,13 +92,8 @@ class StatCache
         symlink_cache_t        symlink_cache;
         notruncate_dir_map_t   notruncate_file_cache;
 
-    private:
         StatCache();
         ~StatCache();
-        StatCache(const StatCache&) = delete;
-        StatCache(StatCache&&) = delete;
-        StatCache& operator=(const StatCache&) = delete;
-        StatCache& operator=(StatCache&&) = delete;
 
         void Clear();
         bool GetStat(const std::string& key, struct stat* pst, headers_t* meta, bool overcheck, const char* petag, bool* pisforce);
@@ -111,6 +106,11 @@ class StatCache
         bool DelNotruncateCache(const std::string& key);
 
     public:
+        StatCache(const StatCache&) = delete;
+        StatCache(StatCache&&) = delete;
+        StatCache& operator=(const StatCache&) = delete;
+        StatCache& operator=(StatCache&&) = delete;
+
         // Reference singleton
         static StatCache* getStatCacheData()
         {

--- a/src/fdcache_auto.h
+++ b/src/fdcache_auto.h
@@ -42,15 +42,13 @@ class AutoFdEntity
       FdEntity* pFdEntity;
       int       pseudo_fd;
 
-  private:
+  public:
+      AutoFdEntity();
+      ~AutoFdEntity();
       AutoFdEntity(const AutoFdEntity&) = delete;
       AutoFdEntity(AutoFdEntity&&) = delete;
       AutoFdEntity& operator=(const AutoFdEntity&) = delete;
       AutoFdEntity& operator=(AutoFdEntity&&) = delete;
-
-  public:
-      AutoFdEntity();
-      ~AutoFdEntity();
 
       bool Close();
       int Detach();

--- a/src/fdcache_pseudofd.h
+++ b/src/fdcache_pseudofd.h
@@ -40,21 +40,21 @@ class PseudoFdManager
         pseudofd_list_t pseudofd_list;
         std::mutex      pseudofd_list_lock;    // protects pseudofd_list
 
-    private:
         static PseudoFdManager& GetManager();
 
         PseudoFdManager() = default;
         ~PseudoFdManager() = default;
-        PseudoFdManager(const PseudoFdManager&) = delete;
-        PseudoFdManager(PseudoFdManager&&) = delete;
-        PseudoFdManager& operator=(const PseudoFdManager&) = delete;
-        PseudoFdManager& operator=(PseudoFdManager&&) = delete;
 
         int GetUnusedMinPseudoFd() const;
         int CreatePseudoFd();
         bool ReleasePseudoFd(int fd);
 
     public:
+        PseudoFdManager(const PseudoFdManager&) = delete;
+        PseudoFdManager(PseudoFdManager&&) = delete;
+        PseudoFdManager& operator=(const PseudoFdManager&) = delete;
+        PseudoFdManager& operator=(PseudoFdManager&&) = delete;
+
         static int Get();
         static bool Release(int fd);
 };

--- a/src/sighandlers.h
+++ b/src/sighandlers.h
@@ -50,10 +50,6 @@ class S3fsSignals
         static bool InitHupHandler();
 
         S3fsSignals();
-        S3fsSignals(const S3fsSignals&) = delete;
-        S3fsSignals(S3fsSignals&&) = delete;
-        S3fsSignals& operator=(const S3fsSignals&) = delete;
-        S3fsSignals& operator=(S3fsSignals&&) = delete;
 
         bool InitUsr1Handler();
         bool DestroyUsr1Handler();
@@ -61,6 +57,11 @@ class S3fsSignals
 
     public:
         ~S3fsSignals();
+        S3fsSignals(const S3fsSignals&) = delete;
+        S3fsSignals(S3fsSignals&&) = delete;
+        S3fsSignals& operator=(const S3fsSignals&) = delete;
+        S3fsSignals& operator=(S3fsSignals&&) = delete;
+
         static bool Initialize();
         static bool Destroy();
 

--- a/src/threadpoolman.h
+++ b/src/threadpoolman.h
@@ -76,10 +76,6 @@ class ThreadPoolMan
 
         explicit ThreadPoolMan(int count = 1);
         ~ThreadPoolMan();
-        ThreadPoolMan(const ThreadPoolMan&) = delete;
-        ThreadPoolMan(ThreadPoolMan&&) = delete;
-        ThreadPoolMan& operator=(const ThreadPoolMan&) = delete;
-        ThreadPoolMan& operator=(ThreadPoolMan&&) = delete;
 
         bool IsExit() const;
         void SetExitFlag(bool exit_flag);
@@ -89,6 +85,11 @@ class ThreadPoolMan
         void SetInstruction(const thpoolman_param& pparam);
 
     public:
+        ThreadPoolMan(const ThreadPoolMan&) = delete;
+        ThreadPoolMan(ThreadPoolMan&&) = delete;
+        ThreadPoolMan& operator=(const ThreadPoolMan&) = delete;
+        ThreadPoolMan& operator=(ThreadPoolMan&&) = delete;
+
         static bool Initialize(int count);
         static void Destroy();
         static bool Instruct(const thpoolman_param& pparam);


### PR DESCRIPTION
Deleting them better conveys the intent.