### PR TITLE
Fixed hardlink test for macos

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -784,18 +784,11 @@ function test_hardlink {
     echo foo > "${TEST_TEXT_FILE}"
 
     (
-        if ! uname | grep -q Darwin; then
-            set +o pipefail
-            ln "${TEST_TEXT_FILE}" "${ALT_TEST_TEXT_FILE}" 2>&1 | grep -q -e 'Operation not supported' -e 'Not supported'
-        else
-            # [macos] fuse-t
-            # Not error return code, and no stderr
-            #
-            ln "${TEST_TEXT_FILE}" "${ALT_TEST_TEXT_FILE}"
-            if stat "${ALT_TEST_TEXT_FILE}" >/dev/null 2>&1; then
-                exit 1
-            fi
-        fi
+        # [NOTE]
+        # macos-fuse-t returns 'Input/output error'
+        #
+        set +o pipefail
+        ln "${TEST_TEXT_FILE}" "${ALT_TEST_TEXT_FILE}" 2>&1 | grep -q -e 'Operation not supported' -e 'Not supported' -e 'Input/output error'
     )
 
     rm_test_file


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2418

### Details
Until recently, hardlink on macos-fuse-t was not implemented by s3fs and resulted in an error, but the error output was empty.
When I noticed currently, it was outputting `"Input/output error"`.
This caused `test_hardlink` execution(which had a special branch for macos-fuse-t) to fail, so I fixed it.

Note, this error output may change in the future, but I will check again if it does.
(s3fs is returning an ENOTSUP error, and "Input/output error" seems inappropriate as the message.)

Although the `test_hardlink` test was fixed, other tests still fail, so the macos tests do not pass overall.