### PR TITLE
Remove more raw pointers

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -131,7 +131,7 @@ class S3fsCurl
             std::mutex      ssl_session;
         } callback_locks;
         static bool             is_initglobal_done;
-        static CurlHandlerPool* sCurlPool;
+        static std::unique_ptr<CurlHandlerPool> sCurlPool;
         static int              sCurlPoolSize;
         static CURLSH*          hCurlShare;
         static bool             is_cert_check;

--- a/src/threadpoolman.cpp
+++ b/src/threadpoolman.cpp
@@ -30,7 +30,7 @@
 //------------------------------------------------
 // ThreadPoolMan class variables
 //------------------------------------------------
-ThreadPoolMan* ThreadPoolMan::singleton = nullptr;
+std::unique_ptr<ThreadPoolMan> ThreadPoolMan::singleton;
 
 //------------------------------------------------
 // ThreadPoolMan class methods
@@ -38,19 +38,16 @@ ThreadPoolMan* ThreadPoolMan::singleton = nullptr;
 bool ThreadPoolMan::Initialize(int count)
 {
     if(ThreadPoolMan::singleton){
-        S3FS_PRN_WARN("Already singleton for Thread Manager is existed, then re-create it.");
-        ThreadPoolMan::Destroy();
+        S3FS_PRN_CRIT("Already singleton for Thread Manager exists.");
+        abort();
     }
-    ThreadPoolMan::singleton = new ThreadPoolMan(count);
+    ThreadPoolMan::singleton.reset(new ThreadPoolMan(count));
     return true;
 }
 
 void ThreadPoolMan::Destroy()
 {
-    if(ThreadPoolMan::singleton){
-        delete ThreadPoolMan::singleton;
-        ThreadPoolMan::singleton = nullptr;
-    }
+    ThreadPoolMan::singleton.reset();
 }
 
 bool ThreadPoolMan::Instruct(const thpoolman_param& param)
@@ -119,7 +116,7 @@ ThreadPoolMan::ThreadPoolMan(int count) : is_exit(false), thpoolman_sem(0)
         abort();
     }
     if(ThreadPoolMan::singleton){
-        S3FS_PRN_CRIT("Already singleton for Thread Manager is existed.");
+        S3FS_PRN_CRIT("Already singleton for Thread Manager exists.");
         abort();
     }
 

--- a/src/threadpoolman.h
+++ b/src/threadpoolman.h
@@ -61,7 +61,7 @@ typedef std::list<thpoolman_param> thpoolman_params_t;
 class ThreadPoolMan
 {
     private:
-        static ThreadPoolMan* singleton;
+        static std::unique_ptr<ThreadPoolMan> singleton;
 
         std::atomic<bool>     is_exit;
         Semaphore             thpoolman_sem;
@@ -74,7 +74,6 @@ class ThreadPoolMan
         static void Worker(ThreadPoolMan* psingleton, std::promise<int> promise);
 
         explicit ThreadPoolMan(int count = 1);
-        ~ThreadPoolMan();
 
         bool IsExit() const;
         void SetExitFlag(bool exit_flag);
@@ -84,6 +83,7 @@ class ThreadPoolMan
         void SetInstruction(const thpoolman_param& pparam);
 
     public:
+        ~ThreadPoolMan();
         ThreadPoolMan(const ThreadPoolMan&) = delete;
         ThreadPoolMan(ThreadPoolMan&&) = delete;
         ThreadPoolMan& operator=(const ThreadPoolMan&) = delete;


### PR DESCRIPTION
Make destructor public so `std::unique_ptr` can call it.    Also restrict singleton creation to satisfy cppcheck.