### PR TITLE
Refactored single type requests to use through ThreadPoolMan

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,6 +43,7 @@ s3fs_SOURCES = \
     string_util.cpp \
     s3fs_cred.cpp \
     s3fs_util.cpp \
+    s3fs_threadreqs.cpp \
     fdcache.cpp \
     fdcache_entity.cpp \
     fdcache_page.cpp \

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -80,6 +80,7 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
     private:
         static int FillFile(int fd, unsigned char byte, off_t size, off_t start);
         static ino_t GetInode(int fd);
+        static void* MultipartUploadThreadWorker(void* arg);          // ([TODO] This is a temporary method is moved when S3fsMultiCurl is deprecated.)
 
         void Clear();
         ino_t GetInode() const REQUIRES(FdEntity::fdent_data_lock);
@@ -89,9 +90,10 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
         bool IsUploading() REQUIRES(FdEntity::fdent_lock);
         bool SetAllStatus(bool is_loaded) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         bool SetAllStatusUnloaded() REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock) { return SetAllStatus(false); }
-        int NoCachePreMultipartPost(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
-        int NoCacheMultipartPost(PseudoFdInfo* pseudo_obj, int tgfd, off_t start, off_t size) REQUIRES(FdEntity::fdent_lock);
-        int NoCacheCompleteMultipartPost(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock);
+        int PreMultipartUploadRequest(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock, fdent_data_lock);
+        int NoCachePreMultipartUploadRequest(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        int NoCacheMultipartUploadRequest(PseudoFdInfo* pseudo_obj, int tgfd, off_t start, off_t size) REQUIRES(FdEntity::fdent_lock);
+        int NoCacheMultipartUploadComplete(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock);
         int RowFlushHasLock(int fd, const char* tpath, bool force_sync) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         int RowFlushNoMultipart(const PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         int RowFlushMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);

--- a/src/fdcache_fdinfo.h
+++ b/src/fdcache_fdinfo.h
@@ -34,24 +34,6 @@
 class UntreatedParts;
 
 //------------------------------------------------
-// Structure of parameters to pass to thread
-//------------------------------------------------
-class PseudoFdInfo;
-
-struct pseudofdinfo_thparam
-{
-    PseudoFdInfo* ppseudofdinfo = nullptr;
-    std::string   path;
-    std::string   upload_id;
-    int           upload_fd = -1;
-    off_t         start = 0;
-    off_t         size = 0;
-    bool          is_copy = false;
-    int           part_num = -1;
-    etagpair*     petag = nullptr;
-};
-
-//------------------------------------------------
 // Class PseudoFdInfo
 //------------------------------------------------
 class PseudoFdInfo
@@ -83,6 +65,7 @@ class PseudoFdInfo
         bool GetUploadInfo(std::string& id, int& fd) const;
         bool ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy);
         bool InsertUploadPart(off_t start, off_t size, int part_num, bool is_copy, etagpair** ppetag);
+        bool PreMultipartUploadRequest(const std::string& strpath, const headers_t& meta);
         bool CancelAllThreads();
         bool ExtractUploadPartsFromUntreatedArea(off_t untreated_start, off_t untreated_size, mp_part_list_t& to_upload_list, filepart_list_t& cancel_upload_list, off_t max_mp_size);
         bool IsUploadingHasLock() const REQUIRES(upload_list_lock);

--- a/src/mpu_util.cpp
+++ b/src/mpu_util.cpp
@@ -28,6 +28,7 @@
 #include "s3fs_xml.h"
 #include "s3fs_auth.h"
 #include "string_util.h"
+#include "s3fs_threadreqs.h"
 
 //-------------------------------------------------------------------
 // Global variables
@@ -68,7 +69,6 @@ static bool abort_incomp_mpu_list(const incomp_mpu_list_t& list, time_t abort_ti
     time_t now_time = time(nullptr);
 
     // do removing.
-    S3fsCurl s3fscurl;
     bool     result = true;
     for(auto iter = list.cbegin(); iter != list.cend(); ++iter){
         const char* tpath     = (*iter).key.c_str();
@@ -85,15 +85,12 @@ static bool abort_incomp_mpu_list(const incomp_mpu_list_t& list, time_t abort_ti
             }
         }
 
-        if(0 != s3fscurl.AbortMultipartUpload(tpath, upload_id)){
+        if(0 != abort_multipart_upload_request(std::string(tpath), upload_id)){
             S3FS_PRN_EXIT("Failed to remove %s multipart uploading object.", tpath);
             result = false;
         }else{
             printf("Succeed to remove %s multipart uploading object.\n", tpath);
         }
-
-        // reset(initialize) curl object
-        s3fscurl.DestroyCurlHandle();
     }
     return result;
 }

--- a/src/s3fs_cred.h
+++ b/src/s3fs_cred.h
@@ -115,14 +115,24 @@ class S3fsCred
 
         bool SetIsIBMIAMAuth(bool flag);
 
-        int SetIMDSVersion(int version) REQUIRES(S3fsCred::token_lock);
+        int SetIMDSVersionHasLock(int version) REQUIRES(S3fsCred::token_lock);
+        int SetIMDSVersion(int version)
+        {
+            const std::lock_guard<std::mutex> lock(token_lock);
+            return SetIMDSVersionHasLock(version);
+        }
         int GetIMDSVersion() const REQUIRES(S3fsCred::token_lock);
 
-        bool SetIAMv2APIToken(const std::string& token) REQUIRES(S3fsCred::token_lock);
+        bool SetIAMv2APITokenHasLock(const std::string& token) REQUIRES(S3fsCred::token_lock);
         const std::string& GetIAMv2APIToken() const REQUIRES(S3fsCred::token_lock);
 
         bool SetIAMRole(const char* role) REQUIRES(S3fsCred::token_lock);
-        const std::string& GetIAMRole() const REQUIRES(S3fsCred::token_lock);
+        const std::string& GetIAMRoleHasLock() const REQUIRES(S3fsCred::token_lock);
+        const std::string& GetIAMRole() const
+        {
+            const std::lock_guard<std::mutex> lock(token_lock);
+            return GetIAMRoleHasLock();
+        }
         bool IsSetIAMRole() const REQUIRES(S3fsCred::token_lock);
         size_t SetIAMFieldCount(size_t field_count);
         std::string SetIAMCredentialsURL(const char* url);
@@ -142,8 +152,8 @@ class S3fsCred
 
         bool GetIAMCredentialsURL(std::string& url, bool check_iam_role) REQUIRES(S3fsCred::token_lock);
         bool LoadIAMCredentials() REQUIRES(S3fsCred::token_lock);
-        bool SetIAMCredentials(const char* response) REQUIRES(S3fsCred::token_lock);
-        bool SetIAMRoleFromMetaData(const char* response) REQUIRES(S3fsCred::token_lock);
+        bool SetIAMCredentials(const char* response);
+        bool SetIAMRoleFromMetaData(const char* response);
 
         bool SetExtCredLib(const char* arg);
         bool IsSetExtCredLib() const;

--- a/src/s3fs_help.cpp
+++ b/src/s3fs_help.cpp
@@ -244,7 +244,7 @@ static constexpr char help_string[] =
     "\n"
     "   parallel_count (default=\"5\")\n"
     "      - number of parallel request for uploading big objects.\n"
-    "      s3fs uploads large object (over 20MB) by multipart post request, \n"
+    "      s3fs uploads large object (over 20MB) by multipart upload request, \n"
     "      and sends parallel requests.\n"
     "      This option limits parallel request count which s3fs requests \n"
     "      at once. It is necessary to set this value depending on a CPU \n"

--- a/src/s3fs_threadreqs.cpp
+++ b/src/s3fs_threadreqs.cpp
@@ -1,0 +1,591 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "common.h"
+#include "s3fs_threadreqs.h"
+#include "threadpoolman.h"
+#include "curl_util.h"
+#include "s3fs_logger.h"
+
+//-------------------------------------------------------------------
+// Thread Worker functions for MultiThread Request
+//-------------------------------------------------------------------
+//
+// Thread Worker function for head request
+//
+void* head_req_threadworker(void* arg)
+{
+    auto* pthparam = static_cast<head_req_thparam*>(arg);
+    if(!pthparam || !pthparam->pmeta){
+        return reinterpret_cast<void*>(-EIO);
+    }
+    S3FS_PRN_INFO3("Head Request [path=%s][pmeta=%p]", pthparam->path.c_str(), pthparam->pmeta);
+
+    S3fsCurl s3fscurl;
+    pthparam->result = s3fscurl.HeadRequest(pthparam->path.c_str(), *(pthparam->pmeta));
+
+    return reinterpret_cast<void*>(pthparam->result);
+}
+
+//
+// Thread Worker function for delete request
+//
+void* delete_req_threadworker(void* arg)
+{
+    auto* pthparam = static_cast<delete_req_thparam*>(arg);
+    if(!pthparam){
+        return reinterpret_cast<void*>(-EIO);
+    }
+    S3FS_PRN_INFO3("Delete Request [path=%s]", pthparam->path.c_str());
+
+    S3fsCurl s3fscurl;
+    pthparam->result = s3fscurl.DeleteRequest(pthparam->path.c_str());
+
+    return reinterpret_cast<void*>(pthparam->result);
+}
+
+//
+// Thread Worker function for put head request
+//
+void* put_head_req_threadworker(void* arg)
+{
+    auto* pthparam = static_cast<put_head_req_thparam*>(arg);
+    if(!pthparam){
+        return reinterpret_cast<void*>(-EIO);
+    }
+    S3FS_PRN_INFO3("Put Head Request [path=%s][meta count=%lu][is copy=%s]", pthparam->path.c_str(), pthparam->meta.size(), (pthparam->isCopy ? "true" : "false"));
+
+    S3fsCurl s3fscurl(true);
+    pthparam->result = s3fscurl.PutHeadRequest(pthparam->path.c_str(), pthparam->meta, pthparam->isCopy);
+
+    return reinterpret_cast<void*>(pthparam->result);
+}
+
+//
+// Thread Worker function for put request
+//
+void* put_req_threadworker(void* arg)
+{
+    auto* pthparam = static_cast<put_req_thparam*>(arg);
+    if(!pthparam){
+        return reinterpret_cast<void*>(-EIO);
+    }
+    S3FS_PRN_INFO3("Put Request [path=%s][meta count=%lu][fd=%d][use_ahbe=%s]", pthparam->path.c_str(), pthparam->meta.size(), pthparam->fd, (pthparam->ahbe ? "true" : "false"));
+
+    S3fsCurl s3fscurl(pthparam->ahbe);
+    pthparam->result = s3fscurl.PutRequest(pthparam->path.c_str(), pthparam->meta, pthparam->fd);
+
+    return reinterpret_cast<void*>(pthparam->result);
+}
+
+//
+// Thread Worker function for list bucket request
+//
+void* list_bucket_req_threadworker(void* arg)
+{
+    auto* pthparam = static_cast<list_bucket_req_thparam*>(arg);
+    if(!pthparam || !(pthparam->presponseBody)){
+        return reinterpret_cast<void*>(-EIO);
+    }
+    S3FS_PRN_INFO3("List Bucket Request [path=%s][query=%s]", pthparam->path.c_str(), pthparam->query.c_str());
+
+    S3fsCurl s3fscurl;
+    if(0 == (pthparam->result = s3fscurl.ListBucketRequest(pthparam->path.c_str(), pthparam->query.c_str()))){
+        *(pthparam->presponseBody) = s3fscurl.GetBodyData();
+    }
+    return reinterpret_cast<void*>(pthparam->result);
+}
+
+//
+// Thread Worker function for check service request
+//
+void* check_service_req_threadworker(void* arg)
+{
+    auto* pthparam = static_cast<check_service_req_thparam*>(arg);
+    if(!pthparam || !(pthparam->presponseCode) || !(pthparam->presponseBody)){
+        return reinterpret_cast<void*>(-EIO);
+    }
+    S3FS_PRN_INFO3("Check Service Request [path=%s][support compat dir=%s][force No SSE=%s]", pthparam->path.c_str(), (pthparam->support_compat_dir ? "true" : "false"), (pthparam->forceNoSSE ? "true" : "false"));
+
+    S3fsCurl s3fscurl;
+    if(0 == (pthparam->result = s3fscurl.CheckBucket(pthparam->path.c_str(), pthparam->support_compat_dir, pthparam->forceNoSSE))){
+        *(pthparam->presponseCode) = s3fscurl.GetLastResponseCode();
+        *(pthparam->presponseBody) = s3fscurl.GetBodyData();
+    }
+    return reinterpret_cast<void*>(pthparam->result);
+}
+
+//
+// Worker function for pre multipart upload request
+//
+void* pre_multipart_upload_req_threadworker(void* arg)
+{
+    auto* pthparam = static_cast<pre_multipart_upload_req_thparam*>(arg);
+    if(!pthparam){
+        return reinterpret_cast<void*>(-EIO);
+    }
+    S3FS_PRN_INFO3("Pre Multipart Upload Request [path=%s][meta count=%lu]", pthparam->path.c_str(), pthparam->meta.size());
+
+    S3fsCurl s3fscurl(true);
+    pthparam->result = s3fscurl.PreMultipartUploadRequest(pthparam->path.c_str(), pthparam->meta, pthparam->upload_id);
+
+    return reinterpret_cast<void*>(pthparam->result);
+}
+
+//
+// Worker function for complete multipart upload request
+//
+void* complete_multipart_upload_threadworker(void* arg)
+{
+    auto* pthparam = static_cast<complete_multipart_upload_req_thparam*>(arg);
+    if(!pthparam){
+        return reinterpret_cast<void*>(-EIO);
+    }
+    S3FS_PRN_INFO3("Complete Multipart Upload Request [path=%s][upload id=%s][etaglist=%lu]", pthparam->path.c_str(), pthparam->upload_id.c_str(), pthparam->etaglist.size());
+
+    S3fsCurl s3fscurl(true);
+    pthparam->result = s3fscurl.MultipartUploadComplete(pthparam->path.c_str(), pthparam->upload_id, pthparam->etaglist);
+
+    return reinterpret_cast<void*>(pthparam->result);
+}
+
+//
+// Worker function for abort multipart upload request
+//
+void* abort_multipart_upload_req_threadworker(void* arg)
+{
+    auto* pthparam = static_cast<abort_multipart_upload_req_thparam*>(arg);
+    if(!pthparam){
+        return reinterpret_cast<void*>(-EIO);
+    }
+    S3FS_PRN_INFO3("Abort Multipart Upload Request [path=%s][upload id=%s]", pthparam->path.c_str(), pthparam->upload_id.c_str());
+
+    S3fsCurl s3fscurl(true);
+    pthparam->result = s3fscurl.AbortMultipartUpload(pthparam->path.c_str(), pthparam->upload_id);
+
+    return reinterpret_cast<void*>(pthparam->result);
+}
+
+//
+// Thread Worker function for get object request
+//
+void* get_object_req_threadworker(void* arg)
+{
+    auto* pthparam = static_cast<get_object_req_thparam*>(arg);
+    if(!pthparam){
+        return reinterpret_cast<void*>(-EIO);
+    }
+    S3FS_PRN_INFO3("Get Object Request [path=%s][fd=%d][start=%lld][size=%lld]", pthparam->path.c_str(), pthparam->fd, static_cast<long long>(pthparam->start), static_cast<long long>(pthparam->size));
+
+    sse_type_t  ssetype = sse_type_t::SSE_DISABLE;
+    std::string ssevalue;
+    if(!get_object_sse_type(pthparam->path.c_str(), ssetype, ssevalue)){
+        S3FS_PRN_WARN("Failed to get SSE type for file(%s).", pthparam->path.c_str());
+    }
+
+    S3fsCurl    s3fscurl;
+    pthparam->result = s3fscurl.GetObjectRequest(pthparam->path.c_str(), pthparam->fd, pthparam->start, pthparam->size, ssetype, ssevalue);
+
+    return reinterpret_cast<void*>(pthparam->result);
+}
+
+//-------------------------------------------------------------------
+// Utility functions
+//-------------------------------------------------------------------
+//
+// Calls S3fsCurl::HeadRequest via head_req_threadworker
+//
+int head_request(const std::string& strpath, headers_t& header)
+{
+    // parameter for thread worker
+    head_req_thparam thargs;
+    thargs.path   = strpath;
+    thargs.pmeta  = &header;
+    thargs.result = 0;
+
+    // make parameter for thread pool
+    thpoolman_param  ppoolparam;
+    ppoolparam.args  = &thargs;
+    ppoolparam.psem  = nullptr;         // case await
+    ppoolparam.pfunc = head_req_threadworker;
+
+    // send request by thread
+    if(!ThreadPoolMan::AwaitInstruct(ppoolparam)){
+        S3FS_PRN_ERR("failed to setup Await Head Request Thread Worker [path=%s]", strpath.c_str());
+        return -EIO;
+    }
+    if(0 != thargs.result){
+        S3FS_PRN_DBG("Await Head Request by error(%d) [path=%s]", thargs.result, strpath.c_str());
+        return thargs.result;
+    }
+
+    return 0;
+}
+
+//
+// Calls S3fsCurl::DeleteRequest via delete_req_threadworker
+//
+int delete_request(const std::string& strpath)
+{
+    // parameter for thread worker
+    delete_req_thparam thargs;
+    thargs.path   = strpath;
+    thargs.result = 0;
+
+    // make parameter for thread pool
+    thpoolman_param  ppoolparam;
+    ppoolparam.args  = &thargs;
+    ppoolparam.psem  = nullptr;         // case await
+    ppoolparam.pfunc = delete_req_threadworker;
+
+    // send request by thread
+    if(!ThreadPoolMan::AwaitInstruct(ppoolparam)){
+        S3FS_PRN_ERR("failed to setup Await Delete Request Thread Worker [path=%s]", strpath.c_str());
+        return -EIO;
+    }
+    if(0 != thargs.result){
+        S3FS_PRN_DBG("Await Delete Request by error(%d) [path=%s]", thargs.result, strpath.c_str());
+        return thargs.result;
+    }
+    return 0;
+}
+
+//
+// Calls S3fsCurl::PutHeadRequest via put_head_req_threadworker
+//
+int put_head_request(const std::string& strpath, const headers_t& meta, bool is_copy)
+{
+    // parameter for thread worker
+    put_head_req_thparam thargs;
+    thargs.path   = strpath;
+    thargs.meta   = meta;               // copy
+    thargs.isCopy = is_copy;
+    thargs.result = 0;
+
+    // make parameter for thread pool
+    thpoolman_param  ppoolparam;
+    ppoolparam.args  = &thargs;
+    ppoolparam.psem  = nullptr;         // case await
+    ppoolparam.pfunc = put_head_req_threadworker;
+
+    // send request by thread
+    if(!ThreadPoolMan::AwaitInstruct(ppoolparam)){
+        S3FS_PRN_ERR("failed to setup Await Put Head Request Thread Worker [path=%s][meta count=%lu][is copy=%s]", strpath.c_str(), meta.size(), (is_copy ? "true" : "false"));
+        return -EIO;
+    }
+    if(0 != thargs.result){
+        S3FS_PRN_ERR("Await Put Head Request by error(%d) [path=%s][meta count=%lu][is copy=%s]", thargs.result, strpath.c_str(), meta.size(), (is_copy ? "true" : "false"));
+        return thargs.result;
+    }
+    return 0;
+}
+
+//
+// Calls S3fsCurl::PutRequest via put_req_threadworker
+//
+int put_request(const std::string& strpath, const headers_t& meta, int fd, bool ahbe)
+{
+    // parameter for thread worker
+    put_req_thparam thargs;
+    thargs.path   = strpath;
+    thargs.meta   = meta;               // copy
+    thargs.fd     = fd;                 // fd=-1 means for creating zero byte object.
+    thargs.ahbe   = ahbe;
+    thargs.result = 0;
+
+    // make parameter for thread pool
+    thpoolman_param  ppoolparam;
+    ppoolparam.args  = &thargs;
+    ppoolparam.psem  = nullptr;         // case await
+    ppoolparam.pfunc = put_req_threadworker;
+
+    // send request by thread
+    if(!ThreadPoolMan::AwaitInstruct(ppoolparam)){
+        S3FS_PRN_ERR("failed to setup Await Put Request Thread Worker [path=%s][meta count=%lu][fd=%d][use_ahbe=%s]", strpath.c_str(), meta.size(), fd, (ahbe ? "true" : "false"));
+        return -EIO;
+    }
+    if(0 != thargs.result){
+        S3FS_PRN_ERR("Await Put Request by error(%d) [path=%s][meta count=%lu][fd=%d][use_ahbe=%s]", thargs.result, strpath.c_str(), meta.size(), fd, (ahbe ? "true" : "false"));
+        return thargs.result;
+    }
+    return 0;
+}
+
+//
+// Calls S3fsCurl::ListBucketRequest via list_bucket_req_threadworker
+//
+int list_bucket_request(const std::string& strpath, const std::string& query, std::string& responseBody)
+{
+    // parameter for thread worker
+    list_bucket_req_thparam thargs;
+    thargs.path          = strpath;
+    thargs.query         = query;
+    thargs.presponseBody = &responseBody;
+    thargs.result        = 0;
+
+    // make parameter for thread pool
+    thpoolman_param  ppoolparam;
+    ppoolparam.args  = &thargs;
+    ppoolparam.psem  = nullptr;         // case await
+    ppoolparam.pfunc = list_bucket_req_threadworker;
+
+    // send request by thread
+    if(!ThreadPoolMan::AwaitInstruct(ppoolparam)){
+        S3FS_PRN_ERR("failed to setup Await List Bucket Request Thread Worker [path=%s][query=%s]", strpath.c_str(), query.c_str());
+        return -EIO;
+    }
+    if(0 != thargs.result){
+        S3FS_PRN_ERR("Await List Bucket Request by error(%d) [path=%s][query=%s]", thargs.result, strpath.c_str(), query.c_str());
+        return thargs.result;
+    }
+    return 0;
+}
+
+//
+// Calls S3fsCurl::CheckBucket via check_service_req_threadworker
+//
+int check_service_request(const std::string& strpath, bool forceNoSSE, bool support_compat_dir, long& responseCode, std::string& responseBody)
+{
+    // parameter for thread worker
+    check_service_req_thparam thargs;
+    thargs.path               = strpath;
+    thargs.forceNoSSE         = forceNoSSE;
+    thargs.support_compat_dir = support_compat_dir;
+    thargs.presponseCode      = &responseCode;
+    thargs.presponseBody      = &responseBody;
+    thargs.result             = 0;
+
+    // make parameter for thread pool
+    thpoolman_param  ppoolparam;
+    ppoolparam.args  = &thargs;
+    ppoolparam.psem  = nullptr;         // case await
+    ppoolparam.pfunc = check_service_req_threadworker;
+
+    // send request by thread
+    if(!ThreadPoolMan::AwaitInstruct(ppoolparam)){
+        S3FS_PRN_ERR("failed to setup Await Check Service Request Thread Worker [path=%s][support compat dir=%s][force No SSE=%s]", strpath.c_str(), (support_compat_dir ? "true" : "false"), (forceNoSSE ? "true" : "false"));
+        return -EIO;
+    }
+    if(0 != thargs.result){
+        S3FS_PRN_ERR("Await Check Service Request by error(%d) [path=%s][support compat dir=%s][force No SSE=%s]", thargs.result, strpath.c_str(), (support_compat_dir ? "true" : "false"), (forceNoSSE ? "true" : "false"));
+        return thargs.result;
+    }
+    return 0;
+}
+
+//
+// Calls S3fsCurl::PreMultipartUploadRequest via pre_multipart_upload_req_threadworker
+//
+// [NOTE]
+// If the request is successful, sets upload_id.
+//
+int pre_multipart_upload_request(const std::string& path, const headers_t& meta, std::string& upload_id)
+{
+    // parameter for thread worker
+    pre_multipart_upload_req_thparam thargs;
+    thargs.path    = path;
+    thargs.meta    = meta;              // copy
+    thargs.upload_id.clear();           // clear
+    thargs.result  = 0;
+
+    // make parameter for thread pool
+    thpoolman_param  ppoolparam;
+    ppoolparam.args  = &thargs;
+    ppoolparam.psem  = nullptr;         // case await
+    ppoolparam.pfunc = pre_multipart_upload_req_threadworker;
+
+    // send request by thread
+    if(!ThreadPoolMan::AwaitInstruct(ppoolparam)){
+        S3FS_PRN_ERR("failed to setup Pre Multipart Upload Request Thread Worker");
+        return -EIO;
+    }
+    if(0 != thargs.result){
+        S3FS_PRN_ERR("Pre Multipart Upload Request(path=%s) returns with error(%d)", path.c_str(), thargs.result);
+        return thargs.result;
+    }
+    // set upload_id
+    upload_id = thargs.upload_id;
+
+    return 0;
+}
+
+//
+// Calls S3fsCurl::MultipartUploadComplete via complete_multipart_upload_threadworker
+//
+int complete_multipart_upload_request(const std::string& path, const std::string& upload_id, const etaglist_t& parts)
+{
+    // parameter for thread worker
+    complete_multipart_upload_req_thparam thargs;
+    thargs.path      = path;
+    thargs.upload_id = upload_id;
+    thargs.etaglist  = parts;           // copy
+    thargs.result    = 0;
+
+    // make parameter for thread pool
+    thpoolman_param  ppoolparam;
+    ppoolparam.args  = &thargs;
+    ppoolparam.psem  = nullptr;         // case await
+    ppoolparam.pfunc = complete_multipart_upload_threadworker;
+
+    // send request by thread
+    if(!ThreadPoolMan::AwaitInstruct(ppoolparam)){
+        S3FS_PRN_ERR("failed to setup Complete Multipart Upload Request Thread Worker");
+        return -EIO;
+    }
+    if(0 != thargs.result){
+        S3FS_PRN_ERR("Complete Multipart Upload Request(path=%s) returns with error(%d)", path.c_str(), thargs.result);
+        return thargs.result;
+    }
+    return 0;
+}
+
+//
+// Calls S3fsCurl::AbortMultipartUpload via abort_multipart_upload_req_threadworker
+//
+int abort_multipart_upload_request(const std::string& path, const std::string& upload_id)
+{
+    // parameter for thread worker
+    abort_multipart_upload_req_thparam thargs;
+    thargs.path      = path;
+    thargs.upload_id = upload_id;
+    thargs.result    = 0;
+
+    // make parameter for thread pool
+    thpoolman_param  ppoolparam;
+    ppoolparam.args  = &thargs;
+    ppoolparam.psem  = nullptr;         // case await
+    ppoolparam.pfunc = abort_multipart_upload_req_threadworker;
+
+    // send request by thread
+    if(!ThreadPoolMan::AwaitInstruct(ppoolparam)){
+        S3FS_PRN_ERR("failed to setup Abort Multipart Upload Request Thread Worker");
+        return -EIO;
+    }
+    if(0 != thargs.result){
+        S3FS_PRN_ERR("Abort Multipart Upload Request(path=%s) returns with error(%d)", path.c_str(), thargs.result);
+        return thargs.result;
+    }
+    return 0;
+}
+
+//
+// Calls S3fsCurl::GetObjectRequest via get_object_req_threadworker
+//
+int get_object_request(const std::string& path, int fd, off_t start, off_t size)
+{
+    // parameter for thread worker
+    get_object_req_thparam thargs;
+    thargs.path   = path;
+    thargs.fd     = fd;
+    thargs.start  = start;
+    thargs.size   = size;
+    thargs.result = 0;
+
+    // make parameter for thread pool
+    thpoolman_param  ppoolparam;
+    ppoolparam.args  = &thargs;
+    ppoolparam.psem  = nullptr;         // case await
+    ppoolparam.pfunc = get_object_req_threadworker;
+
+    // send request by thread
+    if(!ThreadPoolMan::AwaitInstruct(ppoolparam)){
+        S3FS_PRN_ERR("failed to setup Await Get Object Request Thread Worker [path=%s][fd=%d][start=%lld][size=%lld]", path.c_str(), fd, static_cast<long long int>(start), static_cast<long long int>(size));
+        return -EIO;
+    }
+    if(0 != thargs.result){
+        S3FS_PRN_ERR("Await Get Object Request by error(%d) [path=%s][fd=%d][start=%lld][size=%lld]", thargs.result, path.c_str(), fd, static_cast<long long int>(start), static_cast<long long int>(size));
+        return thargs.result;
+    }
+    return 0;
+}
+
+//-------------------------------------------------------------------
+// Direct Call Utility Functions
+//-------------------------------------------------------------------
+// These functions (mainly IAM token-related) are not called from
+// a thread.
+//
+// [NOTE]
+// The request for IAM token calls are called from S3fsCurl::RequestPerform
+// method if the IAM token needs to be updated during each request
+// processing. (NOTE: Each request is already executed in a thread.)
+// If the number of threads has reached the limit when these functions
+// are called, they will block until a thread that can execute this
+// process is found.
+// This may result in all processing being blocked.
+// Therefore, the following functions(IAM token requests) will not be
+// processed by a thread worker, but will process the request directly.
+//
+// If it is a different request called from within a thread worker,
+// please process it like this.
+//
+
+//
+// Directly calls S3fsCurl::GetIAMv2ApiToken
+//
+int get_iamv2api_token_request(const std::string& strurl, int tokenttl, const std::string& strttlhdr, std::string& token)
+{
+    S3FS_PRN_INFO3("Get IAMv2 API Toekn Request directly [url=%s][token ttl=%d][ttl header=%s]", strurl.c_str(), tokenttl, strttlhdr.c_str());
+
+    S3fsCurl s3fscurl;
+
+    return s3fscurl.GetIAMv2ApiToken(strurl.c_str(), tokenttl, strttlhdr.c_str(), token);
+}
+
+//
+// Directly calls S3fsCurl::GetIAMRoleFromMetaData
+//
+int get_iamrole_request(const std::string& strurl, const std::string& striamtoken, std::string& token)
+{
+    S3FS_PRN_INFO3("Get IAM Role Request directly [url=%s][iam token=%s]", strurl.c_str(), striamtoken.c_str());
+
+    S3fsCurl s3fscurl;
+    int      result = 0;
+    if(!s3fscurl.GetIAMRoleFromMetaData(strurl.c_str(), (striamtoken.empty() ? nullptr : striamtoken.c_str()), token)){
+        S3FS_PRN_ERR("Something error occurred during getting IAM Role from MetaData.");
+        result = -EIO;
+    }
+    return result;
+}
+
+//
+// Directly calls S3fsCurl::GetIAMCredentials
+//
+int get_iamcred_request(const std::string& strurl, const std::string& striamtoken, const std::string& stribmsecret, std::string& cred)
+{
+    S3FS_PRN_INFO3("Get IAM Credentials Request directly [url=%s][iam token=%s][ibm secrect access key=%s]", strurl.c_str(), striamtoken.c_str(), stribmsecret.c_str());
+
+    S3fsCurl s3fscurl;
+    int      result = 0;
+    if(!s3fscurl.GetIAMCredentials(strurl.c_str(), (striamtoken.empty() ? nullptr : striamtoken.c_str()), (stribmsecret.empty() ? nullptr : stribmsecret.c_str()), cred)){
+        S3FS_PRN_ERR("Something error occurred during getting IAM Credentials.");
+        result = -EIO;
+    }
+    return result;
+}
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/

--- a/src/s3fs_threadreqs.h
+++ b/src/s3fs_threadreqs.h
@@ -1,0 +1,187 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef S3FS_THREADREQS_H_
+#define S3FS_THREADREQS_H_
+
+#include <string>
+
+#include "common.h"
+#include "metaheader.h"
+#include "curl.h"
+
+//-------------------------------------------------------------------
+// Structures for MultiThread Request
+//-------------------------------------------------------------------
+//
+// Head Request parameter structure for Thread Pool.
+//
+struct head_req_thparam
+{
+    std::string path;
+    headers_t*  pmeta  = nullptr;
+    int         result = 0;
+};
+
+//
+// Delete Request parameter structure for Thread Pool.
+//
+struct delete_req_thparam
+{
+    std::string path;
+    int         result = 0;
+};
+
+//
+// Put Head Request parameter structure for Thread Pool.
+//
+struct put_head_req_thparam
+{
+    std::string path;
+    headers_t   meta;
+    bool        isCopy = false;
+    int         result = 0;
+};
+
+//
+// Put Request parameter structure for Thread Pool.
+//
+struct put_req_thparam
+{
+    std::string path;
+    headers_t   meta;
+    int         fd     = -1;
+    bool        ahbe   = false;
+    int         result = 0;
+};
+
+//
+// List Bucket Request parameter structure for Thread Pool.
+//
+struct list_bucket_req_thparam
+{
+    std::string  path;
+    std::string  query;
+    std::string* presponseBody = nullptr;
+    int          result        = 0;
+};
+
+//
+// Check Service Request parameter structure for Thread Pool.
+//
+struct check_service_req_thparam
+{
+    std::string  path;
+    bool         forceNoSSE         = false;
+    bool         support_compat_dir = false;
+    long*        presponseCode      = nullptr;
+    std::string* presponseBody      = nullptr;
+    int          result             = 0;
+};
+
+//
+// Pre Multipart Upload Request parameter structure for Thread Pool.
+//
+struct pre_multipart_upload_req_thparam
+{
+    std::string path;
+    headers_t   meta;
+    std::string upload_id;
+    int         result = 0;
+};
+
+//
+// Complete Multipart Upload Request parameter structure for Thread Pool.
+//
+struct complete_multipart_upload_req_thparam
+{
+    std::string path;
+    std::string upload_id;
+    etaglist_t  etaglist;
+    int         result = 0;
+};
+
+//
+// Abort Multipart Upload Request parameter structure for Thread Pool.
+//
+struct abort_multipart_upload_req_thparam
+{
+    std::string path;
+    std::string upload_id;
+    int         result = 0;
+};
+
+//
+// Get Object Request parameter structure for Thread Pool.
+//
+struct get_object_req_thparam
+{
+    std::string path;
+    int         fd     = -1;
+    off_t       start  = 0;
+    off_t       size   = 0;
+    int         result = 0;
+};
+
+//-------------------------------------------------------------------
+// Thread Worker functions for MultiThread Request
+//-------------------------------------------------------------------
+void* head_req_threadworker(void* arg);
+void* delete_req_threadworker(void* arg);
+void* put_head_req_threadworker(void* arg);
+void* put_req_threadworker(void* arg);
+void* list_bucket_req_threadworker(void* arg);
+void* check_service_req_threadworker(void* arg);
+void* pre_multipart_upload_req_threadworker(void* arg);
+void* complete_multipart_upload_threadworker(void* arg);
+void* abort_multipart_upload_req_threadworker(void* arg);
+void* get_object_req_threadworker(void* arg);
+
+//-------------------------------------------------------------------
+// Utility functions
+//-------------------------------------------------------------------
+int head_request(const std::string& strpath, headers_t& header);
+int delete_request(const std::string& strpath);
+int put_head_request(const std::string& strpath, const headers_t& meta, bool is_copy);
+int put_request(const std::string& strpath, const headers_t& meta, int fd, bool ahbe);
+int list_bucket_request(const std::string& strpath, const std::string& query, std::string& responseBody);
+int check_service_request(const std::string& strpath, bool forceNoSSE, bool support_compat_dir, long& responseCode, std::string& responseBody);
+int pre_multipart_upload_request(const std::string& path, const headers_t& meta, std::string& upload_id);
+int complete_multipart_upload_request(const std::string& path, const std::string& upload_id, const etaglist_t& parts);
+int abort_multipart_upload_request(const std::string& path, const std::string& upload_id);
+int get_object_request(const std::string& path, int fd, off_t start, off_t size);
+
+//-------------------------------------------------------------------
+// Direct Call Utility Functions
+//-------------------------------------------------------------------
+int get_iamv2api_token_request(const std::string& strurl, int tokenttl, const std::string& strttlhdr, std::string& token);
+int get_iamrole_request(const std::string& strurl, const std::string& striamtoken, std::string& token);
+int get_iamcred_request(const std::string& strurl, const std::string& striamtoken, const std::string& stribmsecret, std::string& cred);
+
+#endif // S3FS_THREADREQS_H_
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/

--- a/src/threadpoolman.h
+++ b/src/threadpoolman.h
@@ -92,6 +92,7 @@ class ThreadPoolMan
         static bool Initialize(int count);
         static void Destroy();
         static bool Instruct(const thpoolman_param& pparam);
+        static bool AwaitInstruct(const thpoolman_param& param);
 };
 
 #endif // S3FS_THREADPOOLMAN_H_


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2600

### Details
This is the split PR Phase 2 (2/8) for #2600.

Single requests(synchronous requests) are changed to process by a worker thread managed by `ThreadPoolMan`.

The implementation of each request process has been moved to the handler(Callback) function of the worker thread.
As a result, the `S3fsCurl` object held by each request process function has been moved to a worker thread managed by `ThreadPoolMan`.
(In a future PR, the construction location of the `S3fsCurl` object will be moved again.)
All worker thread processing is concentrated in new `s3fs_threadreqs.cpp`  file.
(From now on, I will continue to concentrate in this file.)

Asynchronous and multi-request processing is not yet modified in this PR.

This PR will be rebased and removed from draft status once the previous PR(#2601) is merged into master.

