### PR TITLE
Update COMPILATION.md

### DIFF
--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -64,7 +64,7 @@ Keep in mind using the pre-built packages when available.
 
 On Windows, use [MSYS2](https://www.msys2.org/) to compile for itself.
 
-1. Install [WinFsp](https://github.com/billziss-gh/winfsp) to your machine. Note it should be installed with developper mode to include header files.
+1. Install [WinFsp](https://github.com/billziss-gh/winfsp) to your machine. Note it should be installed with developer mode to include header files.
 2. Install dependencies onto MSYS2:
 
    ```sh

--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -64,7 +64,7 @@ Keep in mind using the pre-built packages when available.
 
 On Windows, use [MSYS2](https://www.msys2.org/) to compile for itself.
 
-1. Install [WinFsp](https://github.com/billziss-gh/winfsp) to your machine.
+1. Install [WinFsp](https://github.com/billziss-gh/winfsp) to your machine. Note it should be installed with developper mode to include header files.
 2. Install dependencies onto MSYS2:
 
    ```sh


### PR DESCRIPTION
add hint for windows compilation

<!-- --------------------------------------------------------------------------

--------------------------------------------------------------------------- -->

### Relevant Issue (if applicable)
<!-- If there are Issues related to this PullRequest, please list it. -->

### Details
<!-- Please describe the details of PullRequest. -->
If winfsp is installed without any manual set, it is to be without any 
header files needed by compilation of s3fs.
Add a hint for help.
