### PR TITLE
Improved stat cache to include ListBucket results

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -101,11 +101,13 @@ class StatCache
         {
             return GetStat(key, nullptr, nullptr, nullptr, petag);
         }
+        bool GetS3ObjList(const std::string& key, S3ObjList& list);
 
         // Add stat cache
         bool AddStat(const std::string& key, const struct stat& stbuf, const headers_t& meta, objtype_t type, bool notruncate = false);
         bool AddStat(const std::string& key, const struct stat& stbuf, objtype_t type, bool notruncate = false);
         bool AddNegativeStat(const std::string& key);
+        bool AddS3ObjList(const std::string& key, const S3ObjList& list);
 
         // Update meta stats
         bool UpdateStat(const std::string& key, const struct stat& stbuf, const headers_t& meta);

--- a/src/s3objlist.h
+++ b/src/s3objlist.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <sstream>
 
 #include "types.h"
 
@@ -70,6 +71,9 @@ class S3ObjList
         bool GetNameList(s3obj_list_t& list, bool OnlyNormalized = true, bool CutSlash = true) const;
         bool GetNameMap(s3obj_type_map_t& objmap, bool OnlyNormalized = true, bool CutSlash = true) const;
         bool GetLastName(std::string& lastname) const;
+        bool HasName(const std::string& strName);
+        bool Remove(const std::string& strName);
+        void Dump(const std::string& indent, std::ostringstream& oss) const;
 
         static bool MakeHierarchizedList(s3obj_list_t& list, bool haveSlash);
 };


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2730

### Details
The S3ObjList resulting from temporary parsing of ListBucket results can now be cached in StatCache.
This reduces ListBucket requests.

For reference, a comparison of the number of requests between the base code in #2730 and this one is shown below.
(Compare the results of running `small-integration-test.sh`.)

| Branch     | Result  |
| ---------- | ------- |
| #2730 code | Number of head object requests: 4294<br> Number of put object requests: 616<br> Number of get object requests: 162<br> Number of delete object requests: 575<br> Number of list bucket requests: 2059<br> Number of initiate MPU requests: 104<br> Number of complete MPU requests: 104<br> Number of abort MPU requests: 0<br> Number of upload MPU part requests: 141<br> Number of copy MPU part requests: 76 |
| this PR    | Number of head object requests: 4286<br> Number of put object requests: 620<br> Number of get object requests: 153<br> Number of delete object requests: 575<br> Number of list bucket requests: 1749<br> Number of initiate MPU requests: 98<br> Number of complete MPU requests: 98<br> Number of abort MPU requests: 0<br> Number of upload MPU part requests: 133<br> Number of copy MPU part requests: 63   |

