### PR TITLE
Disable thread safety analysis on conditional locks

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -66,6 +66,9 @@ extern std::string    instance_name;
 #define REQUIRES(...) \
     THREAD_ANNOTATION_ATTRIBUTE(requires_capability(__VA_ARGS__))
 
+#define NO_THREAD_SAFETY_ANALYSIS \
+    THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis)
+
 #endif // S3FS_COMMON_H_
 
 /*

--- a/src/curl.h
+++ b/src/curl.h
@@ -227,8 +227,8 @@ class S3fsCurl
         static bool DestroyGlobalCurl();
         static bool InitShareCurl();
         static bool DestroyShareCurl();
-        static void LockCurlShare(CURL* handle, curl_lock_data nLockData, curl_lock_access laccess, void* useptr);
-        static void UnlockCurlShare(CURL* handle, curl_lock_data nLockData, void* useptr);
+        static void LockCurlShare(CURL* handle, curl_lock_data nLockData, curl_lock_access laccess, void* useptr) NO_THREAD_SAFETY_ANALYSIS;
+        static void UnlockCurlShare(CURL* handle, curl_lock_data nLockData, void* useptr) NO_THREAD_SAFETY_ANALYSIS;
         static bool InitCryptMutex();
         static bool DestroyCryptMutex();
         static int CurlProgress(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow);

--- a/src/openssl_auth.cpp
+++ b/src/openssl_auth.cpp
@@ -84,7 +84,7 @@ struct CRYPTO_dynlock_value
 
 static std::mutex* s3fs_crypt_mutex = nullptr;
 
-static void s3fs_crypt_mutex_lock(int mode, int pos, const char* file, int line) __attribute__ ((unused));
+static void s3fs_crypt_mutex_lock(int mode, int pos, const char* file, int line) __attribute__ ((unused)) NO_THREAD_SAFETY_ANALYSIS;
 static void s3fs_crypt_mutex_lock(int mode, int pos, const char* file, int line)
 {
     if(s3fs_crypt_mutex){
@@ -109,7 +109,7 @@ static struct CRYPTO_dynlock_value* s3fs_dyn_crypt_mutex(const char* file, int l
     return dyndata;
 }
 
-static void s3fs_dyn_crypt_mutex_lock(int mode, struct CRYPTO_dynlock_value* dyndata, const char* file, int line) __attribute__ ((unused));
+static void s3fs_dyn_crypt_mutex_lock(int mode, struct CRYPTO_dynlock_value* dyndata, const char* file, int line) __attribute__ ((unused)) NO_THREAD_SAFETY_ANALYSIS;
 static void s3fs_dyn_crypt_mutex_lock(int mode, struct CRYPTO_dynlock_value* dyndata, const char* file, int line)
 {
     if(dyndata){


### PR DESCRIPTION
Clang does not support this:

https://clang.llvm.org/docs/ThreadSafetyAnalysis.html#conditional-locks