### PR TITLE
Make callbacks parameters type-safe

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1231,9 +1231,9 @@ bool S3fsCurl::SetIPResolveType(const char* value)
 // cppcheck-suppress unmatchedSuppression
 // cppcheck-suppress constParameter
 // cppcheck-suppress constParameterCallback
-bool S3fsCurl::UploadMultipartPostCallback(S3fsCurl* s3fscurl, void* param)
+bool S3fsCurl::UploadMultipartPostCallback(S3fsCurl* s3fscurl)
 {
-    if(!s3fscurl || param){     // this callback does not need a parameter
+    if(!s3fscurl){
         return false;
     }
 
@@ -1243,9 +1243,9 @@ bool S3fsCurl::UploadMultipartPostCallback(S3fsCurl* s3fscurl, void* param)
 // cppcheck-suppress unmatchedSuppression
 // cppcheck-suppress constParameter
 // cppcheck-suppress constParameterCallback
-bool S3fsCurl::MixMultipartPostCallback(S3fsCurl* s3fscurl, void* param)
+bool S3fsCurl::MixMultipartPostCallback(S3fsCurl* s3fscurl)
 {
-    if(!s3fscurl || param){     // this callback does not need a parameter
+    if(!s3fscurl){
         return false;
     }
 
@@ -4385,9 +4385,9 @@ bool S3fsCurl::UploadMultipartPostComplete()
 // cppcheck-suppress unmatchedSuppression
 // cppcheck-suppress constParameter
 // cppcheck-suppress constParameterCallback
-bool S3fsCurl::CopyMultipartPostCallback(S3fsCurl* s3fscurl, void* param)
+bool S3fsCurl::CopyMultipartPostCallback(S3fsCurl* s3fscurl)
 {
-    if(!s3fscurl || param){     // this callback does not need a parameter
+    if(!s3fscurl){
         return false;
     }
 

--- a/src/curl.h
+++ b/src/curl.h
@@ -244,9 +244,9 @@ class S3fsCurl
         static size_t UploadReadCallback(void *ptr, size_t size, size_t nmemb, void *userp);
         static size_t DownloadWriteCallback(void* ptr, size_t size, size_t nmemb, void* userp);
 
-        static bool UploadMultipartPostCallback(S3fsCurl* s3fscurl, void* param);
-        static bool CopyMultipartPostCallback(S3fsCurl* s3fscurl, void* param);
-        static bool MixMultipartPostCallback(S3fsCurl* s3fscurl, void* param);
+        static bool UploadMultipartPostCallback(S3fsCurl* s3fscurl);
+        static bool CopyMultipartPostCallback(S3fsCurl* s3fscurl);
+        static bool MixMultipartPostCallback(S3fsCurl* s3fscurl);
         static std::unique_ptr<S3fsCurl> UploadMultipartPostRetryCallback(S3fsCurl* s3fscurl);
         static std::unique_ptr<S3fsCurl> CopyMultipartPostRetryCallback(S3fsCurl* s3fscurl);
         static std::unique_ptr<S3fsCurl> MixMultipartPostRetryCallback(S3fsCurl* s3fscurl);

--- a/src/curl_multi.cpp
+++ b/src/curl_multi.cpp
@@ -36,7 +36,7 @@
 //-------------------------------------------------------------------
 // Class S3fsMultiCurl 
 //-------------------------------------------------------------------
-S3fsMultiCurl::S3fsMultiCurl(int maxParallelism, bool not_abort) : maxParallelism(maxParallelism), not_abort(not_abort), SuccessCallback(nullptr), NotFoundCallback(nullptr), RetryCallback(nullptr), pSuccessCallbackParam(nullptr), pNotFoundCallbackParam(nullptr)
+S3fsMultiCurl::S3fsMultiCurl(int maxParallelism, bool not_abort) : maxParallelism(maxParallelism), not_abort(not_abort), SuccessCallback(nullptr), NotFoundCallback(nullptr), RetryCallback(nullptr)
 {
 }
 
@@ -69,14 +69,14 @@ bool S3fsMultiCurl::ClearEx(bool is_all)
     return true;
 }
 
-S3fsMultiSuccessCallback S3fsMultiCurl::SetSuccessCallback(S3fsMultiSuccessCallback function)
+S3fsMultiSuccessCallback S3fsMultiCurl::SetSuccessCallback(const S3fsMultiSuccessCallback &function)
 {
     S3fsMultiSuccessCallback old = SuccessCallback;
     SuccessCallback = function;
     return old;
 }
 
-S3fsMultiNotFoundCallback S3fsMultiCurl::SetNotFoundCallback(S3fsMultiNotFoundCallback function)
+S3fsMultiNotFoundCallback S3fsMultiCurl::SetNotFoundCallback(const S3fsMultiNotFoundCallback &function)
 {
     S3fsMultiNotFoundCallback old = NotFoundCallback;
     NotFoundCallback = function;
@@ -87,20 +87,6 @@ S3fsMultiRetryCallback S3fsMultiCurl::SetRetryCallback(S3fsMultiRetryCallback fu
 {
     S3fsMultiRetryCallback old = RetryCallback;
     RetryCallback = function;
-    return old;
-}
-
-void* S3fsMultiCurl::SetSuccessCallbackParam(void* param)
-{
-    void* old = pSuccessCallbackParam;
-    pSuccessCallbackParam = param;
-    return old;
-}
-
-void* S3fsMultiCurl::SetNotFoundCallbackParam(void* param)
-{
-    void* old = pNotFoundCallbackParam;
-    pNotFoundCallbackParam = param;
     return old;
 }
 
@@ -212,7 +198,7 @@ int S3fsMultiCurl::MultiRead()
                 // add into stat cache
                 // cppcheck-suppress unmatchedSuppression
                 // cppcheck-suppress knownPointerToBool
-                if(SuccessCallback && !SuccessCallback(s3fscurl.get(), pSuccessCallbackParam)){
+                if(SuccessCallback && !SuccessCallback(s3fscurl.get())){
                     S3FS_PRN_WARN("error from success callback function(%s).", s3fscurl->url.c_str());
                 }
             }else if(400 == responseCode){
@@ -228,7 +214,7 @@ int S3fsMultiCurl::MultiRead()
 				// Call callback function
                 // cppcheck-suppress unmatchedSuppression
                 // cppcheck-suppress knownPointerToBool
-                if(NotFoundCallback && !NotFoundCallback(s3fscurl.get(), pNotFoundCallbackParam)){
+                if(NotFoundCallback && !NotFoundCallback(s3fscurl.get())){
                     S3FS_PRN_WARN("error from not found callback function(%s).", s3fscurl->url.c_str());
                 }
             }else if(500 == responseCode){

--- a/src/curl_multi.h
+++ b/src/curl_multi.h
@@ -35,8 +35,8 @@
 class S3fsCurl;
 
 typedef std::vector<std::unique_ptr<S3fsCurl>> s3fscurllist_t;
-typedef bool (*S3fsMultiSuccessCallback)(S3fsCurl* s3fscurl, void* param);  // callback for succeed multi request
-typedef bool (*S3fsMultiNotFoundCallback)(S3fsCurl* s3fscurl, void* param); // callback for succeed multi request
+typedef std::function<bool(S3fsCurl*)> S3fsMultiSuccessCallback;  // callback for succeed multi request
+typedef std::function<bool(S3fsCurl*)> S3fsMultiNotFoundCallback; // callback for succeed multi request
 typedef std::unique_ptr<S3fsCurl> (*S3fsMultiRetryCallback)(S3fsCurl* s3fscurl);  // callback for failure and retrying
 
 //----------------------------------------------
@@ -54,8 +54,6 @@ class S3fsMultiCurl
         S3fsMultiSuccessCallback   SuccessCallback;
         S3fsMultiNotFoundCallback  NotFoundCallback;
         S3fsMultiRetryCallback     RetryCallback;
-        void*                      pSuccessCallbackParam;
-        void*                      pNotFoundCallbackParam;
 
         std::mutex completed_tids_lock;
         std::vector<std::thread::id> completed_tids GUARDED_BY(completed_tids_lock);
@@ -77,11 +75,9 @@ class S3fsMultiCurl
 
         int GetMaxParallelism() const { return maxParallelism; }
 
-        S3fsMultiSuccessCallback SetSuccessCallback(S3fsMultiSuccessCallback function);
-        S3fsMultiNotFoundCallback SetNotFoundCallback(S3fsMultiNotFoundCallback function);
+        S3fsMultiSuccessCallback SetSuccessCallback(const S3fsMultiSuccessCallback &function);
+        S3fsMultiNotFoundCallback SetNotFoundCallback(const S3fsMultiNotFoundCallback &function);
         S3fsMultiRetryCallback SetRetryCallback(S3fsMultiRetryCallback function);
-        void* SetSuccessCallbackParam(void* param);
-        void* SetNotFoundCallbackParam(void* param);
         bool Clear() { return ClearEx(true); }
         bool SetS3fsCurlObject(std::unique_ptr<S3fsCurl> s3fscurl);
         int Request();


### PR DESCRIPTION
Instead of storing and passing void pointers, lambdas can capture additional parameters.