### PR TITLE
Remove explicit `std::string` constructors

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1551,7 +1551,7 @@ int FdEntity::RowFlushMultipart(PseudoFdInfo* pseudo_obj, const char* tpath)
 
             }else if(pagelist.Size() >= S3fsCurl::GetMultipartSize()){
                 // multipart uploading
-                result = multipart_upload_request((tpath ? std::string(tpath) : tmppath), tmporgmeta, physical_fd);
+                result = multipart_upload_request(tpath ? tpath : tmppath, tmporgmeta, physical_fd);
             }else{
                 // normal uploading (too small part size)
 
@@ -1693,7 +1693,7 @@ int FdEntity::RowFlushMixMultipart(PseudoFdInfo* pseudo_obj, const char* tpath)
                 }
 
                 // multipart uploading with copy api
-                result = mix_multipart_upload_request((tpath ? std::string(tpath) : tmppath), tmporgmeta, physical_fd, mixuppages);
+                result = mix_multipart_upload_request(tpath ? tpath : tmppath, tmporgmeta, physical_fd, mixuppages);
 
             }else{
                 // normal uploading (too small part size)

--- a/src/mpu_util.cpp
+++ b/src/mpu_util.cpp
@@ -86,7 +86,7 @@ static bool abort_incomp_mpu_list(const incomp_mpu_list_t& list, time_t abort_ti
             }
         }
 
-        if(0 != abort_multipart_upload_request(std::string(tpath), upload_id)){
+        if(0 != abort_multipart_upload_request(tpath, upload_id)){
             S3FS_PRN_EXIT("Failed to remove %s multipart uploading object.", tpath);
             result = false;
         }else{

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1001,7 +1001,7 @@ static int create_file_object(const char* path, mode_t mode, uid_t uid, gid_t gi
     meta["x-amz-meta-mtime"] = strnow;
 
     int result;
-    if(0 != (result = put_request(std::string(SAFESTRPTR(path)), meta, -1, true/* ahbe */))){
+    if(0 != (result = put_request(SAFESTRPTR(path), meta, -1, true/* ahbe */))){
         return result;
     }
     return 0;
@@ -1197,7 +1197,7 @@ static int s3fs_unlink(const char* _path)
         return result;
     }
 
-    if(0 != (result = delete_request(std::string(SAFESTRPTR(path))))){
+    if(0 != (result = delete_request(SAFESTRPTR(path)))){
         return result;
     }
 
@@ -1551,7 +1551,7 @@ static int rename_large_object(const char* from, const char* to)
         return result;
     }
 
-    if(0 != (result = multipart_put_head_request(std::string(from), std::string(to), buf.st_size, meta))){
+    if(0 != (result = multipart_put_head_request(from, to, buf.st_size, meta))){
         return result;
     }
 
@@ -3079,7 +3079,7 @@ static int readdir_multi_head(const char* path, const S3ObjList& head, void* buf
     // Make base path list.
     s3obj_list_t  headlist;
     head.GetNameList(headlist, true, false);                                        // get name with "/".
-    StatCache::getStatCacheData()->GetNotruncateCache(std::string(path), headlist); // Add notruncate file name from stat cache
+    StatCache::getStatCacheData()->GetNotruncateCache(path, headlist); // Add notruncate file name from stat cache
 
     // Initialize SyncFiller object
     SyncFiller syncfiller(buf, filler);
@@ -3276,7 +3276,7 @@ static int list_bucket(const char* path, S3ObjList& head, const char* delimiter,
         each_query += query_prefix;
 
         // send request
-        if(0 != (result = list_bucket_request(std::string(SAFESTRPTR(path)), each_query, responseBody))){
+        if(0 != (result = list_bucket_request(SAFESTRPTR(path), each_query, responseBody))){
             return result;
         }
 

--- a/src/s3fs_cred.cpp
+++ b/src/s3fs_cred.cpp
@@ -359,7 +359,7 @@ bool S3fsCred::GetIAMCredentialsURL(std::string& url, bool check_iam_role)
         //
         if(GetIMDSVersion() > 1){
             std::string token;
-            int result = get_iamv2api_token_request(std::string(S3fsCred::IAMv2_token_url), S3fsCred::IAMv2_token_ttl, std::string(S3fsCred::IAMv2_token_ttl_hdr), token);
+            int result = get_iamv2api_token_request(S3fsCred::IAMv2_token_url, S3fsCred::IAMv2_token_ttl, S3fsCred::IAMv2_token_ttl_hdr, token);
 
             if(-ENOENT == result){
                 // If we get a 404 back when requesting the token service,


### PR DESCRIPTION
`char *` automatically convert via the implicit `std::string` constructor.