### PR TITLE
Remove Ubuntu 20.04 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
           - ubuntu:25.04
           - ubuntu:24.04
           - ubuntu:22.04
-          - ubuntu:20.04
           - debian:bookworm
           - debian:bullseye
           - rockylinux:9

--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -103,13 +103,6 @@ elif [ "${CONTAINER_FULLNAME}" = "ubuntu:22.04" ]; then
 
     INSTALL_PACKAGES="autoconf autotools-dev openjdk-21-jre-headless fuse jq libfuse-dev libcurl4-openssl-dev libxml2-dev locales-all mime-support libtool pkg-config libssl-dev attr curl python3-pip unzip"
 
-elif [ "${CONTAINER_FULLNAME}" = "ubuntu:20.04" ]; then
-    PACKAGE_MANAGER_BIN="apt-get"
-    PACKAGE_UPDATE_OPTIONS="update -y -qq"
-    PACKAGE_INSTALL_OPTIONS="install -y"
-
-    INSTALL_PACKAGES="autoconf autotools-dev openjdk-21-jre-headless fuse jq libfuse-dev libcurl4-openssl-dev libxml2-dev locales-all mime-support libtool pkg-config libssl-dev attr curl python3-pip unzip"
-
 elif [ "${CONTAINER_FULLNAME}" = "debian:bookworm" ]; then
     PACKAGE_MANAGER_BIN="apt-get"
     PACKAGE_UPDATE_OPTIONS="update -y -qq"


### PR DESCRIPTION
This is EOL:
https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare