### PR TITLE
Fixed a bug in clearing the queue accumulated during USR1 processing

### DIFF
--- a/src/sighandlers.cpp
+++ b/src/sighandlers.cpp
@@ -113,9 +113,7 @@ void S3fsSignals::CheckCacheWorker(Semaphore* pSem)
         }
 
         // do not allow request queuing
-        for(int value = pSem->get_value(); 0 < value; value = pSem->get_value()){
-            pSem->wait();
-        }
+        while(pSem->try_wait());
     }
 }
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
https://github.com/s3fs-fuse/s3fs-fuse/pull/2569/files#r1815840691

### Details
In SignalUSR1 processing, a bug has been fixed in the process of disabling request queuing caused by multiple interrupts.

