### PR TITLE
Log entire line when curldbg lacks a newline

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1920,6 +1920,10 @@ int S3fsCurl::RawCurlDebugFunc(const CURL* hcurl, curl_infotype type, char* data
                 int newline = 0;
                 if (eol == nullptr) {
                     eol = reinterpret_cast<char*>(memchr(p, '\r', remaining));
+                    if (eol == nullptr) {
+                        // No newlines, just emit entire line.
+                        eol = p + remaining;
+                    }
                 } else {
                     if (eol > p && *(eol - 1) == '\r') {
                         newline++;


### PR DESCRIPTION
Previously `-o curldbg=body` would read uninitialized memory.

<!-- --------------------------------------------------------------------------
 Please describe the purpose of the pull request(such as resolving the issue)
 and what the fix/update is.
--------------------------------------------------------------------------- -->

### Relevant Issue (if applicable)
<!-- If there are Issues related to this PullRequest, please list it. -->

### Details
<!-- Please describe the details of PullRequest. -->

