### PR TITLE
Enable readability-implicit-bool-conversion

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -71,7 +71,6 @@ Checks: '
     -readability-function-cognitive-complexity,
     -readability-function-size,
     -readability-identifier-length,
-    -readability-implicit-bool-conversion,
     -readability-inconsistent-declaration-parameter-name,
     -readability-isolate-declaration,
     -readability-magic-numbers,
@@ -81,3 +80,6 @@ Checks: '
     -readability-redundant-declaration,
     -readability-simplify-boolean-expr,
     -readability-suspicious-call-argument'
+CheckOptions:
+    readability-implicit-bool-conversion.AllowIntegerConditions: 'true'
+    readability-implicit-bool-conversion.AllowPointerConditions: 'true'

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3122,7 +3122,7 @@ int S3fsCurl::GetIAMv2ApiToken(const char* token_url, int token_ttl, const char*
         return -EIO;
     }
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_INFILESIZE, 0)){
-        return false;
+        return -EIO;
     }
     if(!S3fsCurl::AddUserAgent(hCurl)){                            // put User-Agent
         return -EIO;
@@ -4280,8 +4280,9 @@ int S3fsCurl::UploadMultipartPostRequest(const char* tpath, int part_num, const 
 
     // request
     if(0 == (result = RequestPerform())){
-        // UploadMultipartPostComplete returns true on success -> convert to 0
-        result = !UploadMultipartPostComplete();
+        if(!UploadMultipartPostComplete()){
+            result = -EIO;
+        }
     }
 
     // closing

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -279,7 +279,7 @@ static bool IS_RMTYPEDIR(dirtype type)
 static bool IS_CREATE_MP_STAT(const char* path)
 {
     // [NOTE] has_mp_stat is set in get_object_attribute()
-    return (path && 0 == strcmp(path, "/") && !has_mp_stat);
+    return (path != nullptr && 0 == strcmp(path, "/") && !has_mp_stat);
 }
 
 static bool is_special_name_folder_object(const char* path)

--- a/src/s3fs_cred.cpp
+++ b/src/s3fs_cred.cpp
@@ -241,9 +241,9 @@ bool S3fsCred::SetAccessKey(const char* AccessKeyId, const char* SecretAccessKey
 
 bool S3fsCred::SetAccessKeyWithSessionToken(const char* AccessKeyId, const char* SecretAccessKey, const char * SessionToken)
 {
-    bool access_key_is_empty        = !AccessKeyId     || '\0' == AccessKeyId[0];
-    bool secret_access_key_is_empty = !SecretAccessKey || '\0' == SecretAccessKey[0];
-    bool session_token_is_empty     = !SessionToken    || '\0' == SessionToken[0];
+    bool access_key_is_empty        = AccessKeyId == nullptr     || '\0' == AccessKeyId[0];
+    bool secret_access_key_is_empty = SecretAccessKey == nullptr || '\0' == SecretAccessKey[0];
+    bool session_token_is_empty     = SessionToken == nullptr    || '\0' == SessionToken[0];
 
     if((!is_ibm_iam_auth && access_key_is_empty) || secret_access_key_is_empty || session_token_is_empty){
         return false;


### PR DESCRIPTION
This fixes one real error, one misreported `EPERM`, and some false positives.  References #2529.