### PR TITLE
Use more efficient line-buffered awk

### DIFF
--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -350,7 +350,7 @@ function start_s3fs {
             -f \
             "${@}" &
         echo $! >&3
-    ) 3>pid | "${STDBUF_COMMAND_LINE[@]}" "${SED_BIN}" "${SED_BUFFER_FLAG}" "s/^/s3fs: /" &
+    ) 3>pid | "${STDBUF_COMMAND_LINE[@]}" awk "{print \"s3fs: \" \$0}" &
     sleep 1
     S3FS_PID=$(<pid)
     export S3FS_PID

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -77,7 +77,6 @@ else
     export TRUNCATE_BIN="truncate"
     export SED_BIN="sed"
 fi
-export SED_BUFFER_FLAG="--unbuffered"
 
 # [NOTE]
 # Specifying cache disable option depending on stat(coreutils) version


### PR DESCRIPTION
`sed --unbuffered` reads character-by-character.  This saves 3 seconds of CPU time per test flag.