### PR TITLE
Fixed refactoring mistakes about loading IAM credentials

### DIFF
--- a/src/s3fs_cred.cpp
+++ b/src/s3fs_cred.cpp
@@ -452,6 +452,11 @@ bool S3fsCred::LoadIAMCredentials()
         S3FS_PRN_ERR("Something error occurred, could not set IAM credentials.");
         return false;
     }
+
+    if(!SetIAMCredentials(cred.c_str())){
+        S3FS_PRN_ERR("Something error occurred, could not set IAM role name.");
+        return false;
+    }
     return true;
 }
 
@@ -497,8 +502,6 @@ bool S3fsCred::LoadIAMRoleFromMetaData()
 
 bool S3fsCred::SetIAMCredentials(const char* response)
 {
-    const std::lock_guard<std::mutex> lock(token_lock);
-
     S3FS_PRN_INFO3("IAM credential response = \"%s\"", response);
 
     iamcredmap_t keyval;

--- a/src/s3fs_cred.h
+++ b/src/s3fs_cred.h
@@ -152,7 +152,7 @@ class S3fsCred
 
         bool GetIAMCredentialsURL(std::string& url, bool check_iam_role) REQUIRES(S3fsCred::token_lock);
         bool LoadIAMCredentials() REQUIRES(S3fsCred::token_lock);
-        bool SetIAMCredentials(const char* response);
+        bool SetIAMCredentials(const char* response) REQUIRES(S3fsCred::token_lock);
         bool SetIAMRoleFromMetaData(const char* response);
 
         bool SetExtCredLib(const char* arg);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2602
#2612

### Details
There was a mistake in the refactoring of #2602, so I fixed it.
The problem in issue #2612 is another reason in only v1.95, so it is different from this fix.
(The #2602 refactoring cleared the problem in v1.95, but it introduced this problem instead.)

