### PR TITLE
Fixed the random string generation in test script for macos

### DIFF
--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -397,12 +397,10 @@ function make_random_string() {
     else
         local END_POS=8
     fi
-    if [ "$(uname)" = "Darwin" ]; then
-        local BASE64_OPT="--break=0"
-    else
-        local BASE64_OPT="--wrap=0"
-    fi
-    "${BASE64_BIN}" "${BASE64_OPT}" < /dev/urandom 2>/dev/null | tr -d /+ | head -c "${END_POS}"
+    local READ_SIZE=$((END_POS * 2))
+    local BASE64_OPT="--wrap=0"
+
+    head -c "${READ_SIZE}" < /dev/urandom | "${BASE64_BIN}" "${BASE64_OPT}" | tr -d '/+' | head -c "${END_POS}"
 
     return 0
 }


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
In the `make_random_string` function in the test script, the `gbase64` command and the `--break=0` option are used for macos, but an error occurs if not use `--wrap=0` instead of this option.(It is unclear when this has been the case.)
So I modified it to use `--wrap=0` for macos.
_(Note: `base64` can also be used in the macos runner of Github Actions, but this modification was not made.)_

I also modified the script a little so that the reading from `/dev/random` and the passing of data to `base64` (`gbase64`) do not result in unnecessary data.

Before changing the `make_random_string` function, the file name suffix was empty, which caused the `test_update_metadata_external_small_object` and `test_update_metadata_external_large_object` tests to fail.
_(but this is not the only reason for the failure.)_

I made this modification because the macos tests often failed.

