### PR TITLE
Added a flag to prevent stats cache expiration checks

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1231,6 +1231,9 @@ static int s3fs_mkdir(const char* _path, mode_t mode)
         return -EIO;
     }
 
+    // keep stat cache without checking expiration
+    PreventStatCacheExpire nocacheexpire;
+
     // check parent directory attribute.
     if(0 != (result = check_parent_object_access(path, W_OK | X_OK))){
         return result;
@@ -1321,6 +1324,9 @@ static int s3fs_rmdir(const char* _path)
     objtype_t   ObjType;
 
     FUSE_CTX_INFO("[path=%s]", path);
+
+    // keep stat cache without checking expiration
+    PreventStatCacheExpire nocacheexpire;
 
     if(0 != (result = check_parent_object_access(path, W_OK | X_OK))){
         return result;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2729

### Details
A flag has been added to prevent StatCache expiration checks.
This flag will be incorporated into several places in the future.
For now, it has been incorporated into mkdir/rmdir, which is the part that will be least affected (the part that will be least affected by the fix).

