### PR TITLE
Wrap `CURL*` in a `std::unique_ptr`

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -76,6 +76,7 @@ struct curlprogress {
     double dl_progress;
     double ul_progress;
 };
+typedef std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> CurlUniquePtr;
 
 //----------------------------------------------
 // class S3fsCurl
@@ -173,7 +174,7 @@ class S3fsCurl
         static long             ipresolve_type;    // this value is a libcurl symbol.
 
         // variables
-        CURL*                hCurl;
+        CurlUniquePtr        hCurl = {nullptr, curl_easy_cleanup};
         REQTYPE              type;                 // type of request
         std::string          path;                 // target object path
         std::string          base_path;            // base path (for multi curl head request)
@@ -256,7 +257,7 @@ class S3fsCurl
         static bool LoadEnvSseCKeys();
         static bool LoadEnvSseKmsid();
         static bool PushbackSseKeys(const std::string& onekey);
-        static bool AddUserAgent(CURL* hCurl);
+        static bool AddUserAgent(const CurlUniquePtr& hCurl);
 
         static int CurlDebugFunc(const CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr);
         static int CurlDebugBodyInFunc(const CURL* hcurl, curl_infotype type, char* data, size_t size, void* userptr);
@@ -391,7 +392,6 @@ class S3fsCurl
         int MultipartRenameRequest(const char* from, const char* to, headers_t& meta, off_t size);
 
         // methods(variables)
-        CURL* GetCurlHandle() const { return hCurl; }
         const std::string& GetPath() const { return path; }
         const std::string& GetBasePath() const { return base_path; }
         const std::string& GetSpecialSavedPath() const { return saved_path; }

--- a/src/curl_handlerpool.h
+++ b/src/curl_handlerpool.h
@@ -24,12 +24,13 @@
 #include <cassert>
 #include <curl/curl.h>
 #include <list>
+#include <memory>
 #include <mutex>
 
 //----------------------------------------------
 // Typedefs
 //----------------------------------------------
-typedef std::list<CURL*>            hcurllist_t;
+typedef std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> CurlUniquePtr;
 
 //----------------------------------------------
 // class CurlHandlerPool
@@ -49,14 +50,14 @@ class CurlHandlerPool
         bool Init();
         bool Destroy();
 
-        CURL* GetHandler(bool only_pool);
-        void ReturnHandler(CURL* hCurl, bool restore_pool);
+        CurlUniquePtr GetHandler(bool only_pool);
+        void ReturnHandler(CurlUniquePtr&& hCurl, bool restore_pool);
         void ResetHandler(CURL* hCurl);
 
     private:
         int             mMaxHandlers;
         std::mutex      mLock;
-        hcurllist_t     mPool;
+        std::list<CurlUniquePtr> mPool;
 };
 
 #endif // S3FS_CURL_HANDLERPOOL_H_


### PR DESCRIPTION
This is safer and clarifies the ownership of pointers.