### PR TITLE
Fixed a logic in the multi head request retry count check

### DIFF
--- a/src/s3fs_threadreqs.cpp
+++ b/src/s3fs_threadreqs.cpp
@@ -61,18 +61,6 @@ void* multi_head_req_threadworker(S3fsCurl& s3fscurl, void* arg)
         return reinterpret_cast<void*>(-EIO);
     }
 
-    // Check retry max count and print debug message
-    {
-        const std::lock_guard<std::mutex> lock(*(pthparam->pthparam_lock));
-
-        S3FS_PRN_INFO3("Multi Head Request [filler=%p][thparam_lock=%p][retrycount=%d][notfound_list=%p][wtf8=%s][path=%s]", pthparam->psyncfiller, pthparam->pthparam_lock, *(pthparam->pretrycount), pthparam->pnotfound_list, pthparam->use_wtf8 ? "true" : "false", pthparam->path.c_str());
-
-        if(S3fsCurl::GetRetries() < *(pthparam->pretrycount)){
-            S3FS_PRN_ERR("Head request(%s) reached the maximum number of retry count(%d).", pthparam->path.c_str(), *(pthparam->pretrycount));
-            return reinterpret_cast<void*>(-EIO);
-        }
-    }
-
     s3fscurl.SetUseAhbe(false);
 
     // loop for head request
@@ -416,18 +404,6 @@ void* multipart_put_head_req_threadworker(S3fsCurl& s3fscurl, void* arg)
     std::unique_ptr<multipart_put_head_req_thparam> pthparam(static_cast<multipart_put_head_req_thparam*>(arg));
     if(!pthparam || !pthparam->ppartdata || !pthparam->pthparam_lock || !pthparam->pretrycount || !pthparam->presult){
         return reinterpret_cast<void*>(-EIO);
-    }
-
-    // Check retry max count and print debug message
-    {
-        const std::lock_guard<std::mutex> lock(*(pthparam->pthparam_lock));
-
-        S3FS_PRN_INFO3("Multipart Put Head Request [from=%s][to=%s][upload_id=%s][part_number=%d][filepart=%p][thparam_lock=%p][retrycount=%d][from=%s][to=%s]", pthparam->from.c_str(), pthparam->to.c_str(), pthparam->upload_id.c_str(), pthparam->part_number, pthparam->ppartdata, pthparam->pthparam_lock, *(pthparam->pretrycount), pthparam->from.c_str(), pthparam->to.c_str());
-
-        if(S3fsCurl::GetRetries() < *(pthparam->pretrycount)){
-            S3FS_PRN_ERR("Multipart Put Head request(%s->%s) reached the maximum number of retry count(%d).", pthparam->from.c_str(), pthparam->to.c_str(), *(pthparam->pretrycount));
-            return reinterpret_cast<void*>(-EIO);
-        }
     }
 
     s3fscurl.SetUseAhbe(true);


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Found an issue with checking the retry limit for multi head requests and multi put head requests.

When s3fs executes commands(such as ls) on a directory that contains multiple files and directories, head requests are processed in parallel as the multi head request.

Currently, the retry limit is set for all multiple head requests.
This limit prevents new head requests(after problem request) from being sent if the retry limit is reached while processing multiple head requests.

The problem is that if an object that cannot be read exists in the directory where user is trying to execute `ls` and the retry limit is reached, user will not be able to read some files or directories after reaching limit.

For example, if user execute `ls` on a directory with 100 files, if there is a file that has a reason to reach the retry limit, the result of the `ls` may be 80(example) files instead of 99.

To avoid this issue, in the case of a head request, it is necessary to allow one head request to be executed even if the retry limit is reached.
This can be avoided by deleting the first retry upper limit check in the `multi_head_req_threadworker()` and `multipart_put_head_req_threadworker()` functions.
(Previously, when we added the retry upper limit check for multi requests, but we did not take into consideration head requests like this case.)

A similar retry upper limit check is also performed in `parallel_get_object_req_threadworker()`, but since this is parallel execution of the upload process for one file, there is no problem with the current code.
