### PR TITLE
Added new class for curl share handle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
             elif [ "${{ matrix.checktype }}" = "sanitize_thread" ]; then
                 echo 'CXX=clang++'
                 echo "CXXFLAGS=${COMMON_CXXFLAGS} -O0 -fsanitize=thread"
-                echo 'TSAN_OPTIONS=halt_on_error=1,suppressions=threadsanitizer_suppressions.txt'
+                echo 'TSAN_OPTIONS=halt_on_error=1'
                 # [NOTE]
                 # Set this to avoid following error when running configure.
                 # "FATAL: ThreadSanitizer: unexpected memory mapping"
@@ -269,7 +269,7 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          /bin/sh -c "CXX=${CXX} CXXFLAGS=\"${CXXFLAGS}\" LDFLAGS=\"${LDFLAGS}\" TSAN_OPTIONS=\"\" ./configure --prefix=/usr --with-openssl"
+          /bin/sh -c "CXX=${CXX} CXXFLAGS=\"${CXXFLAGS}\" LDFLAGS=\"${LDFLAGS}\" ./configure --prefix=/usr --with-openssl"
           make
 
       - name: Test suite

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,6 +36,7 @@ s3fs_SOURCES = \
     metaheader.cpp \
     mpu_util.cpp \
     curl.cpp \
+    curl_share.cpp \
     curl_util.cpp \
     s3objlist.cpp \
     cache.cpp \

--- a/src/curl.h
+++ b/src/curl.h
@@ -127,10 +127,7 @@ class S3fsCurl
             std::mutex      ssl_session;
         } callback_locks;
         static bool             is_initglobal_done;
-        static CURLSH*          hCurlShare;
         static bool             is_cert_check;
-        static bool             is_dns_cache;
-        static bool             is_ssl_session_cache;
         static long             connect_timeout;
         static time_t           readwrite_timeout;
         static int              retries;
@@ -211,10 +208,6 @@ class S3fsCurl
         // class methods
         static bool InitGlobalCurl();
         static bool DestroyGlobalCurl();
-        static bool InitShareCurl();
-        static bool DestroyShareCurl();
-        static void LockCurlShare(CURL* handle, curl_lock_data nLockData, curl_lock_access laccess, void* useptr) NO_THREAD_SAFETY_ANALYSIS;
-        static void UnlockCurlShare(CURL* handle, curl_lock_data nLockData, void* useptr) NO_THREAD_SAFETY_ANALYSIS;
         static bool InitCryptMutex();
         static bool DestroyCryptMutex();
         static int CurlProgress(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow);
@@ -274,8 +267,6 @@ class S3fsCurl
         // class methods(variables)
         static std::string LookupMimeType(const std::string& name);
         static bool SetCheckCertificate(bool isCertCheck);
-        static bool SetDnsCache(bool isCache);
-        static bool SetSslSessionCache(bool isCache);
         static long SetConnectTimeout(long timeout);
         static time_t SetReadwriteTimeout(time_t timeout);
         static time_t GetReadwriteTimeout() { return S3fsCurl::readwrite_timeout; }

