### PR TITLE
Modified and bypassed test_multipart_mix on MacOS with nocopyapi

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -2758,7 +2758,19 @@ function add_all_tests {
     add_tests test_rename_before_close
     add_tests test_multipart_upload
     add_tests test_multipart_copy
-    add_tests test_multipart_mix
+
+    if ! uname | grep -q Darwin || ! s3fs_args | grep -q nocopyapi; then
+        # FIXME:
+        # If you specify the nocopyapi option with macos-fuse-t, the following error will
+        # occur when manipulating the xattr of the copied object:
+        #    "could not copy extended attributes to <file>: Result too large"
+        # As no solution has been found at this time, this test is bypassed on macos with
+        # nocopyapi.
+        # Please pay attention to future developments in macos-fuse-t.
+        #
+        add_tests test_multipart_mix
+    fi
+
     add_tests test_utimens_during_multipart
     add_tests test_special_characters
     add_tests test_hardlink


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2531 

### Details
This is a follow-up fix to #2531.

In MacOS testing, the `test_multipart_mix` test fails when the `nocopyapi` option is specified.
The error occurs in the `list`/`remove` operation to `xattr`, as shown below(one example), and the test fails:
```
s3fs: [INF] s3fs.cpp:s3fs_listxattr(3988): [path=/testrun-12125/big-file-s3fs-14543.txt][list=0x7fda31008200][size=16384]
s3fs: [INF] s3fs.cpp:s3fs_listxattr(3988): [path=/testrun-12125/big-file-s3fs-14543.txt-mix][list=0x7fda31008200][size=16384]
s3fs: [INF] s3fs.cpp:s3fs_removexattr(4054): [path=/testrun-12125/big-file-s3fs-14543.txt-mix][name=com.apple.FinderInfo][pid=0,uid=501,gid=20]
s3fs: [INF] s3fs.cpp:s3fs_listxattr(3988): [path=/testrun-12125/big-file-s3fs-14543.txt][list=0x7fda28868200][size=16384]
s3fs: [INF] s3fs.cpp:s3fs_listxattr(3988): [path=/testrun-12125/big-file-s3fs-14543.txt][list=0x7fda29017400][size=16384]
cp: big-file-s3fs-14543.txt: could not copy extended attributes to big-file-s3fs-14543.txt-mix: Result too large

```
We need to investigate the cause, but as of now, we have not been able to find a workaround, as with this PR, so we will create a PR to bypass it.


