### PR TITLE
Call `std::get_time` instead of `strptime`

### DIFF
--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -254,7 +254,7 @@ time_t cvtIAMExpireStringToTime(const char* s)
     if(!s){
         return 0L;
     }
-    strptime(s, "%Y-%m-%dT%H:%M:%S", &tm);
+    s3fs_strptime(s, "%Y-%m-%dT%H:%M:%S", &tm);
     return timegm(&tm); // GMT
 }
 
@@ -264,7 +264,7 @@ time_t get_lastmodified(const char* s)
     if(!s){
         return -1;
     }
-    strptime(s, "%a, %d %b %Y %H:%M:%S %Z", &tm);
+    s3fs_strptime(s, "%a, %d %b %Y %H:%M:%S %Z", &tm);
     return timegm(&tm); // GMT
 }
 

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -49,23 +49,18 @@ std::string str(const struct timespec& value)
     return s.str();
 }
 
-#ifdef __MSYS__
-/*
- * Polyfill for strptime function
- *
- * This source code is from https://gist.github.com/jeremyfromearth/5694aa3a66714254752179ecf3c95582 .
- */
-char* strptime(const char* s, const char* f, struct tm* tm)
+// This source code is from https://gist.github.com/jeremyfromearth/5694aa3a66714254752179ecf3c95582 .
+const char* s3fs_strptime(const char* s, const char* f, struct tm* tm)
 {
     std::istringstream input(s);
+    // TODO: call to setlocale required?
     input.imbue(std::locale(setlocale(LC_ALL, nullptr)));
     input >> std::get_time(tm, f);
     if (input.fail()) {
         return nullptr;
     }
-    return (char*)(s + input.tellg());
+    return s + input.tellg();
 }
-#endif
 
 bool s3fs_strtoofft(off_t* value, const char* str, int base)
 {
@@ -303,7 +298,7 @@ bool get_unixtime_from_iso8601(const char* pdate, time_t& unixtime)
     }
 
     struct tm tm;
-    const char* prest = strptime(pdate, "%Y-%m-%dT%T", &tm);
+    const char* prest = s3fs_strptime(pdate, "%Y-%m-%dT%T", &tm);
     if(prest == pdate){
         // wrong format
         return false;

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -65,12 +65,10 @@ static inline const char* SAFESTRPTR(const char *strptr) { return strptr ? strpt
 // TODO: rename to to_string?
 std::string str(const struct timespec& value);
 
-#ifdef __MSYS__
 //
-// Polyfill for strptime function.
+// Cross-platform strptime
 //
-char* strptime(const char* s, const char* f, struct tm* tm);
-#endif
+const char* s3fs_strptime(const char* s, const char* f, struct tm* tm);
 //
 // Convert string to off_t.  Returns false on bad input.
 // Replacement for C++11 std::stoll.


### PR DESCRIPTION
This reduces the Windows-specific code.