### PR TITLE
Create random string with date without /dev/urandom

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -463,7 +463,7 @@ function test_update_metadata_external_small_object() {
     # [NOTE]
     # Use the only filename in the test to avoid being affected by noobjcache.
     #
-    local TEST_FILE_EXT; TEST_FILE_EXT=$(make_random_string)
+    local TEST_FILE_EXT; TEST_FILE_EXT=$(make_dec_string_9)
     local TEST_CHMOD_FILE="${TEST_TEXT_FILE}_chmod.${TEST_FILE_EXT}"
     local TEST_CHOWN_FILE="${TEST_TEXT_FILE}_chown.${TEST_FILE_EXT}"
     local TEST_UTIMENS_FILE="${TEST_TEXT_FILE}_utimens.${TEST_FILE_EXT}"
@@ -527,7 +527,7 @@ function test_update_metadata_external_large_object() {
     # [NOTE]
     # Use the only filename in the test to avoid being affected by noobjcache.
     #
-    local TEST_FILE_EXT; TEST_FILE_EXT=$(make_random_string)
+    local TEST_FILE_EXT; TEST_FILE_EXT=$(make_dec_string_9)
     local TEST_CHMOD_FILE="${TEST_TEXT_FILE}_chmod.${TEST_FILE_EXT}"
     local TEST_CHOWN_FILE="${TEST_TEXT_FILE}_chown.${TEST_FILE_EXT}"
     local TEST_UTIMENS_FILE="${TEST_TEXT_FILE}_utimens.${TEST_FILE_EXT}"

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -401,14 +401,14 @@ function wait_for_port() {
     done
 }
 
-function make_random_string() {
-    if [ -n "$1" ]; then
-        local END_POS="$1"
-    else
-        local END_POS=8
-    fi
-    LC_ALL=C tr -cd A-Za-z0-9 < /dev/urandom | head -c "${END_POS}"
-
+# [NOTE][FIXME]
+# Makes <sec>.<nano sec>(ex. 1750690134.308 553 074) and returns nine decimal
+# digits from last three digits of seconds and microseconds.
+# This is a function instead of using /dev/urandom.
+# See the PR(Issue) for more details.
+#
+function make_dec_string_9() {
+    date +%s%N | cut -c 8-16
     return 0
 }
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2687

### Details
In the function for adding suffixes to test file names, I changed it so that it does not use `/dev/urandom`, but uses a random string using seconds and microseconds from the `date` command.

#### Why was this necessary?
I did not understand the root cause of this.
However, it seems that the phenomenon is related to `/dev/urandom` used in the `make_random_string` test utility function for MacOS.

In order to proceed with the problem phenomenon #2687, I was investigating the test results of `test_update_metadata_external_small(large)_object`.
And I found an abnormal slowdown in processing speed that sometimes occurred on MacOS.
This was caused by processing being blocked in the following part.
```
TEST_FILE_EXT=$(make_random_string)
```
I tried many things such as changing the way the `make_random_string` function is called, but as long as `/dev/urandom` is used, this problem continues to occur.
In particular, when running Github Actions (CI) with `dbglevel=dbg`, the blocking is noticeable.
_The block mentioned here means that the s3fs-fuse test script is blocked from running._

While this is blocked, s3fs-fuse periodically references the `/` and `/test-XXXX` directories.
_(For example, `s3fs_getattrs` called by `macos-fuse-t`.)_

#### About the solution
The fundamental solution to this problem is still unknown.
This is a very strange and difficult problem to understand.
But we need to avoid blocking work that was not essential to our tests, so I change it to not access `/dev/urandom` as a simple solution.

If possible, it would be a good idea to try only the above test cases at dbg level on MacOS.
I would also like some advice on this matter.

##### Note
This problem is blocking #2687.

