### PR TITLE
Change CI test macos from macos-13 to macos-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,15 @@ jobs:
   #   This job doesn't work with GitHub Actions using macOS 11+ because "load_osxfuse" returns
   #   "exit code = 1".(requires OS reboot)
   #
-  macos-13:
-    runs-on: macos-13
+  macos-14:
+    runs-on: macos-14
+
+    # [NOTE]
+    # In macos-14 (and maybe later), the location of the CA certificate is different and you need to specify it.
+    # We give the CA path as an environment variable.
+    #
+    env:
+        CURL_CA_BUNDLE: "/opt/homebrew/etc/ca-certificates/cert.pem"
 
     steps:
       - name: Checkout source code
@@ -132,6 +139,7 @@ jobs:
 
       - name: Install fuse-t
         run: |
+          if [ ! -d /usr/local/include ]; then sudo mkdir -p /usr/local/include; echo "Created /usr/local/include directory"; fi
           HOMEBREW_NO_AUTO_UPDATE=1 brew install fuse-t
 
       - name: Install brew other packages

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -58,7 +58,18 @@ export LC_ALL=en_US.UTF-8
 # Set your PATH appropriately so that you can find these commands.
 #
 if [ "$(uname)" = "Darwin" ]; then
-    export STDBUF_BIN="gstdbuf"
+    # [NOTE][TODO]
+    # In macos-14(and maybe later), currently coreutils' gstdbuf doesn't
+    # work with the Github Actions Runner.
+    # This is because libstdbuf.so is arm64, when arm64e is required.
+    # To resolve this case, we'll avoid making calls to stdbuf. This can
+    # result in mixed log output, but there is currently no workaround.
+    #
+    if lipo -archs /opt/homebrew/Cellar/coreutils/9.8/libexec/coreutils/libstdbuf.so 2>/dev/null | grep -q 'arm64e'; then
+        export STDBUF_BIN="gstdbuf"
+    else
+        export STDBUF_BIN=""
+    fi
     export TRUNCATE_BIN="gtruncate"
     export SED_BIN="gsed"
 else


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2747

### Details
I've updated GitHub Actions to use macos-14.

I encountered a few issues when using macos-14.
#### (1) CA Certificate
The path to the CA certificate is different from macos-13.
Therefore, the path to this CA certificate needs to be passed to s3fs (and curl).
I defined this as the environment variable `CURL_CA_BUNDLE` in ci.yml and passed it to the macos job.

#### (2) gstdbuf
In the macos-14 environment for GitHub Actions, it appears that `arm64e` is required for DSO calls.
The following error message is displayed when trying to run `gstdbuf`:
```
dyld[41023]: tried: '/opt/homebrew/Cellar/coreutils/9.8/libexec/coreutils/libstdbuf.so' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e')), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/coreutils/9.8/libexec/coreutils/libstdbuf.so' (no such file), '/opt/homebrew/Cellar/coreutils/9.8/libexec/coreutils/libstdbuf.so' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e'))
```
`libstdbuf.so` is `arm64`, and linking fails.
This can be confirmed with the following command:
```
$ lipo -archs /opt/homebrew/Cellar/coreutils/9.8/libexec/coreutils/libstdbuf.so
arm64
```
I checked coreutils and found that `arm64e` is not currently available.

Therefore, for macos-14, I modified it so that `gstdbuf` is not used.
(I believe there is no other way. I have used this workaround in the past.)
This causes some log clutter, but it does not affect the test itself, so I think it is acceptable.

##### NOTE
In addition to `stdbuf`, `truncate` and `sed` also use `coreutils` and `gnu-sed` on macos.
I have confirmed that both `truncate` and `sed`, and these work fine despite being `arm64`.
(These do not use DSO at runtime. Therefore, the problem occurs only with `stdbuf`, and it appears to be caused by linking `libstdbuf.so`.)
