### PR TITLE
Simplify temporary file creation via `mktemp`

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -463,7 +463,7 @@ function test_update_metadata_external_small_object() {
     # [NOTE]
     # Use the only filename in the test to avoid being affected by noobjcache.
     #
-    local TEST_FILE_EXT; TEST_FILE_EXT=$(make_random_string)
+    local TEST_FILE_EXT; TEST_FILE_EXT=$(mktemp "XXXXXXXXXX")
     local TEST_CHMOD_FILE="${TEST_TEXT_FILE}_chmod.${TEST_FILE_EXT}"
     local TEST_CHOWN_FILE="${TEST_TEXT_FILE}_chown.${TEST_FILE_EXT}"
     local TEST_UTIMENS_FILE="${TEST_TEXT_FILE}_utimens.${TEST_FILE_EXT}"
@@ -527,7 +527,7 @@ function test_update_metadata_external_large_object() {
     # [NOTE]
     # Use the only filename in the test to avoid being affected by noobjcache.
     #
-    local TEST_FILE_EXT; TEST_FILE_EXT=$(make_random_string)
+    local TEST_FILE_EXT; TEST_FILE_EXT=$(mktemp "XXXXXXXXXX")
     local TEST_CHMOD_FILE="${TEST_TEXT_FILE}_chmod.${TEST_FILE_EXT}"
     local TEST_CHOWN_FILE="${TEST_TEXT_FILE}_chown.${TEST_FILE_EXT}"
     local TEST_UTIMENS_FILE="${TEST_TEXT_FILE}_utimens.${TEST_FILE_EXT}"

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -401,17 +401,6 @@ function wait_for_port() {
     done
 }
 
-function make_random_string() {
-    if [ -n "$1" ]; then
-        local END_POS="$1"
-    else
-        local END_POS=8
-    fi
-    LC_ALL=C tr -cd A-Za-z0-9 < /dev/urandom | head -c "${END_POS}"
-
-    return 0
-}
-
 function s3fs_args() {
     if [ "$(uname)" = "Darwin" ]; then
         ps -o args -p "${S3FS_PID}" | tail -n +2


### PR DESCRIPTION
Previously this used `/dev/urandom` does not guarantee uniqueness and sometimes blocked on macOS.  References #2690.