### PR TITLE
Remove unneeded lock utility functions

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -5652,21 +5652,6 @@ int main(int argc, char* argv[])
         exit(EXIT_FAILURE);
     }
 
-    // mutex for xml
-    if(!init_parser_xml_lock()){
-        S3FS_PRN_EXIT("could not initialize mutex for xml parser.");
-        s3fs_destroy_global_ssl();
-        exit(EXIT_FAILURE);
-    }
-
-    // mutex for basename/dirname
-    if(!init_basename_lock()){
-        S3FS_PRN_EXIT("could not initialize mutex for basename/dirname.");
-        s3fs_destroy_global_ssl();
-        destroy_parser_xml_lock();
-        exit(EXIT_FAILURE);
-    }
-
     // init curl (without mime types)
     //
     // [NOTE]
@@ -5686,8 +5671,6 @@ int main(int argc, char* argv[])
     if(!S3fsCurl::InitS3fsCurl()){
         S3FS_PRN_EXIT("Could not initiate curl library.");
         s3fs_destroy_global_ssl();
-        destroy_parser_xml_lock();
-        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -5698,8 +5681,6 @@ int main(int argc, char* argv[])
     if(0 != fuse_opt_parse(&custom_args, nullptr, nullptr, my_fuse_opt_proc)){
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
-        destroy_parser_xml_lock();
-        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -5715,16 +5696,12 @@ int main(int argc, char* argv[])
         S3FS_PRN_EXIT("use_sse option could not be specified with storage class reduced_redundancy.");
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
-        destroy_parser_xml_lock();
-        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
     if(!S3fsCurl::FinalCheckSse()){
         S3FS_PRN_EXIT("something wrong about SSE options.");
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
-        destroy_parser_xml_lock();
-        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -5743,8 +5720,6 @@ int main(int argc, char* argv[])
     if(!ps3fscred->CheckAllParams()){
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
-        destroy_parser_xml_lock();
-        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -5758,8 +5733,6 @@ int main(int argc, char* argv[])
             show_usage();
             S3fsCurl::DestroyS3fsCurl();
             s3fs_destroy_global_ssl();
-            destroy_parser_xml_lock();
-            destroy_basename_lock();
             exit(EXIT_FAILURE);
         }
     }
@@ -5769,8 +5742,6 @@ int main(int argc, char* argv[])
         S3FS_PRN_EXIT("temporary directory doesn't exists.");
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
-        destroy_parser_xml_lock();
-        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -5779,8 +5750,6 @@ int main(int argc, char* argv[])
         S3FS_PRN_EXIT("could not allow cache directory permission, check permission of cache directories.");
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
-        destroy_parser_xml_lock();
-        destroy_basename_lock();
         exit(EXIT_FAILURE);
     }
 
@@ -5827,7 +5796,6 @@ int main(int argc, char* argv[])
                 S3FS_PRN_EXIT("Using https and a bucket name with periods is unsupported.");
                 S3fsCurl::DestroyS3fsCurl();
                 s3fs_destroy_global_ssl();
-                destroy_parser_xml_lock();
                 exit(EXIT_FAILURE);
             }
         }
@@ -5839,8 +5807,6 @@ int main(int argc, char* argv[])
 
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
-        destroy_parser_xml_lock();
-        destroy_basename_lock();
         exit(exitcode);
     }
 
@@ -5859,8 +5825,6 @@ int main(int argc, char* argv[])
         if(!FdManager::IsSafeDiskSpaceWithLog(nullptr, S3fsCurl::GetMultipartSize() * S3fsCurl::GetMaxParallelCount())){
             S3fsCurl::DestroyS3fsCurl();
             s3fs_destroy_global_ssl();
-            destroy_parser_xml_lock();
-            destroy_basename_lock();
             exit(EXIT_FAILURE);
         }
     }
@@ -5922,8 +5886,6 @@ int main(int argc, char* argv[])
         S3FS_PRN_WARN("Could not release curl library.");
     }
     s3fs_destroy_global_ssl();
-    destroy_parser_xml_lock();
-    destroy_basename_lock();
     delete pHasMpStat;
 
     // cleanup xml2

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -169,16 +169,6 @@ int is_uid_include_group(uid_t uid, gid_t gid)
 //
 static std::mutex basename_lock;
 
-bool init_basename_lock()
-{
-    return true;
-}
-
-bool destroy_basename_lock()
-{
-    return true;
-}
-
 std::string mydirname(const std::string& path)
 {
     const std::lock_guard<std::mutex> lock(basename_lock);

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -45,8 +45,6 @@ void init_sysconf_vars();
 std::string get_username(uid_t uid);
 int is_uid_include_group(uid_t uid, gid_t gid);
 
-bool init_basename_lock();
-bool destroy_basename_lock();
 std::string mydirname(const char* path);
 std::string mydirname(const std::string& path);
 std::string mybasename(const char* path);

--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -481,19 +481,6 @@ bool simple_parse_xml(const char* data, size_t len, const char* key, std::string
     return result;
 }
 
-//-------------------------------------------------------------------
-// Utility for lock
-//-------------------------------------------------------------------
-bool init_parser_xml_lock()
-{
-    return true;
-}
-
-bool destroy_parser_xml_lock()
-{
-    return true;
-}
-
 /*
 * Local variables:
 * tab-width: 4

--- a/src/s3fs_xml.h
+++ b/src/s3fs_xml.h
@@ -47,9 +47,6 @@ bool get_incomp_mpu_list(xmlDocPtr doc, incomp_mpu_list_t& list);
 
 bool simple_parse_xml(const char* data, size_t len, const char* key, std::string& value);
 
-bool init_parser_xml_lock();
-bool destroy_parser_xml_lock();
-
 #endif // S3FS_S3FS_XML_H_
 
 /*


### PR DESCRIPTION
`std::mutex` RAII removes the need for these.