### PR TITLE
Add missing `GUARDED_BY` to `fdcache_entity`

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -66,6 +66,9 @@ extern std::string    instance_name;
 #define REQUIRES(...) \
     THREAD_ANNOTATION_ATTRIBUTE(requires_capability(__VA_ARGS__))
 
+#define RETURN_CAPABILITY(...) \
+    THREAD_ANNOTATION_ATTRIBUTE(lock_returned(__VA_ARGS__))
+
 #define NO_THREAD_SAFETY_ANALYSIS \
     THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis)
 

--- a/src/fdcache_fdinfo.h
+++ b/src/fdcache_fdinfo.h
@@ -25,11 +25,11 @@
 #include <mutex>
 
 #include "common.h"
+#include "fdcache_entity.h"
 #include "psemaphore.h"
 #include "metaheader.h"
 #include "types.h"
 
-class FdEntity;
 class UntreatedParts;
 
 //------------------------------------------------
@@ -116,7 +116,7 @@ class PseudoFdInfo
         bool ParallelMultipartUploadAll(const char* path, const mp_part_list_t& to_upload_list, const mp_part_list_t& copy_list, int& result);
 
         int WaitAllThreadsExit();
-        ssize_t UploadBoundaryLastUntreatedArea(const char* path, headers_t& meta, FdEntity* pfdent);
+        ssize_t UploadBoundaryLastUntreatedArea(const char* path, headers_t& meta, FdEntity* pfdent) REQUIRES(pfdent->GetMutex());
         bool ExtractUploadPartsFromAllArea(UntreatedParts& untreated_list, mp_part_list_t& to_upload_list, mp_part_list_t& to_copy_list, mp_part_list_t& to_download_list, filepart_list_t& cancel_upload_list, bool& wait_upload_complete, off_t max_mp_size, off_t file_size, bool use_copy);
 };
 

--- a/src/sighandlers.cpp
+++ b/src/sighandlers.cpp
@@ -22,6 +22,7 @@
 #include <csignal>
 #include <thread>
 
+#include "psemaphore.h"
 #include "s3fs_logger.h"
 #include "sighandlers.h"
 #include "fdcache.h"


### PR DESCRIPTION
This requires a fake `GetMutex` for the lock checker to understand the control flow.  Also remove unneeded locking comments that annotation supersede.  Follows on to #2491.