### PR TITLE
Fixed to not call xmlReadMemory if data length is 0

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3586,6 +3586,16 @@ static int list_bucket(const char* path, S3ObjList& head, const char* delimiter,
         //
         std::string encbody = get_encoded_cr_code(responseBody.c_str());
 
+        // [NOTE]
+        // If encbody is empty, xmlReadMemory will output the message
+        // ":1: parser error : Document is empty" to stderr.
+        // Make sure encbody is not empty beforehand.
+        //
+        if(encbody.empty()){
+            S3FS_PRN_ERR("The data length passed to xmlReadMemory is 0.");
+            return -EIO;
+        }
+
         // xmlDocPtr
         std::unique_ptr<xmlDoc, decltype(&xmlFreeDoc)> doc(xmlReadMemory(encbody.c_str(), static_cast<int>(encbody.size()), "", nullptr, 0), xmlFreeDoc);
         if(nullptr == doc){

--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -451,11 +451,16 @@ bool simple_parse_xml(const char* data, size_t len, const char* key, std::string
 {
     bool result = false;
 
-    if(!data || !key){
+    if(!data || !key || 0 == len){
         return false;
     }
     value.clear();
 
+    // [NOTE]
+    // If data is not nullptr and len is 0, this function will output the message
+    // ":1: parser error : Document is empty" to stderr.
+    // Make sure len is not 0 beforehand.
+    //
     std::unique_ptr<xmlDoc, decltype(&xmlFreeDoc)> doc(xmlReadMemory(data, static_cast<int>(len), "", nullptr, 0), xmlFreeDoc);
     if(nullptr == doc){
         return false;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2738 #2737

### Details
The error `:1: parser error: Document is empty` may be output to stderr.
This occurs when calling the following function:
```
xmlDoc* xmlReadMemory(const char *buffer, int size, const char *URL, const char *encoding, int options)
```
This error is output when buffer is not nullptr and size is 0. (xmlDoc* returns nullptr.)
Therefore, we now check whether the data length is 0 before calling this function.

_This fix is ​​not a workaround for the current CI test failures in Ubuntu 25.10 and other releases._

