### PR TITLE
Checked and fixed the internal data lock of PseudoFdInfo class

### DIFF
--- a/src/fdcache_fdinfo.h
+++ b/src/fdcache_fdinfo.h
@@ -81,10 +81,11 @@ class PseudoFdInfo
         bool ResetUploadInfo() REQUIRES(upload_list_lock);
         bool RowInitialUploadInfo(const std::string& id, bool is_cancel_mp);
         bool CompleteInstruction(int result) REQUIRES(upload_list_lock);
-        bool ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy) REQUIRES(upload_list_lock);
+        bool ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy);
         bool InsertUploadPart(off_t start, off_t size, int part_num, bool is_copy, etagpair** ppetag) REQUIRES(upload_list_lock);
         bool CancelAllThreads();
         bool ExtractUploadPartsFromUntreatedArea(const off_t& untreated_start, const off_t& untreated_size, mp_part_list_t& to_upload_list, filepart_list_t& cancel_upload_list, off_t max_mp_size);
+        bool IsUploadingHasLock() const REQUIRES(upload_list_lock);
 
     public:
         explicit PseudoFdInfo(int fd = -1, int open_flags = 0);
@@ -104,7 +105,7 @@ class PseudoFdInfo
         bool ClearUploadInfo(bool is_cancel_mp = false);
         bool InitialUploadInfo(const std::string& id){ return RowInitialUploadInfo(id, true); }
 
-        bool IsUploading() const { return !upload_id.empty(); }
+        bool IsUploading() const;
         bool GetUploadId(std::string& id) const;
         bool GetEtaglist(etaglist_t& list) const;
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2487

### Details
Improved locking about upload_id variable in PseudoFdInfo class(`fdcache_fdinfo.[cpp|h]`).