### PR TITLE
Fixed miss-return code in S3fsCurl::RequestPerform

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2572,7 +2572,8 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
         }
 
         if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_HTTPHEADER, requestHeaders)){
-            return false;
+            S3FS_PRN_ERR("Failed to call curl_easy_setopt, returned NOT CURLE_OK.");
+            return -EIO;
         }
 
         // Requests


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
A simple coding mistake inside S3fsCurl::RequestPerform has been fixed.
_(It's a mystery why such a simple mistake still exists, but we'll be more careful in the future. I think it probably wasn't detected because this error didn't occur.)_