### PR TITLE
Add missing mutex header

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <cstdlib>
+#include <mutex>
 #include <string>
 #include <sys/stat.h>
 #include <utility>

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -25,6 +25,7 @@
 #include <ctime>
 #include <fstream>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <unistd.h>

--- a/src/curl_handlerpool.cpp
+++ b/src/curl_handlerpool.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <cstdio>
+#include <mutex>
 #include <utility>
 
 #include "s3fs_logger.h"

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <cerrno>
 #include <future>
+#include <mutex>
 #include <thread>
 #include <utility>
 #include <vector>

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -24,6 +24,7 @@
 #include <climits>
 #include <unistd.h>
 #include <dirent.h>
+#include <mutex>
 #include <string>
 #include <sys/stat.h>
 #include <sys/statvfs.h>

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -24,6 +24,7 @@
 #include <climits>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/fdcache_fdinfo.cpp
+++ b/src/fdcache_fdinfo.cpp
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/fdcache_pseudofd.cpp
+++ b/src/fdcache_pseudofd.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <mutex>
 #include <vector>
 
 #include "fdcache_pseudofd.h"

--- a/src/fdcache_untreated.cpp
+++ b/src/fdcache_untreated.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <cstdlib>
+#include <mutex>
 
 #include "s3fs_logger.h"
 #include "fdcache_untreated.h"

--- a/src/s3fs_cred.cpp
+++ b/src/s3fs_cred.cpp
@@ -24,6 +24,7 @@
 #include <sys/stat.h>
 #include <dlfcn.h>
 #include <fstream>
+#include <mutex>
 #include <sstream>
 #include <string>
 

--- a/src/threadpoolman.cpp
+++ b/src/threadpoolman.cpp
@@ -22,6 +22,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <future>
+#include <mutex>
 #include <thread>
 #include <utility>
 


### PR DESCRIPTION
Found via clang-tidy.