### PR TITLE
Fixed Stat cache expire check processing

### DIFF
--- a/src/cache_node.h
+++ b/src/cache_node.h
@@ -253,6 +253,7 @@ class DirStatCache : public StatCacheNode
         bool ClearHasLock() override REQUIRES(StatCacheNode::cache_lock);
         bool RemoveChildHasLock(const std::string& strpath) override REQUIRES(StatCacheNode::cache_lock);
         bool isRemovableHasLock() override REQUIRES(StatCacheNode::cache_lock);
+        bool HasExistedChildHasLock() REQUIRES(StatCacheNode::cache_lock, dir_cache_lock);
 
         bool AddHasLock(const std::string& strpath, const struct stat* pstat, const headers_t* pmeta, objtype_t type, bool is_notruncate) override REQUIRES(StatCacheNode::cache_lock);
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2707

### Details
There was problem in the process of checking whether stat cache was available for cash out, which has been fixed.
(There were cases where cash out was not possible when negative cache was present.)

_This PR is one in a series of enhancements using Stat Cache following #2707. (The PRs have been separated into smaller PRs.)_