### PR TITLE
Remove unneeded x-prefix in comparisons

### DIFF
--- a/test/filter-suite-log.sh
+++ b/test/filter-suite-log.sh
@@ -36,9 +36,9 @@ SUITELOG="${TOPDIR}/test-suite.log"
 TMP_LINENO_FILE="/tmp/.lineno.tmp"
 
 while [ $# -ne 0 ]; do
-    if [ "X$1" = "X" ]; then
+    if [ "$1" = "" ]; then
         break
-    elif [ "X$1" = "X-h" ] || [ "X$1" = "X-H" ] || [ "X$1" = "X--help" ] || [ "X$1" = "X--HELP" ]; then
+    elif [ "$1" = "-h" ] || [ "$1" = "-H" ] || [ "$1" = "--help" ] || [ "$1" = "--HELP" ]; then
         func_usage "${PRGNAME}"
         exit 0
     else

--- a/test/mergedir.sh
+++ b/test/mergedir.sh
@@ -47,15 +47,15 @@ ALLYES="no"
 DIRPARAM=""
 
 while [ "$1" != "" ]; do
-    if [ "X$1" = "X-help" ] || [ "X$1" = "X-h" ] || [ "X$1" = "X-H" ]; then
+    if [ "$1" = "-help" ] || [ "$1" = "-h" ] || [ "$1" = "-H" ]; then
         UsageFunction "${OWNNAME}"
         exit 0
-    elif [ "X$1" = "X-y" ] || [ "X$1" = "X-Y" ]; then
+    elif [ "$1" = "-y" ] || [ "$1" = "-Y" ]; then
         AUTOYES="yes"
-    elif [ "X$1" = "X-all" ] || [ "X$1" = "X-ALL" ]; then
+    elif [ "$1" = "-all" ] || [ "$1" = "-ALL" ]; then
         ALLYES="yes"
     else
-        if [ "X$DIRPARAM" != "X" ]; then
+        if [ "$DIRPARAM" != "" ]; then
             echo "*** Input error."
             echo ""
             UsageFunction "${OWNNAME}"
@@ -65,7 +65,7 @@ while [ "$1" != "" ]; do
     fi
     shift
 done
-if [ "X$DIRPARAM" = "X" ]; then
+if [ "$DIRPARAM" = "" ]; then
     echo "*** Input error."
     echo ""
     UsageFunction "${OWNNAME}"
@@ -138,11 +138,11 @@ for DIR in $DIRLIST; do
     if [ "${AUTOYES}" = "yes" ]; then
         ANSWER="y"
     fi
-    while [ "X${ANSWER}" != "XY" ] && [ "X${ANSWER}" != "Xy" ] && [ "X${ANSWER}" != "XN" ] && [ "X${ANSWER}" != "Xn" ]; do
+    while [ "${ANSWER}" != "Y" ] && [ "${ANSWER}" != "y" ] && [ "${ANSWER}" != "N" ] && [ "${ANSWER}" != "n" ]; do
         printf "%s" "Do you merge ${DIR} ? (y/n): "
         read -r ANSWER
     done
-    if [ "X${ANSWER}" != "XY" ] && [ "X${ANSWER}" != "Xy" ]; then
+    if [ "${ANSWER}" != "Y" ] && [ "${ANSWER}" != "y" ]; then
         continue
     fi
 

--- a/test/sample_delcache.sh
+++ b/test/sample_delcache.sh
@@ -48,11 +48,11 @@ func_usage()
 
 PRGNAME=$(basename "$0")
 
-if [ "X$1" = "X-h" ] || [ "X$1" = "X-H" ]; then
+if [ "$1" = "-h" ] || [ "$1" = "-H" ]; then
     func_usage "${PRGNAME}"
     exit 0
 fi
-if [ "X$1" = "X" ] || [ "X$2" = "X" ] || [ "X$3" = "X" ]; then
+if [ "$1" = "" ] || [ "$2" = "" ] || [ "$3" = "" ]; then
     func_usage "${PRGNAME}"
     exit 1
 fi
@@ -61,7 +61,7 @@ BUCKET="$1"
 CDIR="$2"
 LIMIT="$3"
 SILENT=0
-if [ "X$4" = "X-silent" ]; then
+if [ "$4" = "-silent" ]; then
     SILENT=1
 fi
 FILES_CDIR="${CDIR}/${BUCKET}"


### PR DESCRIPTION
Found via shellcheck.  Reference:

https://www.shellcheck.net/wiki/SC2268