### PR TITLE
Fixed CacheFileStat to force a sync when a file is changed

### DIFF
--- a/src/fdcache_page.cpp
+++ b/src/fdcache_page.cpp
@@ -845,7 +845,10 @@ bool PageList::Serialize(CacheFileStat& file, ino_t inode)
         S3FS_PRN_ERR("failed to write stats(%d)", errno);
         return false;
     }
-
+    if(0 != fsync(file.GetFd())){
+        S3FS_PRN_ERR("failed to sync stats(%d), but continue...", errno);
+        return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2709

### Details
Stats information for FileCache files is now always synced when updated.
For the cause and solution, see #2709.

