### PR TITLE
s3 signv4 support pefixed s3 hosts

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -233,6 +233,8 @@ class S3fsCurl
         static bool InitCryptMutex();
         static bool DestroyCryptMutex();
         static int CurlProgress(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow);
+        static std::string extractURI(const std::string& url);
+
 
         static bool LocateBundle();
         static size_t HeaderCallback(void *data, size_t blockSize, size_t numBlocks, void *userPtr);


### PR DESCRIPTION
<!-- --------------------------------------------------------------------------
 Please describe the purpose of the pull request(such as resolving the issue)
 and what the fix/update is.
--------------------------------------------------------------------------- -->

### Relevant Issue (if applicable)
<!-- If there are Issues related to this PullRequest, please list it. -->
When trying to connect to a compatible S3 server that is serving the S3 API under a URI prefix, ex: 

```
https://storage.example/s3
```

`s3fs` fails to compute the SignV4; specifically on capturing the URI of the s3host.

### Details
<!-- Please describe the details of PullRequest. -->
This PR will instead use the prefix (if any) when calculating the SignV4 uri; enabling support for custom S3 providers served on a URI.

If no prefix is given in the custom `url`, the current behaviour of using "/" is maintained.

