### PR TITLE
[Improvement #2490] Add GUARDED_BY to FdEntity and fix locking

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1502,13 +1502,14 @@ static int rename_object(const char* from, const char* to, bool update_ctime)
                 ent->SetAtime(atime);
             }
         }
-
-        // copy
-        if(0 != (result = put_headers(to, meta, true, /* use_st_size= */ false))){
-            return result;
-        }
     }
 
+    // copy
+    if(0 != (result = put_headers(to, meta, true, /* use_st_size= */ false))){
+        return result;
+    }
+
+    // rename
     FdManager::get()->Rename(from, to);
 
     // Remove file
@@ -1562,7 +1563,6 @@ static int rename_object_nocopy(const char* from, const char* to, bool update_ct
             return result;
         }
     }
-
     FdManager::get()->Rename(from, to);
 
     // Remove file


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2490

### Details
There were too many requests for fixes in PR #2490, so I created a PR based on #2490.

The biggest difference is that the RowFlushHasLock() (and FlushHasLock()) methods are reentrant, so in order to maintain a strict locking state, it is necessary to separate the functions.
For other details, please see the comments in PR #2490.

