### PR TITLE
Changed to use rename when serializing to FileCacheStat

### DIFF
--- a/src/fdcache_page.h
+++ b/src/fdcache_page.h
@@ -94,7 +94,7 @@ class PageList
 
         void Clear();
         bool Parse(off_t new_pos);
-        bool Serialize(CacheFileStat& file, ino_t inode);
+        bool Serialize(const CacheFileStat& file, ino_t inode) const;
 
     public:
         static void FreeList(fdpage_list_t& list);

--- a/src/fdcache_stat.h
+++ b/src/fdcache_stat.h
@@ -56,6 +56,7 @@ class CacheFileStat
         bool Release();
         bool SetPath(const char* tpath, bool is_open = true);
         int GetFd() const { return fd; }
+        bool OverWriteFile(const std::string& strall) const;
 };
 
 #endif // S3FS_FDCACHE_STAT_H_

--- a/src/test_page_list.cpp
+++ b/src/test_page_list.cpp
@@ -22,7 +22,8 @@
 #include "fdcache_stat.h"
 #include "test_util.h"
 
-bool CacheFileStat::Open() { return false; }  // NOLINT(readability-convert-member-functions-to-static)
+bool CacheFileStat::Open() { return false; }                                            // NOLINT(readability-convert-member-functions-to-static)
+bool CacheFileStat::OverWriteFile(const std::string& strall) const { return false; }    // NOLINT(readability-convert-member-functions-to-static)
 
 void test_compress()
 {


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2709

### Details
Changed `PageList::Serialize()` to use `flock` to exclusively handle `ftruncate`->`pwrite` operations.
This fixes a bug reported in https://github.com/s3fs-fuse/s3fs-fuse/issues/2709#issuecomment-3226548346.

