### PR TITLE
Added backup variable for fdcache entity path

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -163,6 +163,10 @@ void FdEntity::Clear()
     pagelist.Init(0, false, false);
     path      = "";
     cachepath = "";
+
+    // set backup(read only) variable
+    const std::lock_guard<std::mutex> ro_lock(ro_path_lock);
+    ro_path   = path;
 }
 
 // [NOTE]
@@ -722,6 +726,10 @@ bool FdEntity::RenamePath(const std::string& newpath, std::string& fentmapkey)
     }
     // set new path
     path = newpath;
+
+    // set backup(read only) variable
+    const std::lock_guard<std::mutex> ro_lock(ro_path_lock);
+    ro_path = path;
 
     return true;
 }

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -77,6 +77,9 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
         pending_status_t pending_status GUARDED_BY(fdent_data_lock);  // status for new file creation and meta update
         struct timespec  holding_mtime  GUARDED_BY(fdent_data_lock);  // if mtime is updated while the file is open, it is set time_t value
 
+        mutable std::mutex ro_path_lock;                              // for only the ro_path variable
+        std::string        ro_path      GUARDED_BY(ro_path_lock);     // holds the same value as "path". this is used as a backup(read-only variable) by special functions only.
+
     private:
         static int FillFile(int fd, unsigned char byte, off_t size, off_t start);
         static ino_t GetInode(int fd);
@@ -136,6 +139,10 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
             return FindPseudoFdWithLock(fd);
         }
         bool FindPseudoFdWithLock(int fd) const REQUIRES(FdEntity::fdent_lock);
+        std::string GetROPath() const {
+            const std::lock_guard<std::mutex> ro_lock(ro_path_lock);
+            return ro_path;
+        }
         int Open(const headers_t* pmeta, off_t size, const struct timespec& ts_mctime, int flags);
         bool LoadAll(int fd, off_t* size = nullptr, bool force_load = false);
         int Dup(int fd) {


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2623

### Details
This PR adds variables and methods for #2623.

To solve the problem of point out by #2623, the `FdEntity::path` variable needs to be available without locking for performance.
The `FdEntity::path` variable is protected by a lock(`FdEntity::fdent_lock`), but this lock is wide-ranging.
#2623 code should avoid this lock, but I propose this PR method instead of not locking.

I prepared a copy(backup for read only) variable of the `FdEntity::path` variable and prepared a lock(`FdEntity::ro_path_lock`) for only the `FdEntity::ro_path` variable.
This lock variable provides exclusive control only when the `FdEntity::path` variable is updated, so it provides the same functionality as not locking `FdEntity::fdent_lock`.
And I think the variable can be safely held.

@gaul
This process seems wasteful, but I think it is the best way to deal with #2623 at the moment.
Please give me your opinion.