--- a/src/curl_share.cpp
+++ b/src/curl_share.cpp
@@ -1,0 +1,239 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "common.h"
+#include "s3fs.h"
+#include "s3fs_logger.h"
+#include "curl_share.h"
+
+//-------------------------------------------------------------------
+// Class S3fsCurlShare
+//-------------------------------------------------------------------
+bool                                     S3fsCurlShare::is_dns_cache = true;    // default
+bool                                     S3fsCurlShare::is_ssl_cache = true;    // default
+std::mutex                               S3fsCurlShare::curl_share_lock;
+std::map<std::thread::id, CurlSharePtr>  S3fsCurlShare::ShareHandles;
+std::map<std::thread::id, ShareLocksPtr> S3fsCurlShare::ShareLocks;
+
+//-------------------------------------------------------------------
+// Class methods for S3fsCurlShare
+//-------------------------------------------------------------------
+bool S3fsCurlShare::SetDnsCache(bool isCache)
+{
+    bool old = S3fsCurlShare::is_dns_cache;
+    S3fsCurlShare::is_dns_cache = isCache;
+    return old;
+}
+
+bool S3fsCurlShare::SetSslSessionCache(bool isCache)
+{
+    bool old = S3fsCurlShare::is_ssl_cache;
+    S3fsCurlShare::is_ssl_cache = isCache;
+    return old;
+}
+
+void S3fsCurlShare::LockCurlShare(CURL* handle, curl_lock_data nLockData, curl_lock_access laccess, void* useptr)
+{
+    auto* pLocks  = static_cast<curl_share_locks*>(useptr);
+
+    if(CURL_LOCK_DATA_DNS == nLockData){
+        pLocks->lock_dns.lock();
+    }else if(CURL_LOCK_DATA_SSL_SESSION == nLockData){
+        pLocks->lock_session.lock();
+    }
+}
+
+void S3fsCurlShare::UnlockCurlShare(CURL* handle, curl_lock_data nLockData, void* useptr)
+{
+    auto* pLocks  = static_cast<curl_share_locks*>(useptr);
+
+    if(CURL_LOCK_DATA_DNS == nLockData){
+        pLocks->lock_dns.unlock();
+    }else if(CURL_LOCK_DATA_SSL_SESSION == nLockData){
+        pLocks->lock_session.unlock();
+    }
+}
+
+bool S3fsCurlShare::SetCurlShareHandle(CURL* hCurl)
+{
+    if(!hCurl){
+        S3FS_PRN_ERR("Curl handle is null");
+        return false;
+    }
+
+    // get curl share handle
+    S3fsCurlShare CurlShareObj;
+    CURLSH*       hCurlShare = CurlShareObj.GetCurlShareHandle();
+    if(!hCurlShare){
+        // a case of not to use CurlShare
+        return true;
+    }
+
+    // set share handle to curl handle
+    if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_SHARE, hCurlShare)){
+        S3FS_PRN_ERR("Failed to set Curl share handle to curl handle.");
+        return false;
+    }
+    return true;
+}
+
+bool S3fsCurlShare::DestroyCurlShareHandleForThread()
+{
+    S3fsCurlShare CurlShareObj;
+    return CurlShareObj.DestroyCurlShareHandle();
+}
+
+bool S3fsCurlShare::InitializeCurlShare(const CurlSharePtr& hShare, const ShareLocksPtr& ShareLock)
+{
+    CURLSHcode nSHCode;
+
+    // set lock handlers
+    if(CURLSHE_OK != (nSHCode = curl_share_setopt(hShare.get(), CURLSHOPT_LOCKFUNC, S3fsCurlShare::LockCurlShare))){
+        S3FS_PRN_ERR("curl_share_setopt(LOCKFUNC) returns %d(%s)", nSHCode, curl_share_strerror(nSHCode));
+        return false;
+    }
+    if(CURLSHE_OK != (nSHCode = curl_share_setopt(hShare.get(), CURLSHOPT_UNLOCKFUNC, S3fsCurlShare::UnlockCurlShare))){
+        S3FS_PRN_ERR("curl_share_setopt(UNLOCKFUNC) returns %d(%s)", nSHCode, curl_share_strerror(nSHCode));
+        return false;
+    }
+
+    // set user data for lock functions
+    if(CURLSHE_OK != (nSHCode = curl_share_setopt(hShare.get(), CURLSHOPT_USERDATA, ShareLock.get()))){
+        S3FS_PRN_ERR("curl_share_setopt(USERDATA) returns %d(%s)", nSHCode, curl_share_strerror(nSHCode));
+        return false;
+    }
+
+    // set share type
+    if(S3fsCurlShare::is_dns_cache){
+        nSHCode = curl_share_setopt(hShare.get(), CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+        if(CURLSHE_OK != nSHCode && CURLSHE_BAD_OPTION != nSHCode && CURLSHE_NOT_BUILT_IN != nSHCode){
+            S3FS_PRN_ERR("curl_share_setopt(DNS) returns %d(%s)", nSHCode, curl_share_strerror(nSHCode));
+            return false;
+        }else if(CURLSHE_BAD_OPTION == nSHCode || CURLSHE_NOT_BUILT_IN == nSHCode){
+            S3FS_PRN_WARN("curl_share_setopt(DNS) returns %d(%s), but continue without shared dns data.", nSHCode, curl_share_strerror(nSHCode));
+        }
+    }
+    if(S3fsCurlShare::is_ssl_cache){
+        nSHCode = curl_share_setopt(hShare.get(), CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
+        if(CURLSHE_OK != nSHCode && CURLSHE_BAD_OPTION != nSHCode && CURLSHE_NOT_BUILT_IN != nSHCode){
+            S3FS_PRN_ERR("curl_share_setopt(SSL SESSION) returns %d(%s)", nSHCode, curl_share_strerror(nSHCode));
+            return false;
+        }else if(CURLSHE_BAD_OPTION == nSHCode || CURLSHE_NOT_BUILT_IN == nSHCode){
+            S3FS_PRN_WARN("curl_share_setopt(SSL SESSION) returns %d(%s), but continue without shared ssl session data.", nSHCode, curl_share_strerror(nSHCode));
+        }
+    }
+
+    return true;
+}
+
+//-------------------------------------------------------------------
+// Methods for S3fsCurlShare
+//-------------------------------------------------------------------
+// [NOTE]
+// set current thread id(std style) to ThreadId
+//
+S3fsCurlShare::S3fsCurlShare() : ThreadId(std::this_thread::get_id())
+{
+}
+
+bool S3fsCurlShare::DestroyCurlShareHandle()
+{
+    if(!S3fsCurlShare::is_dns_cache && !S3fsCurlShare::is_ssl_cache){
+        // Any curl share handle does not exist
+        return true;
+    }
+
+    const std::lock_guard<std::mutex> lock(S3fsCurlShare::curl_share_lock);
+
+    // find existed handle and cleanup it
+    auto handle_iter = S3fsCurlShare::ShareHandles.find(ThreadId);
+    if(handle_iter == S3fsCurlShare::ShareHandles.end()){
+        S3FS_PRN_WARN("Not found curl share handle");
+    }else{
+        if(CURLSHE_OK != curl_share_cleanup(handle_iter->second.get())){
+            S3FS_PRN_ERR("Failed to cleanup curl share handle");
+            return false;
+        }
+        S3fsCurlShare::ShareHandles.erase(handle_iter);
+    }
+
+    // find lock and cleanup it
+    auto locks_iter = S3fsCurlShare::ShareLocks.find(ThreadId);
+    if(locks_iter == S3fsCurlShare::ShareLocks.end()){
+        S3FS_PRN_WARN("Not found locks of curl share handle");
+    }else{
+        S3fsCurlShare::ShareLocks.erase(locks_iter);
+    }
+
+    return true;
+}
+
+CURLSH* S3fsCurlShare::GetCurlShareHandle()
+{
+    if(!S3fsCurlShare::is_dns_cache && !S3fsCurlShare::is_ssl_cache){
+        // Any curl share handle does not exist
+        return nullptr;
+    }
+
+    const std::lock_guard<std::mutex> lock(S3fsCurlShare::curl_share_lock);
+
+    // find existed handle
+    auto handle_iter = S3fsCurlShare::ShareHandles.find(ThreadId);
+    if(handle_iter != S3fsCurlShare::ShareHandles.end()){
+        // Already created share handle for this thread.
+        return handle_iter->second.get();
+    }
+
+    // create new curl share handle and locks
+    CurlSharePtr hShare = {nullptr, curl_share_cleanup};
+    hShare.reset(curl_share_init());
+    if(!hShare){
+        S3FS_PRN_ERR("Failed to create curl share handle");
+        return nullptr;
+    }
+    ShareLocksPtr pLocks(new curl_share_locks);
+
+    // Initialize curl share handle
+    if(!S3fsCurlShare::InitializeCurlShare(hShare, pLocks)){
+        S3FS_PRN_ERR("Failed to initialize curl share handle");
+        return nullptr;
+    }
+
+    // set map
+    S3fsCurlShare::ShareHandles.emplace(ThreadId, std::move(hShare));
+    S3fsCurlShare::ShareLocks.emplace(ThreadId, std::move(pLocks));
+
+    // For clang-tidy measures
+    handle_iter = S3fsCurlShare::ShareHandles.find(ThreadId);
+    if(handle_iter == S3fsCurlShare::ShareHandles.end()){
+        S3FS_PRN_ERR("Failed to insert curl share to map.");
+        return nullptr;
+    }
+    return handle_iter->second.get();
+}
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/

--- a/src/curl_share.h
+++ b/src/curl_share.h
@@ -1,0 +1,89 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2007 Randy Rizun <rrizun@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef S3FS_CURL_SHARE_H_
+#define S3FS_CURL_SHARE_H_
+
+#include <curl/curl.h>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "common.h"
+
+//----------------------------------------------
+// Structure / Typedefs
+//----------------------------------------------
+struct curl_share_locks {
+    std::mutex lock_dns;
+    std::mutex lock_session;
+};
+
+typedef std::unique_ptr<CURLSH, decltype(&curl_share_cleanup)> CurlSharePtr;
+typedef std::unique_ptr<curl_share_locks>                      ShareLocksPtr;
+
+//----------------------------------------------
+// class S3fsCurlShare
+//----------------------------------------------
+class S3fsCurlShare
+{
+    private:
+        static bool                                     is_dns_cache;
+        static bool                                     is_ssl_cache;
+        static std::mutex                               curl_share_lock;
+        static std::map<std::thread::id, CurlSharePtr>  ShareHandles GUARDED_BY(curl_share_lock);
+        static std::map<std::thread::id, ShareLocksPtr> ShareLocks GUARDED_BY(curl_share_lock);
+
+        std::thread::id                                 ThreadId;
+
+    private:
+        static void LockCurlShare(CURL* handle, curl_lock_data nLockData, curl_lock_access laccess, void* useptr) NO_THREAD_SAFETY_ANALYSIS;
+        static void UnlockCurlShare(CURL* handle, curl_lock_data nLockData, void* useptr) NO_THREAD_SAFETY_ANALYSIS;
+        static bool InitializeCurlShare(const CurlSharePtr& hShare, const ShareLocksPtr& ShareLock) REQUIRES(curl_share_lock);
+
+        bool DestroyCurlShareHandle();
+        CURLSH* GetCurlShareHandle();
+
+    public:
+        static bool SetDnsCache(bool isCache);
+        static bool SetSslSessionCache(bool isCache);
+        static bool SetCurlShareHandle(CURL* hCurl);
+        static bool DestroyCurlShareHandleForThread();
+
+        // constructor/destructor
+        explicit S3fsCurlShare();
+        ~S3fsCurlShare() = default;
+        S3fsCurlShare(const S3fsCurlShare&) = delete;
+        S3fsCurlShare(S3fsCurlShare&&) = delete;
+        S3fsCurlShare& operator=(const S3fsCurlShare&) = delete;
+        S3fsCurlShare& operator=(S3fsCurlShare&&) = delete;
+};
+
+#endif // S3FS_CURL_SHARE_H_
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -43,6 +43,7 @@
 #include "fdcache_auto.h"
 #include "fdcache_stat.h"
 #include "curl.h"
+#include "curl_share.h"
 #include "curl_util.h"
 #include "s3objlist.h"
 #include "cache.h"
@@ -4933,11 +4934,11 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             return 0;
         }
         else if(0 == strcmp(arg, "nodnscache")){
-            S3fsCurl::SetDnsCache(false);
+            S3fsCurlShare::SetDnsCache(false);
             return 0;
         }
         else if(0 == strcmp(arg, "nosscache")){
-            S3fsCurl::SetSslSessionCache(false);
+            S3fsCurlShare::SetSslSessionCache(false);
             return 0;
         }
         else if(is_prefix(arg, "parallel_count=") || is_prefix(arg, "parallel_upload=")){

--- a/src/s3fs_threadreqs.h
+++ b/src/s3fs_threadreqs.h
@@ -209,20 +209,20 @@ struct get_object_req_thparam
 //-------------------------------------------------------------------
 // Thread Worker functions for MultiThread Request
 //-------------------------------------------------------------------
-void* head_req_threadworker(void* arg);
-void* multi_head_req_threadworker(void* arg);
-void* delete_req_threadworker(void* arg);
-void* put_head_req_threadworker(void* arg);
-void* put_req_threadworker(void* arg);
-void* list_bucket_req_threadworker(void* arg);
-void* check_service_req_threadworker(void* arg);
-void* pre_multipart_upload_req_threadworker(void* arg);
-void* multipart_upload_part_req_threadworker(void* arg);
-void* complete_multipart_upload_threadworker(void* arg);
-void* abort_multipart_upload_req_threadworker(void* arg);
-void* multipart_put_head_req_threadworker(void* arg);
-void* parallel_get_object_req_threadworker(void* arg);
-void* get_object_req_threadworker(void* arg);
+void* head_req_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* multi_head_req_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* delete_req_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* put_head_req_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* put_req_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* list_bucket_req_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* check_service_req_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* pre_multipart_upload_req_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* multipart_upload_part_req_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* complete_multipart_upload_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* abort_multipart_upload_req_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* multipart_put_head_req_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* parallel_get_object_req_threadworker(S3fsCurl& s3fscurl, void* arg);
+void* get_object_req_threadworker(S3fsCurl& s3fscurl, void* arg);
 
 //-------------------------------------------------------------------
 // Utility functions

--- a/src/threadpoolman.h
+++ b/src/threadpoolman.h
@@ -33,10 +33,12 @@
 //------------------------------------------------
 // Typedefs for functions and structures
 //------------------------------------------------
+class S3fsCurl;
+
 //
 // Prototype function
 //
-typedef void* (*thpoolman_worker)(void*);
+typedef void* (*thpoolman_worker)(S3fsCurl&, void*);
 
 //
 // Parameter structure

--- a/test/run_tests_using_sanitizers.sh
+++ b/test/run_tests_using_sanitizers.sh
@@ -49,7 +49,7 @@ ALL_TESTS=1 ASAN_OPTIONS='detect_leaks=1,detect_stack_use_after_return=1' make c
 make clean
 ./configure CXX=clang++ CXXFLAGS="$COMMON_FLAGS -fsanitize=thread"
 make --jobs="$(nproc)"
-ALL_TESTS=1 TSAN_OPTIONS='halt_on_error=1,suppressions=threadsanitizer_suppressions.txt' make check -C test/
+ALL_TESTS=1 TSAN_OPTIONS='halt_on_error=1' make check -C test/
 
 # run tests under UndefinedBehaviorSanitizer, https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
 make clean

--- a/test/threadsanitizer_suppressions.txt
+++ b/test/threadsanitizer_suppressions.txt
@@ -1,1 +1,0 @@
-race:OPENSSL_sk_free


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2600

### Details
This is the split PR Phase 8 (8/8) for #2600.

Added the `S3fsCurlShare` class which manages Curl Share handles.
This class manages Curl Share Handle for each Thread.

The retention(creation and management) of `S3fsCurl` objects has been moved to `ThreadPoolMan`'s worker thread management function.
As a result, the Handler(Callback) for each request does not retain the `S3fsCurl` object, but receives it as a parameter.

As a result, the Data Race issue has been resolved by managing the Curl Share Handle on a per-thread basis.
This re-enables `CURL_LOCK_DATA_SSL_SESSION`, which was disabled in #2601.
Last, I removed the threadsanitizer_suppressions.txt file that ignores DataRace, which was added in #2559, and reverted it.

This PR will be rebased and removed from draft status once the previous PR(#2607) is merged into master.