### PR TITLE
Remove unused headers found by clang-tidy

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -21,10 +21,10 @@
 #ifndef S3FS_COMMON_H_
 #define S3FS_COMMON_H_
 
+#include <string>
 #include <sys/types.h>
 
 #include "../config.h"
-#include "types.h"
 
 //-------------------------------------------------------------------
 // Global variables

--- a/src/fdcache_pseudofd.cpp
+++ b/src/fdcache_pseudofd.cpp
@@ -22,7 +22,6 @@
 #include <cstdlib>
 #include <vector>
 
-#include "s3fs_logger.h"
 #include "fdcache_pseudofd.h"
 
 //------------------------------------------------

--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -21,7 +21,6 @@
 #include <ctime>
 #include <unistd.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 
 #include "common.h"
 #include "metaheader.h"

--- a/src/mpu_util.cpp
+++ b/src/mpu_util.cpp
@@ -21,7 +21,6 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include "s3fs.h"
 #include "s3fs_logger.h"
 #include "mpu_util.h"
 #include "curl.h"

--- a/src/openssl_auth.cpp
+++ b/src/openssl_auth.cpp
@@ -32,10 +32,8 @@
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/md5.h>
-#include <openssl/sha.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>
-#include <string>
 
 #include "s3fs_auth.h"
 #include "s3fs_logger.h"

--- a/src/s3fs_cred.cpp
+++ b/src/s3fs_cred.cpp
@@ -22,7 +22,6 @@
 #include <unistd.h>
 #include <pwd.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <dlfcn.h>
 #include <fstream>
 #include <sstream>

--- a/src/s3fs_logger.cpp
+++ b/src/s3fs_logger.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <strings.h>
 
 #include "common.h"
 #include "s3fs_logger.h"

--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -24,7 +24,6 @@
 #include <mutex>
 
 #include "common.h"
-#include "s3fs.h"
 #include "s3fs_logger.h"
 #include "s3fs_xml.h"
 #include "s3fs_util.h"

--- a/src/threadpoolman.cpp
+++ b/src/threadpoolman.cpp
@@ -19,7 +19,6 @@
  */
 
 #include <cerrno>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 


### PR DESCRIPTION
Found via misc-include-cleaner but this requires more work.