### PR TITLE
fix NoCacheLoadAndPost data corruption

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1560,6 +1560,14 @@ int FdEntity::RowFlushMultipart(PseudoFdInfo* pseudo_obj, const char* tpath)
             S3FS_PRN_ERR("failed to complete(finish) multipart post for file(physical_fd=%d).", physical_fd);
             return result;
         }
+
+        struct stat st {};
+        if(GetStatsHasLock(st)){
+            size_orgmeta = st.st_size;
+        } else {
+            S3FS_PRN_ERR("fstat is failed by errno(%d), but continue...", errno);
+        }
+
         // truncate file to zero
         if(-1 == ftruncate(physical_fd, 0)){
             // So the file has already been removed, skip error.
@@ -1687,6 +1695,14 @@ int FdEntity::RowFlushMixMultipart(PseudoFdInfo* pseudo_obj, const char* tpath)
             S3FS_PRN_ERR("failed to complete(finish) multipart post for file(physical_fd=%d).", physical_fd);
             return result;
         }
+
+        struct stat st {};
+        if(GetStatsHasLock(st)){
+            size_orgmeta = st.st_size;
+        } else {
+            S3FS_PRN_ERR("fstat is failed by errno(%d), but continue...", errno);
+        }
+        
         // truncate file to zero
         if(-1 == ftruncate(physical_fd, 0)){
             // So the file has already been removed, skip error.


### PR DESCRIPTION
The size_orgmeta was not updated correctly in cases of insufficient cache, which resulted in the previously uploaded data not being loaded correctly when re-entering the NoCacheLoadAndPost process

<!-- --------------------------------------------------------------------------
 Please describe the purpose of the pull request(such as resolving the issue)
 and what the fix/update is.
--------------------------------------------------------------------------- -->
### Details
<!-- Please describe the details of PullRequest. -->
https://github.com/s3fs-fuse/s3fs-fuse/blob/df5364d7588ea5758706b928f6bd205191a92120/src/fdcache_entity.cpp#L1149-L1159
