### PR TITLE
Added DirStatCache::GetChildLeafNameHasLock method

### DIFF
--- a/src/cache_node.h
+++ b/src/cache_node.h
@@ -265,6 +265,8 @@ class DirStatCache : public StatCacheNode
 
         bool TruncateCacheHasLock() override REQUIRES(StatCacheNode::cache_lock);
 
+        bool GetChildLeafNameHasLock(const std::string& strpath, std::string& strLeafName, bool& hasNestedChildren) REQUIRES(StatCacheNode::cache_lock);
+
         void DumpHasLock(const std::string& indent, bool detail, std::ostringstream& oss) override REQUIRES(StatCacheNode::cache_lock);
 
     public:


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Common processing in several methods in `DirStatCache` class has been consolidated into the `DirStatCache::GetChildLeafNameHasLock` method.
Also, confusing variable names have been changed.

_This PR is one in a series of feature enhancements using the Stat Cache. (The PRs have been separated into smaller sections.)_

