### PR TITLE
Refactored for standardizing content and copy handling for Multipart Upload

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -277,10 +277,10 @@ class S3fsCurl
         }
         std::string CalcSignatureV2(const std::string& method, const std::string& strMD5, const std::string& content_type, const std::string& date, const std::string& resource, const std::string& secret_access_key, const std::string& access_token);
         std::string CalcSignature(const std::string& method, const std::string& canonical_uri, const std::string& query_string, const std::string& strdate, const std::string& payload_hash, const std::string& date8601, const std::string& secret_access_key, const std::string& access_token);
-        int MultipartUploadPartSetup(const char* tpath, int part_num, const std::string& upload_id);
-        int CopyMultipartUploadSetup(const char* from, const char* to, int part_num, const std::string& upload_id, const headers_t& meta);
-        bool MultipartUploadPartComplete();
-        bool CopyMultipartUploadComplete();
+        int MultipartUploadContentPartSetup(const char* tpath, int part_num, const std::string& upload_id);
+        int MultipartUploadCopyPartSetup(const char* from, const char* to, int part_num, const std::string& upload_id, const headers_t& meta);
+        bool MultipartUploadContentPartComplete();
+        bool MultipartUploadCopyPartComplete();
         int MapPutErrorResponse(int result);
 
     public:
@@ -289,7 +289,6 @@ class S3fsCurl
         static bool InitCredentialObject(S3fsCred* pcredobj);
         static bool InitMimeType(const std::string& strFile);
         static bool DestroyS3fsCurl();
-        static std::unique_ptr<S3fsCurl> CreateParallelS3fsCurl(const char* tpath, int fd, off_t start, off_t size, int part_num, bool is_copy, etagpair* petag, const std::string& upload_id, int& result);
         static int ParallelMultipartUploadRequest(const char* tpath, const headers_t& meta, int fd);
         static int ParallelMixMultipartUploadRequest(const char* tpath, headers_t& meta, int fd, const fdpage_list_t& mixuppages);
 
@@ -377,13 +376,13 @@ class S3fsCurl
         int CheckBucket(const char* check_path, bool compat_dir, bool force_no_sse);
         int ListBucketRequest(const char* tpath, const char* query);
         int PreMultipartUploadRequest(const char* tpath, const headers_t& meta, std::string& upload_id);
+        int MultipartUploadPartSetup(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy);
         int MultipartUploadComplete(const char* tpath, const std::string& upload_id, const etaglist_t& parts);
-        int MultipartUploadPartRequest(const char* tpath, int part_num, const std::string& upload_id);
-        bool MixMultipartUploadComplete();
+        bool MultipartUploadPartComplete();
         int MultipartListRequest(std::string& body);
         int AbortMultipartUpload(const char* tpath, const std::string& upload_id);
         int MultipartPutHeadRequest(const std::string& from, const std::string& to, int part_number, const std::string& upload_id, const headers_t& meta);
-        int MultipartUploadRequest(const std::string& upload_id, const char* tpath, int fd, off_t offset, off_t size, etagpair* petagpair);
+        int MultipartUploadPartRequest(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy);
 
         // methods(variables)
         const std::string& GetPath() const { return path; }

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -80,7 +80,6 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
     private:
         static int FillFile(int fd, unsigned char byte, off_t size, off_t start);
         static ino_t GetInode(int fd);
-        static void* MultipartUploadThreadWorker(void* arg);          // ([TODO] This is a temporary method is moved when S3fsMultiCurl is deprecated.)
 
         void Clear();
         ino_t GetInode() const REQUIRES(FdEntity::fdent_data_lock);

--- a/src/s3fs_threadreqs.h
+++ b/src/s3fs_threadreqs.h
@@ -125,6 +125,23 @@ struct pre_multipart_upload_req_thparam
 };
 
 //
+// Multipart Upload Part Request parameter structure for Thread Pool.
+//
+struct multipart_upload_part_req_thparam
+{
+    std::string   path;
+    std::string   upload_id;
+    int           upload_fd      = -1;
+    off_t         start          = 0;
+    off_t         size           = 0;
+    bool          is_copy        = false;
+    int           part_num       = -1;
+    std::mutex*   pthparam_lock  = nullptr;
+    etagpair*     petag          = nullptr;
+    int*          presult        = nullptr;
+};
+
+//
 // Complete Multipart Upload Request parameter structure for Thread Pool.
 //
 struct complete_multipart_upload_req_thparam
@@ -200,6 +217,7 @@ void* put_req_threadworker(void* arg);
 void* list_bucket_req_threadworker(void* arg);
 void* check_service_req_threadworker(void* arg);
 void* pre_multipart_upload_req_threadworker(void* arg);
+void* multipart_upload_part_req_threadworker(void* arg);
 void* complete_multipart_upload_threadworker(void* arg);
 void* abort_multipart_upload_req_threadworker(void* arg);
 void* multipart_put_head_req_threadworker(void* arg);
@@ -217,6 +235,8 @@ int put_request(const std::string& strpath, const headers_t& meta, int fd, bool 
 int list_bucket_request(const std::string& strpath, const std::string& query, std::string& responseBody);
 int check_service_request(const std::string& strpath, bool forceNoSSE, bool support_compat_dir, long& responseCode, std::string& responseBody);
 int pre_multipart_upload_request(const std::string& path, const headers_t& meta, std::string& upload_id);
+int multipart_upload_part_request(const std::string& path, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy, Semaphore* psem, std::mutex* pthparam_lock, int* req_result);
+int await_multipart_upload_part_request(const std::string& path, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy);
 int complete_multipart_upload_request(const std::string& path, const std::string& upload_id, const etaglist_t& parts);
 int abort_multipart_upload_request(const std::string& path, const std::string& upload_id);
 int multipart_put_head_request(const std::string& strfrom, const std::string& strto, off_t size, const headers_t& meta);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2600

### Details
This is the split PR Phase 6 (6/8) for #2600.

The Multipart Upload (Contents / Copy) process has been changed so that it no longer uses `S3fsMultiCurl`.
Instead, it has been moved to a worker thread managed by `ThreadPoolMan`.
The Contents and Copy processes for Multipart Upload have also been reorganized, and common parts that can be commonized have been made common.

This PR will be rebased and removed from draft status once the previous PR(#2605) is merged into master.