### PR TITLE
Fixed test_external_modification test for MacOS

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -403,7 +403,14 @@ function test_external_modification {
     # cache will be read out.
     # Therefore, we need to wait over 1 second here.
     #
+    # In particular, on MacOS, getattrs may be called after a file is
+    # uploaded(released).
+    # This extends the expiration date of the target file(1 sec by
+    # stat_cache_interval_expire option).
+    # Therefore, on MacOS, you need to add an additional 1 sec.
+    #
     sleep 1
+    wait_ostype 1 "Darwin"
 
     local OBJECT_NAME; OBJECT_NAME=$(basename "${PWD}")/"${TEST_TEXT_FILE}"
     echo "new new" | s3_cp "${TEST_BUCKET_1}/${OBJECT_NAME}"


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
In a recent CI(GHA) run, the `test_external_modification` test on macOS often failed.
I investigated the cause and have now found it, so I posted this PR.

The cause was a difference in the way `getattr` calls are made from FUSE on macOS and other Linuxs.
In the `test_external_modification` test, after uploading a file, it waits one second(while the file contents are modified by external process) and then reads it.
On other Linuxs, there is no `getattr` call after uploading, but on macOS, the `getattr` call is made.

The `stat_cache_interval_expire=1` option was set for s3fs when the test was run, so if the cache is accessed via a `getattr` call within the cache expiration period, the expiration period is extended.
For this reason, the `getattr` call is made on macOS, and waiting 1 second will still be within the cache expiration period.

To avoid this, added an additional 1-second sleep on macOS.

