### PR TITLE
Continued Github Actions(CI) execution after CentOS 7 EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           - fedora:39
           - opensuse/leap:15
           - alpine:3.20
+          - centos:centos7
 
     container:
       image: ${{ matrix.container }}
@@ -71,6 +72,12 @@ jobs:
       # Installation special environment variables for debian and ubuntu.
       #
       DEBIAN_FRONTEND:  noninteractive
+      # [NOTE]
+      # actions/checkout uses node20, but can only run up to node16 on centos7.
+      # (glibc 2.27 or later is required to use node20)
+      # This is a temporary solution and will be removed when centos7 support is discontinued.
+      #
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: ${{ matrix.container == 'centos:centos7' && true || false }}
 
     steps:
       # [NOTE]
@@ -82,9 +89,8 @@ jobs:
           zypper install -y tar gzip
 
       # [NOTE]
-      # actions/checkout@v3 uses nodejs v16 and will be deprecated.
-      # However, @v4 does not work on centos7 depending on the glibc version,
-      # so we will continue to use @v3.
+      # Use actions/checkout@v4 except for centos7.
+      # On centos7, we need to run actions/checkout@v3 and configure it to use node16.
       #
       - name: Checkout source code(other than centos7)
         if: matrix.container != 'centos:centos7'

--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -160,6 +160,77 @@ elif [ "${CONTAINER_FULLNAME}" = "rockylinux:8" ]; then
     #
     SHELLCHECK_DIRECT_INSTALL=1
 
+elif [ "${CONTAINER_FULLNAME}" = "centos:centos7" ]; then
+    # [NOTE]
+    # CentOS 7 will reach EOL on June 30, 2024.
+    # After EOL, we will prepare the environment for building and testing using the Vault repository.
+    # The following process switches from the EOL repository to Vault.
+    #
+    grep -v '^enabled=' /etc/yum.repos.d/CentOS-Base.repo | sed -e 's|gpgcheck=1|gpgcheck=1\nenabled=0|g' > /tmp/CentOS-Base.repo
+    cat /tmp/CentOS-Base.repo > /etc/yum.repos.d/CentOS-Base.repo
+
+    {
+        #
+        # CentOS-Vault.repo does not have C7.9.2009 entry, so add it.
+        #
+        echo ''
+        echo '# C7.9.2009'
+        echo '[C7.9.2009-base]'
+        echo 'name=CentOS-7.9.2009 - Base'
+        echo "baseurl=http://vault.centos.org/7.9.2009/os/\$basearch/"
+        echo 'gpgcheck=1'
+        echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7'
+        echo 'enabled=1'
+        echo ''
+        echo '[C7.9.2009-updates]'
+        echo 'name=CentOS-7.9.2009 - Updates'
+        echo "baseurl=http://vault.centos.org/7.9.2009/updates/\$basearch/"
+        echo 'gpgcheck=1'
+        echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7'
+        echo 'enabled=1'
+        echo ''
+        echo '[C7.9.2009-extras]'
+        echo 'name=CentOS-7.9.2009 - Extras'
+        echo "baseurl=http://vault.centos.org/7.9.2009/extras/\$basearch/"
+        echo 'gpgcheck=1'
+        echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7'
+        echo 'enabled=1'
+        echo ''
+        echo '[C7.9.2009-centosplus]'
+        echo 'name=CentOS-7.9.2009 - CentOSPlus'
+        echo "baseurl=http://vault.centos.org/7.9.2009/centosplus/\$basearch/"
+        echo 'gpgcheck=1'
+        echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7'
+        echo 'enabled=1'
+        echo ''
+        echo '[C7.9.2009-fasttrack]'
+        echo 'name=CentOS-7.9.2009 - Fasttrack'
+        echo "baseurl=http://vault.centos.org/7.9.2009/fasttrack/\$basearch/"
+        echo 'gpgcheck=1'
+        echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7'
+        echo 'enabled=1'
+        echo ''
+    } >> /etc/yum.repos.d/CentOS-Base.repo
+
+    yum clean all
+    yum update -q -y
+    #
+    # Finish change package repo to Vault.
+    #
+
+    PACKAGE_MANAGER_BIN="yum"
+    PACKAGE_UPDATE_OPTIONS="update -y"
+    PACKAGE_INSTALL_OPTIONS="install -y"
+
+    # [NOTE]
+    # ShellCheck version(0.3.8) is too low to check.
+    # And in this version, it cannot be passed due to following error.
+    # "shellcheck: ./test/integration-test-main.sh: hGetContents: invalid argument (invalid byte sequence)"
+    #
+    INSTALL_PACKAGES="curl-devel fuse fuse-devel gcc libstdc++-devel llvm-toolset-7-clang-tools-extra gcc-c++ glibc-langpack-en java-11-openjdk-headless libxml2-devel mailcap git automake make openssl openssl-devel attr curl python3 epel-release unzip"
+    INSTALL_CHECKER_PKGS="cppcheck jq"
+    INSTALL_CHECKER_PKG_OPTIONS="--enablerepo=epel"
+
 elif [ "${CONTAINER_FULLNAME}" = "fedora:40" ]; then
     PACKAGE_MANAGER_BIN="dnf"
     PACKAGE_UPDATE_OPTIONS="update -y -qq"


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2469 #2485 #2496

### Details
In order to make release 1.95 the last supported package for CentOS 7, we are temporarily restoring CI execution(Github Actions) for CentOS 7.

This PR makes the following modifications (restorations):
- Using the Vault repository for CentOS 7
- Setting an environment variable to use nodejs16 when executing actions/checkout on CentOS 7

