### PR TITLE
Add S3 operation performance counters

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -21,6 +21,7 @@
 #ifndef S3FS_COMMON_H_
 #define S3FS_COMMON_H_
 
+#include <atomic>
 #include <string>
 #include <sys/types.h>
 
@@ -45,6 +46,17 @@ extern std::string    mount_prefix;
 extern std::string    region;
 extern std::string    cipher_suites;
 extern std::string    instance_name;
+
+extern std::atomic<long long unsigned> num_requests_head_object;
+extern std::atomic<long long unsigned> num_requests_put_object;
+extern std::atomic<long long unsigned> num_requests_get_object;
+extern std::atomic<long long unsigned> num_requests_delete_object;
+extern std::atomic<long long unsigned> num_requests_list_bucket;
+extern std::atomic<long long unsigned> num_requests_mpu_initiate;
+extern std::atomic<long long unsigned> num_requests_mpu_complete;
+extern std::atomic<long long unsigned> num_requests_mpu_abort;
+extern std::atomic<long long unsigned> num_requests_mpu_upload_part;
+extern std::atomic<long long unsigned> num_requests_mpu_copy_part;
 
 //-------------------------------------------------------------------
 // For weak attribute

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2473,6 +2473,7 @@ int S3fsCurl::DeleteRequest(const char* tpath)
 
     op = "DELETE";
     type = REQTYPE::DELETE;
+    ++num_requests_delete_object;
 
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
         return -EIO;
@@ -2767,6 +2768,7 @@ bool S3fsCurl::PreHeadRequest(const char* tpath, size_t ssekey_pos)
 
     op = "HEAD";
     type = REQTYPE::HEAD;
+    ++num_requests_head_object;
 
     // set lazy function
     fpLazySetup = PreHeadRequestSetCurlOpts;
@@ -2889,6 +2891,7 @@ int S3fsCurl::PutHeadRequest(const char* tpath, const headers_t& meta, bool is_c
 
     op = "PUT";
     type = REQTYPE::PUTHEAD;
+    ++num_requests_head_object;
 
     // setopt
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
@@ -3019,6 +3022,7 @@ int S3fsCurl::PutRequest(const char* tpath, headers_t& meta, int fd)
 
     op = "PUT";
     type = REQTYPE::PUT;
+    ++num_requests_put_object;
 
     // setopt
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
@@ -3090,6 +3094,7 @@ int S3fsCurl::PreGetObjectRequest(const char* tpath, int fd, off_t start, off_t 
 
     op = "GET";
     type = REQTYPE::GET;
+    ++num_requests_get_object;
 
     // set lazy function
     fpLazySetup = PreGetObjectRequestSetCurlOpts;
@@ -3243,6 +3248,7 @@ int S3fsCurl::ListBucketRequest(const char* tpath, const char* query)
 
     op = "GET";
     type = REQTYPE::LISTBUCKET;
+    ++num_requests_list_bucket;
 
     // setopt
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
@@ -3267,7 +3273,7 @@ int S3fsCurl::ListBucketRequest(const char* tpath, const char* query)
 }
 
 //
-// Initialize multipart upload
+// Initiate multipart upload
 //
 // Example :
 //   POST /example-object?uploads HTTP/1.1
@@ -3338,6 +3344,7 @@ int S3fsCurl::PreMultipartUploadRequest(const char* tpath, const headers_t& meta
 
     op = "POST";
     type = REQTYPE::PREMULTIPOST;
+    ++num_requests_mpu_initiate;
 
     // setopt
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
@@ -3496,6 +3503,7 @@ int S3fsCurl::MultipartUploadComplete(const char* tpath, const std::string& uplo
 
     op = "POST";
     type = REQTYPE::COMPLETEMULTIPOST;
+    ++num_requests_mpu_complete;
 
     // setopt
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
@@ -3613,6 +3621,7 @@ int S3fsCurl::AbortMultipartUpload(const char* tpath, const std::string& upload_
 
     op = "DELETE";
     type = REQTYPE::ABORTMULTIUPLOAD;
+    ++num_requests_mpu_abort;
 
     if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_URL, url.c_str())){
         return -EIO;
@@ -3694,6 +3703,7 @@ int S3fsCurl::MultipartUploadContentPartSetup(const char* tpath, int part_num, c
 
     op = "PUT";
     type = REQTYPE::UPLOADMULTIPOST;
+    ++num_requests_mpu_upload_part;
 
     // set lazy function
     fpLazySetup = MultipartUploadPartSetCurlOpts;
@@ -3757,6 +3767,7 @@ int S3fsCurl::MultipartUploadCopyPartSetup(const char* from, const char* to, int
 
     op = "PUT";
     type = REQTYPE::COPYMULTIPOST;
+    ++num_requests_mpu_copy_part;
 
     // set lazy function
     fpLazySetup = CopyMultipartUploadSetCurlOpts;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -5927,6 +5927,17 @@ int main(int argc, char* argv[])
     // cleanup xml2
     xmlCleanupParser();
 
+    S3FS_PRN_DBG("Number of head object requests: %llu", num_requests_head_object.load());
+    S3FS_PRN_DBG("Number of put object requests: %llu", num_requests_put_object.load());
+    S3FS_PRN_DBG("Number of get object requests: %llu", num_requests_get_object.load());
+    S3FS_PRN_DBG("Number of delete object requests: %llu", num_requests_delete_object.load());
+    S3FS_PRN_DBG("Number of list bucket requests: %llu", num_requests_list_bucket.load());
+    S3FS_PRN_DBG("Number of initiate MPU requests: %llu", num_requests_mpu_initiate.load());
+    S3FS_PRN_DBG("Number of complete MPU requests: %llu", num_requests_mpu_complete.load());
+    S3FS_PRN_DBG("Number of abort MPU requests: %llu", num_requests_mpu_abort.load());
+    S3FS_PRN_DBG("Number of upload MPU part requests: %llu", num_requests_mpu_upload_part.load());
+    S3FS_PRN_DBG("Number of copy MPU part requests: %llu", num_requests_mpu_copy_part.load());
+
     exit(fuse_res);
 }
 

--- a/src/s3fs_global.cpp
+++ b/src/s3fs_global.cpp
@@ -37,6 +37,17 @@ std::string region                = "us-east-1";
 std::string cipher_suites;
 std::string instance_name;
 
+std::atomic<long long unsigned> num_requests_head_object;
+std::atomic<long long unsigned> num_requests_put_object;
+std::atomic<long long unsigned> num_requests_get_object;
+std::atomic<long long unsigned> num_requests_delete_object;
+std::atomic<long long unsigned> num_requests_list_bucket;
+std::atomic<long long unsigned> num_requests_mpu_initiate;
+std::atomic<long long unsigned> num_requests_mpu_complete;
+std::atomic<long long unsigned> num_requests_mpu_abort;
+std::atomic<long long unsigned> num_requests_mpu_upload_part;
+std::atomic<long long unsigned> num_requests_mpu_copy_part;
+
 /*
 * Local variables:
 * tab-width: 4


### PR DESCRIPTION
These can be used to evaluate changes like #2707.  Ideally tests could assert how many operations they expect although this will require a localhost HTTP server.