### PR TITLE
change the way to get existing fdentity to optimize concurrent IO performance

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -641,10 +641,9 @@ FdEntity* FdManager::GetExistFdEntity(const char* path, int existfd)
       // no matter use_cache is enabled or not, search from all entities to 
       // find the entity with the same path. And then compare the pseudo fd.
       for(iter = fent.begin(); iter != fent.end(); ++iter) {
-        // path is protected by fd_manager_lock (RenamePath), therefore there 
-        // is no need to hold entity lock inside it (FindPseudoFd holds 
-        // lock inside).
-        if(iter->second && (iter->second->GetPathWithoutLock() == path)
+        // GetROPath() holds ro_path_lock rather than fdent_lock.
+        // Therefore GetExistFdEntity does not contends with FdEntity::Read() / Write().
+        if(iter->second && (iter->second->GetROPath() == path)
            && iter->second->FindPseudoFd(existfd)) {
           return iter->second.get();
         }

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -115,6 +115,7 @@ ino_t FdEntity::GetInode(int fd)
 //------------------------------------------------
 FdEntity::FdEntity(const char* tpath, const char* cpath) :
     path(SAFESTRPTR(tpath)),
+    ro_path(SAFESTRPTR(tpath)),
     physical_fd(-1), inode(0), size_orgmeta(0),
     cachepath(SAFESTRPTR(cpath)), pending_status(pending_status_t::NO_UPDATE_PENDING)
 {

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -115,9 +115,9 @@ ino_t FdEntity::GetInode(int fd)
 //------------------------------------------------
 FdEntity::FdEntity(const char* tpath, const char* cpath) :
     path(SAFESTRPTR(tpath)),
-    ro_path(SAFESTRPTR(tpath)),
     physical_fd(-1), inode(0), size_orgmeta(0),
-    cachepath(SAFESTRPTR(cpath)), pending_status(pending_status_t::NO_UPDATE_PENDING)
+    cachepath(SAFESTRPTR(cpath)), pending_status(pending_status_t::NO_UPDATE_PENDING),
+    ro_path(SAFESTRPTR(tpath))
 {
     holding_mtime.tv_sec = -1;
     holding_mtime.tv_nsec = 0;

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -131,6 +131,7 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
             const std::lock_guard<std::mutex> lock(fdent_lock);
             return (-1 != physical_fd);
         }
+
         bool FindPseudoFd(int fd) const {
             const std::lock_guard<std::mutex> lock(fdent_lock);
             return FindPseudoFdWithLock(fd);
@@ -154,6 +155,7 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
             const std::lock_guard<std::mutex> lock(fdent_lock);
             return path;
         }
+        std::string GetPathWithoutLock() const { return path; }
         bool RenamePath(const std::string& newpath, std::string& fentmapkey);
         int GetPhysicalFd() const REQUIRES(FdEntity::fdent_lock) { return physical_fd; }
         bool IsModified() const;

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -162,7 +162,6 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
             const std::lock_guard<std::mutex> lock(fdent_lock);
             return path;
         }
-        std::string GetPathWithoutLock() const { return path; }
         bool RenamePath(const std::string& newpath, std::string& fentmapkey);
         int GetPhysicalFd() const REQUIRES(FdEntity::fdent_lock) { return physical_fd; }
         bool IsModified() const;

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -134,7 +134,6 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
             const std::lock_guard<std::mutex> lock(fdent_lock);
             return (-1 != physical_fd);
         }
-
         bool FindPseudoFd(int fd) const {
             const std::lock_guard<std::mutex> lock(fdent_lock);
             return FindPseudoFdWithLock(fd);


### PR DESCRIPTION
<!-- --------------------------------------------------------------------------

--------------------------------------------------------------------------- -->

### Relevant Issue (if applicable)
https://github.com/s3fs-fuse/s3fs-fuse/issues/2617

### Details

Change the way to get existing fdentity to better conccurent IO's performance.
Instead of traversing the fent map and only compare the pseudo fd, which needs to hold every fdentity 's lock, I look for the fdentity with path at first and then verify the pseudo fd, which only needs to hold the right fdentity's lock.

I started 20 processes to read/write 500 files of 1MB in total concurrently. For ver 1.91, the RW performance is twice of that of the old code. And for ver 1.95, the performance is 20% better after this fix.

P.S. v1.95 performs worse than v1.91 (just half) according to my test (without this fix). This is another topic though. I will try to figure out the reason too and maybe you can also have a look into it.
