### PR TITLE
Updated to the new issue template workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'feature request'
+assignees: ''
+---
+
+### Feature request
+<!-- -------------------------------------------------------------
+Please let us know your ideas, such as features you want to improve,
+features to add, etc.
+And list any related Issue or Pull Request numbers.
+-------------------------------------------------------------- -->
+
+

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,10 +1,15 @@
+---
+name: Support request (Including bug reports)
+about: Request support for usage, bugs, etc.
+title: ''
+labels: ''
+assignees: ''
+---
+
 <!-- --------------------------------------------------------------------------
  The following information is very important in order to help us to help you.
  Omission of the following details may delay your support request or receive no
  attention at all.
- Keep in mind that the commands we provide to retrieve information are oriented
- to GNU/Linux Distributions, so you could need to use others if you use s3fs on
- macOS or BSD.
 --------------------------------------------------------------------------- -->
 
 ### Additional Information
@@ -37,4 +42,5 @@
 
 ### Details about issue
 <!-- Please describe the content of the issue in detail. -->
+
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Github no longer supports the old issue template, so I'm migrating to a new one.

In the new template, issues are divided into `support requests`(including bug reports) and `feature requests`.
For `feature request` templates, I added a `feature request` label. (Note: remove it if you don't need it.)

