### PR TITLE
Bypassed test_extended_attributes test on MacOS

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -2777,8 +2777,8 @@ function add_all_tests {
     add_tests test_symlink
     if ! uname | grep -q Darwin; then
         add_tests test_mknod
+        add_tests test_extended_attributes
     fi
-    add_tests test_extended_attributes
     add_tests test_mtime_file
 
     add_tests test_update_time_chmod


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2585

### Details
There are some unknown aspects of FUSE-T behavior, so we shuold bypass this `test_extended_attributes` test.
I plan to revert it to the original setting once we understand the cause and workaround.
For more information, see #2585.
