### PR TITLE
Improved handling of XML parser errors

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3597,9 +3597,16 @@ static int list_bucket(const char* path, S3ObjList& head, const char* delimiter,
         }
 
         // xmlDocPtr
+        s3fsXmlBufferParserError parserError;
+        parserError.SetXmlParseError();
+
         std::unique_ptr<xmlDoc, decltype(&xmlFreeDoc)> doc(xmlReadMemory(encbody.c_str(), static_cast<int>(encbody.size()), "", nullptr, 0), xmlFreeDoc);
         if(nullptr == doc){
-            S3FS_PRN_ERR("xmlReadMemory returns with error.");
+            if(parserError.IsXmlParseError()){
+                S3FS_PRN_ERR("xmlReadMemory returns with error: %s", parserError.GetXmlParseError().c_str());
+            }else{
+                S3FS_PRN_ERR("xmlReadMemory returns with error.");
+            }
             return -EIO;
         }
         if(0 != append_objects_from_xml(path, doc.get(), head)){

--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -461,8 +461,16 @@ bool simple_parse_xml(const char* data, size_t len, const char* key, std::string
     // ":1: parser error : Document is empty" to stderr.
     // Make sure len is not 0 beforehand.
     //
+    s3fsXmlBufferParserError parserError;
+    parserError.SetXmlParseError();
+
     std::unique_ptr<xmlDoc, decltype(&xmlFreeDoc)> doc(xmlReadMemory(data, static_cast<int>(len), "", nullptr, 0), xmlFreeDoc);
     if(nullptr == doc){
+        if(parserError.IsXmlParseError()){
+            S3FS_PRN_ERR("xmlReadMemory returns with error: %s", parserError.GetXmlParseError().c_str());
+        }else{
+            S3FS_PRN_ERR("xmlReadMemory returns with error.");
+        }
         return false;
     }
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2740 #2739

### Details
XML parsing errors that occur when calling `xmlReadMemory` are output to stderr, so I've changed it so that these are handled by s3fs.
This allows the error content to be treated as an s3fs error.


