### PR TITLE
Add missing utility header for `std::move`

### DIFF
--- a/src/addhead.cpp
+++ b/src/addhead.cpp
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <fstream>
 #include <strings.h>
+#include <utility>
 #include <vector>
 
 #include "s3fs.h"

--- a/src/addhead.h
+++ b/src/addhead.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <regex.h>
+#include <utility>
 #include <vector>
 
 #include "metaheader.h"

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -22,6 +22,7 @@
 #include <cerrno>
 #include <cstdlib>
 #include <sys/stat.h>
+#include <utility>
 #include <vector>
 
 #include "s3fs.h"

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -18,15 +18,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
+#include <fstream>
 #include <memory>
 #include <unistd.h>
-#include <fstream>
 #include <sstream>
-#include <algorithm>
+#include <utility>
 
 #include "common.h"
 #include "s3fs.h"

--- a/src/curl_handlerpool.cpp
+++ b/src/curl_handlerpool.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <cstdio>
+#include <utility>
 
 #include "s3fs_logger.h"
 #include "curl_handlerpool.h"

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -23,6 +23,7 @@
 #include <cerrno>
 #include <future>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "s3fs.h"

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -26,6 +26,7 @@
 #include <dirent.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
+#include <utility>
 
 #include "fdcache.h"
 #include "fdcache_stat.h"

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -24,8 +24,9 @@
 #include <climits>
 #include <cstring>
 #include <memory>
-#include <unistd.h>
 #include <sys/stat.h>
+#include <unistd.h>
+#include <utility>
 
 #include "common.h"
 #include "fdcache_entity.h"

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -28,6 +28,7 @@
 #include <mutex>
 #include <set>
 #include <unistd.h>
+#include <utility>
 #include <dirent.h>
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/src/s3objlist.h
+++ b/src/s3objlist.h
@@ -23,6 +23,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 //-------------------------------------------------------------------

--- a/src/sighandlers.cpp
+++ b/src/sighandlers.cpp
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <csignal>
 #include <thread>
+#include <utility>
 
 #include "psemaphore.h"
 #include "s3fs_logger.h"

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -23,8 +23,8 @@
 #include <cerrno>
 #include <climits>
 #include <iomanip>
-
 #include <sstream>
+#include <utility>
 
 #include "s3fs_logger.h"
 #include "string_util.h"

--- a/src/threadpoolman.cpp
+++ b/src/threadpoolman.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <future>
 #include <thread>
+#include <utility>
 
 #include "s3fs_logger.h"
 #include "threadpoolman.h"

--- a/src/types.h
+++ b/src/types.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <map>
 #include <list>
+#include <utility>
 #include <vector>
 
 //


### PR DESCRIPTION
Found via clang-tidy.