### PR TITLE
Changed some INFO level log messages to DBG level

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2363,7 +2363,7 @@ bool S3fsCurl::insertV4Headers(const std::string& access_key_id, const std::stri
         return false;
     }
 
-    S3FS_PRN_INFO3("computing signature [%s] [%s] [%s] [%s]", op.c_str(), server_path.c_str(), query_string.c_str(), payload_hash.c_str());
+    S3FS_PRN_DBG("computing signature [%s] [%s] [%s] [%s]", op.c_str(), server_path.c_str(), query_string.c_str(), payload_hash.c_str());
     std::string strdate;
     std::string date8601;
     get_date_sigv3(strdate, date8601);

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -210,7 +210,7 @@ bool MakeUrlResource(const char* realpath, std::string& resourcepath, std::strin
 
 std::string prepare_url(const char* url)
 {
-    S3FS_PRN_INFO3("URL is %s", url);
+    S3FS_PRN_DBG("URL is %s", url);
 
     std::string uri;
     std::string hostname;
@@ -243,7 +243,7 @@ std::string prepare_url(const char* url)
 
     url_str = uri + hostname + path;
 
-    S3FS_PRN_INFO3("URL changed is %s", url_str.c_str());
+    S3FS_PRN_DBG("URL changed is %s", url_str.c_str());
 
     return url_str;
 }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3770,11 +3770,7 @@ static int s3fs_getxattr(const char* path, const char* name, char* value, size_t
 static int s3fs_getxattr(const char* path, const char* name, char* value, size_t size)
 #endif
 {
-#if defined(__APPLE__)
     FUSE_CTX_DBG("[path=%s][name=%s][value=%p][size=%zu]", path, name, value, size);
-#else
-    FUSE_CTX_INFO("[path=%s][name=%s][value=%p][size=%zu]", path, name, value, size);
-#endif
 
     if(!path || !name){
         return -EIO;


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Some message output levels have been changed from `INFO` to `DBG`.

The changed messages previously required the `INFO` level, but I have now determined that it is no longer necessary to have it at that level.
Also, by changing these message output levels, the execution time of Github Actions(`CI`) can be slightly reduced.

- s3fs_getxattr  
On MacOS, there are a large number of calls, so it is already at the `DBG` level.
On Linux systems, there are also a large number of calls, so we can change it to the `DBG` level.

- prepare_url  
This function rewrites the request URL, but this function is stable and does not need to be `INFO`, so we can change it.

- S3fsCurl::insertV4Headers  
Although this function makes a signature, we decided that there is always no need to check the contents when it is operating normally, so we can change it.
