### PR TITLE
Refactored multipart put head request

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -196,13 +196,13 @@ class S3fsCurl
         size_t               b_ssekey_pos;         // backup for retrying
         std::string          b_ssevalue;           // backup for retrying
         sse_type_t           b_ssetype;            // backup for retrying
-        std::string          b_from;               // backup for retrying(for copy request)
+        std::string          b_from;               // backup for retrying(for copy request) ([TODO] If S3fsMultiCurl is discontinued, this variable will be deleted.)
         headers_t            b_meta;               // backup for retrying(for copy request)
         std::string          op;                   // the HTTP verb of the request ("PUT", "GET", etc.)
         std::string          query_string;         // request query string
         Semaphore            *sem;
-        std::mutex           *completed_tids_lock;
-        std::vector<std::thread::id> *completed_tids PT_GUARDED_BY(*completed_tids_lock);
+        std::mutex           *completed_tids_lock;                                         // ([TODO] If S3fsMultiCurl is discontinued, this variable will be deleted.)
+        std::vector<std::thread::id> *completed_tids PT_GUARDED_BY(*completed_tids_lock);  // ([TODO] If S3fsMultiCurl is discontinued, this variable will be deleted.)
         s3fscurl_lazy_setup  fpLazySetup;          // curl options for lazy setting function
         CURLcode             curlCode;             // handle curl return
 
@@ -241,7 +241,6 @@ class S3fsCurl
         static size_t DownloadWriteCallback(void* ptr, size_t size, size_t nmemb, void* userp);
 
         static bool MultipartUploadPartCallback(S3fsCurl* s3fscurl, void* param);
-        static bool CopyMultipartUploadCallback(S3fsCurl* s3fscurl, void* param);
         static bool MixMultipartUploadCallback(S3fsCurl* s3fscurl, void* param);
         static std::unique_ptr<S3fsCurl> MultipartUploadPartRetryCallback(S3fsCurl* s3fscurl);
         static std::unique_ptr<S3fsCurl> CopyMultipartUploadRetryCallback(S3fsCurl* s3fscurl);
@@ -280,7 +279,7 @@ class S3fsCurl
         std::string CalcSignatureV2(const std::string& method, const std::string& strMD5, const std::string& content_type, const std::string& date, const std::string& resource, const std::string& secret_access_key, const std::string& access_token);
         std::string CalcSignature(const std::string& method, const std::string& canonical_uri, const std::string& query_string, const std::string& strdate, const std::string& payload_hash, const std::string& date8601, const std::string& secret_access_key, const std::string& access_token);
         int MultipartUploadPartSetup(const char* tpath, int part_num, const std::string& upload_id);
-        int CopyMultipartUploadSetup(const char* from, const char* to, int part_num, const std::string& upload_id, headers_t& meta);
+        int CopyMultipartUploadSetup(const char* from, const char* to, int part_num, const std::string& upload_id, const headers_t& meta);
         bool MultipartUploadPartComplete();
         bool CopyMultipartUploadComplete();
         int MapPutErrorResponse(int result);
@@ -385,9 +384,8 @@ class S3fsCurl
         bool MixMultipartUploadComplete();
         int MultipartListRequest(std::string& body);
         int AbortMultipartUpload(const char* tpath, const std::string& upload_id);
-        int MultipartHeadRequest(const char* tpath, off_t size, headers_t& meta);
+        int MultipartPutHeadRequest(const std::string& from, const std::string& to, int part_number, const std::string& upload_id, const headers_t& meta);
         int MultipartUploadRequest(const std::string& upload_id, const char* tpath, int fd, off_t offset, off_t size, etagpair* petagpair);
-        int MultipartRenameRequest(const char* from, const char* to, headers_t& meta, off_t size);
 
         // methods(variables)
         const std::string& GetPath() const { return path; }

--- a/src/curl_util.h
+++ b/src/curl_util.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <curl/curl.h>
 #include <string>
+#include "metaheader.h"
 
 enum class sse_type_t : uint8_t;
 
@@ -38,6 +39,7 @@ std::string get_header_value(const struct curl_slist* list, const std::string &k
 bool MakeUrlResource(const char* realpath, std::string& resourcepath, std::string& url);
 std::string prepare_url(const char* url);
 bool get_object_sse_type(const char* path, sse_type_t& ssetype, std::string& ssevalue);   // implement in s3fs.cpp
+int put_headers(const char* path, const headers_t& meta, bool is_copy, bool use_st_size = true);    // implement in s3fs.cpp
 
 bool make_md5_from_binary(const char* pstr, size_t length, std::string& md5);
 std::string url_to_host(const std::string &url);

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -2513,9 +2513,6 @@ bool FdEntity::MergeOrgMeta(headers_t& updatemeta)
     return (pending_status_t::NO_UPDATE_PENDING != pending_status);
 }
 
-// global function in s3fs.cpp
-int put_headers(const char* path, headers_t& meta, bool is_copy, bool use_st_size = true);
-
 int FdEntity::UploadPendingHasLock(int fd)
 {
     int result;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2600

### Details
This is the split PR Phase 4 (4/8) for #2600.

The processing of Multi-PutHead requests(including `Rename` processing) has been changed so that they do not use `S3fsMultiCurl`.
Instead, they have been moved to a worker thread managed by `ThreadPoolMan`.

This PR will be rebased and removed from draft status once the previous PR(#2603) is merged into master.

