### PR TITLE
Prefer C++-style casts over C-style casts

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,7 +37,6 @@ Checks: '
     -cppcoreguidelines-special-member-functions,
     -fuchsia-*,
     -google-build-using-namespace,
-    -google-readability-casting,
     -google-readability-function-size,
     -google-readability-todo,
     -google-runtime-int,

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -499,7 +499,7 @@ size_t S3fsCurl::UploadReadCallback(void* ptr, size_t size, size_t nmemb, void* 
         return 0;
     }
     // read size
-    ssize_t copysize = (size * nmemb) < (size_t)pCurl->partdata.size ? (size * nmemb) : (size_t)pCurl->partdata.size;
+    ssize_t copysize = (size * nmemb) < static_cast<size_t>(pCurl->partdata.size) ? (size * nmemb) : static_cast<size_t>(pCurl->partdata.size);
     ssize_t readbytes;
     ssize_t totalread;
     // read and set
@@ -537,7 +537,7 @@ size_t S3fsCurl::DownloadWriteCallback(void* ptr, size_t size, size_t nmemb, voi
     }
 
     // write size
-    ssize_t copysize = (size * nmemb) < (size_t)pCurl->partdata.size ? (size * nmemb) : (size_t)pCurl->partdata.size;
+    ssize_t copysize = (size * nmemb) < static_cast<size_t>(pCurl->partdata.size) ? (size * nmemb) : static_cast<size_t>(pCurl->partdata.size);
     ssize_t writebytes;
     ssize_t totalwrite;
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2039,10 +2039,10 @@ static int s3fs_chown(const char* _path, uid_t uid, gid_t gid)
         return result;
     }
 
-    if((uid_t)(-1) == uid){
+    if(static_cast<uid_t>(-1) == uid){
         uid = stbuf.st_uid;
     }
-    if((gid_t)(-1) == gid){
+    if(static_cast<gid_t>(-1) == gid){
         gid = stbuf.st_gid;
     }
     if(S_ISDIR(stbuf.st_mode)){
@@ -2161,10 +2161,10 @@ static int s3fs_chown_nocopy(const char* _path, uid_t uid, gid_t gid)
         return result;
     }
 
-    if((uid_t)(-1) == uid){
+    if(static_cast<uid_t>(-1) == uid){
         uid = stbuf.st_uid;
     }
-    if((gid_t)(-1) == gid){
+    if(static_cast<gid_t>(-1) == gid){
         gid = stbuf.st_gid;
     }
 
@@ -2749,7 +2749,7 @@ static int s3fs_open(const char* _path, struct fuse_file_info* fi)
     FdEntity*    ent;
     headers_t    meta;
 
-    if((unsigned int)fi->flags & O_TRUNC){
+    if(static_cast<unsigned int>(fi->flags) & O_TRUNC){
         if(0 != st.st_size){
             st.st_size = 0;
             needs_flush = true;

--- a/test/truncate_read_file.cc
+++ b/test/truncate_read_file.cc
@@ -51,7 +51,7 @@ int main(int argc, const char *argv[])
 
     // truncate
     if(0 != ftruncate(fd, size)){
-        fprintf(stderr, "[ERROR] Could not truncate file(%s) to %lld byte.\n", filepath, (long long)size);
+        fprintf(stderr, "[ERROR] Could not truncate file(%s) to %lld byte.\n", filepath, static_cast<long long>(size));
         close(fd);
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
The former are easier to identify.  Found via clang-tidy.