### PR TITLE
Use pass-by-value for peeloff

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -4406,7 +4406,7 @@ bool S3fsCurl::CopyMultipartPostComplete()
 {
     std::string etag;
     partdata.uploaded = simple_parse_xml(bodydata.c_str(), bodydata.size(), "ETag", etag);
-    partdata.petag->etag = peeloff(etag);
+    partdata.petag->etag = peeloff(std::move(etag));
 
     bodydata.clear();
     headdata.clear();

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -125,12 +125,14 @@ std::string trim(std::string s, const char *t /* = SPACES */)
     return trim_left(trim_right(std::move(s), t), t);
 }
 
-std::string peeloff(const std::string& s)
+std::string peeloff(std::string s)
 {
     if(s.size() < 2 || *s.cbegin() != '"' || *s.rbegin() != '"'){
         return s;
     }
-    return s.substr(1, s.size() - 2);
+    s.erase(s.size() - 1);
+    s.erase(0, 1);
+    return s;
 }
 
 //

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -80,7 +80,7 @@ std::string trim_left(std::string s, const char *t = SPACES);
 std::string trim_right(std::string s, const char *t = SPACES);
 std::string trim(std::string s, const char *t = SPACES);
 std::string lower(std::string s);
-std::string peeloff(const std::string& s);
+std::string peeloff(std::string s);
 
 //
 // Date string


### PR DESCRIPTION
This avoids copies when used with `std::move`.