### PR TITLE
Micro-optimize copies, compares, and logging

### DIFF
--- a/src/cache_node.cpp
+++ b/src/cache_node.cpp
@@ -1311,7 +1311,7 @@ std::shared_ptr<StatCacheNode> DirStatCache::FindHasLock(const std::string& strp
     // [NOTE]
     // Directory paths must end with a slash, but strpath does not.
     //
-    if(GetPathHasLock() == strpath || GetPathHasLock().substr(0, GetPathHasLock().size() - 1) == strpath){
+    if(GetPathHasLock() == strpath || GetPathHasLock().compare(0, GetPathHasLock().size() - 1, strpath) == 0){
         if(IsExpiredHasLock()){
             // this cache is expired
             needTruncate = true;
@@ -1325,7 +1325,7 @@ std::shared_ptr<StatCacheNode> DirStatCache::FindHasLock(const std::string& strp
     }
 
     // Checks whether the path of this object is included
-    if(strpath.substr(0, GetPathHasLock().size()) != GetPathHasLock()){
+    if(strpath.compare(0, GetPathHasLock().size(), GetPathHasLock()) != 0){
         return std::shared_ptr<StatCacheNode>();
     }
 
@@ -1480,7 +1480,7 @@ bool DirStatCache::GetChildLeafNameHasLock(const std::string& strpath, std::stri
         return false;
     }
 
-    strLeafName = strpath.substr(GetPathHasLock().size());
+    strLeafName.assign(strpath, GetPathHasLock().size());
     if(strLeafName.empty()){
         return false;
     }

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -129,7 +129,7 @@ std::string get_sorted_header_keys(const struct curl_slist* list)
         std::string strkey = list->data;
         size_t pos;
         if(std::string::npos != (pos = strkey.find(':', 0))){
-            if (trim(strkey.substr(pos + 1)).empty()) {
+            if(std::string::npos == strkey.find_first_not_of(SPACES, pos + 1)){
                 // skip empty-value headers (as they are discarded by libcurl)
                 continue;
             }
@@ -138,7 +138,7 @@ std::string get_sorted_header_keys(const struct curl_slist* list)
         if(!sorted_headers.empty()){
             sorted_headers += ";";
         }
-        sorted_headers += lower(strkey);
+        sorted_headers += lower(std::move(strkey));
     }
 
     return sorted_headers;
@@ -182,7 +182,7 @@ std::string get_canonical_headers(const struct curl_slist* list, bool only_amz)
                 // skip empty-value headers (as they are discarded by libcurl)
                 continue;
             }
-            strhead = strkey;
+            strhead = std::move(strkey);
             strhead += ":";
             strhead += strval;
         }else{

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -188,7 +188,7 @@ bool FdManager::MakeCachePath(const char* path, std::string& cache_path, bool is
 
     if(is_create_dir){
         int result;
-        if(0 != (result = mkdirp(resolved_path + mydirname(path), 0777))){
+        if(0 != (result = mkdirp(resolved_path + (path == nullptr ? "" : mydirname(path)), 0777))){
             S3FS_PRN_ERR("failed to create dir(%s) by errno(%d).", path, result);
             return false;
         }

--- a/src/s3fs_logger.cpp
+++ b/src/s3fs_logger.cpp
@@ -255,48 +255,44 @@ S3fsLog::Level S3fsLog::LowBumpupLogLevel() const
 
 void s3fs_low_logprn(S3fsLog::Level level, const char* file, const char *func, int line, const char *fmt, ...)
 {
-    if(S3fsLog::IsS3fsLogLevel(level)){
-        va_list va;
-        va_start(va, fmt);
-        size_t len = vsnprintf(nullptr, 0, fmt, va) + 1;
-        va_end(va);
+    va_list va;
+    va_start(va, fmt);
+    size_t len = vsnprintf(nullptr, 0, fmt, va) + 1;
+    va_end(va);
 
-        auto message = std::make_unique<char[]>(len);
-        va_start(va, fmt);
-        vsnprintf(message.get(), len, fmt, va);
-        va_end(va);
+    auto message = std::make_unique<char[]>(len);
+    va_start(va, fmt);
+    vsnprintf(message.get(), len, fmt, va);
+    va_end(va);
 
-        if(foreground || S3fsLog::IsSetLogFile()){
-            S3fsLog::SeekEnd();
-            fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), file, func, line, message.get());
-            S3fsLog::Flush();
-        }else{
-            // TODO: why does this differ from s3fs_low_logprn2?
-            syslog(S3fsLog::GetSyslogLevel(level), "%s%s:%s(%d): %s", instance_name.c_str(), file, func, line, message.get());
-        }
+    if(foreground || S3fsLog::IsSetLogFile()){
+        S3fsLog::SeekEnd();
+        fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), file, func, line, message.get());
+        S3fsLog::Flush();
+    }else{
+        // TODO: why does this differ from s3fs_low_logprn2?
+        syslog(S3fsLog::GetSyslogLevel(level), "%s%s:%s(%d): %s", instance_name.c_str(), file, func, line, message.get());
     }
 }
 
 void s3fs_low_logprn2(S3fsLog::Level level, int nest, const char* file, const char *func, int line, const char *fmt, ...)
 {
-    if(S3fsLog::IsS3fsLogLevel(level)){
-        va_list va;
-        va_start(va, fmt);
-        size_t len = vsnprintf(nullptr, 0, fmt, va) + 1;
-        va_end(va);
+    va_list va;
+    va_start(va, fmt);
+    size_t len = vsnprintf(nullptr, 0, fmt, va) + 1;
+    va_end(va);
 
-        auto message = std::make_unique<char[]>(len);
-        va_start(va, fmt);
-        vsnprintf(message.get(), len, fmt, va);
-        va_end(va);
+    auto message = std::make_unique<char[]>(len);
+    va_start(va, fmt);
+    vsnprintf(message.get(), len, fmt, va);
+    va_end(va);
 
-        if(foreground || S3fsLog::IsSetLogFile()){
-            S3fsLog::SeekEnd();
-            fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), S3fsLog::GetS3fsLogNest(nest), file, func, line, message.get());
-            S3fsLog::Flush();
-        }else{
-            syslog(S3fsLog::GetSyslogLevel(level), "%s%s%s", instance_name.c_str(), S3fsLog::GetS3fsLogNest(nest), message.get());
-        }
+    if(foreground || S3fsLog::IsSetLogFile()){
+        S3fsLog::SeekEnd();
+        fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), S3fsLog::GetS3fsLogNest(nest), file, func, line, message.get());
+        S3fsLog::Flush();
+    }else{
+        syslog(S3fsLog::GetSyslogLevel(level), "%s%s%s", instance_name.c_str(), S3fsLog::GetS3fsLogNest(nest), message.get());
     }
 }
 

--- a/src/s3fs_logger.h
+++ b/src/s3fs_logger.h
@@ -149,13 +149,17 @@ class S3fsLog
 void s3fs_low_logprn(S3fsLog::Level level, const char* file, const char *func, int line, const char *fmt, ...) __attribute__ ((format (printf, 5, 6)));
 #define S3FS_LOW_LOGPRN(level, fmt, ...) \
         do{ \
-            s3fs_low_logprn(level, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__); \
+            if(S3fsLog::IsS3fsLogLevel(level)){ \
+                s3fs_low_logprn(level, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__); \
+            } \
         }while(0)
 
 void s3fs_low_logprn2(S3fsLog::Level level, int nest, const char* file, const char *func, int line, const char *fmt, ...) __attribute__ ((format (printf, 6, 7)));
 #define S3FS_LOW_LOGPRN2(level, nest, fmt, ...) \
         do{ \
-            s3fs_low_logprn2(level, nest, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__); \
+            if(S3fsLog::IsS3fsLogLevel(level)){ \
+                s3fs_low_logprn2(level, nest, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__); \
+            } \
         }while(0)
 
 #define S3FS_LOW_CURLDBG(fmt, ...) \

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -171,18 +171,13 @@ int is_uid_include_group(uid_t uid, gid_t gid)
 //
 static std::mutex basename_lock;
 
-std::string mydirname(const std::string& path)
+// safe variant of dirname
+// dirname clobbers path so let it operate on a tmp copy
+std::string mydirname(std::string path)
 {
     const std::lock_guard<std::mutex> lock(basename_lock);
 
-    return mydirname(path.c_str());
-}
-
-// safe variant of dirname
-// dirname clobbers path so let it operate on a tmp copy
-std::string mydirname(const char* path)
-{
-    if(!path || '\0' == path[0]){
+    if(path.empty()){
         return "";
     }
 
@@ -190,24 +185,17 @@ std::string mydirname(const char* path)
     // Currently, use "&str[pos]" to make it possible to build with C++14.
     // Once we support C++17 or later, we will use "str.data()".
     //
-    std::string strPath = path;
-    strPath.push_back('\0');                    // terminate with a null character and allocate space for it.
-    std::string result = dirname(&strPath[0]);  // NOLINT(readability-container-data-pointer)
-    return result;
-}
-
-std::string mybasename(const std::string& path)
-{
-    const std::lock_guard<std::mutex> data_lock(basename_lock);
-
-    return mybasename(path.c_str());
+    path.push_back('\0');     // terminate with a null character and allocate space for it.
+    return dirname(&path[0]); // NOLINT(readability-container-data-pointer)
 }
 
 // safe variant of basename
 // basename clobbers path so let it operate on a tmp copy
-std::string mybasename(const char* path)
+std::string mybasename(std::string path)
 {
-    if(!path || '\0' == path[0]){
+    const std::lock_guard<std::mutex> data_lock(basename_lock);
+
+    if(path.empty()){
         return "";
     }
 
@@ -215,10 +203,8 @@ std::string mybasename(const char* path)
     // Currently, use "&str[pos]" to make it possible to build with C++14.
     // Once we support C++17 or later, we will use "str.data()".
     //
-    std::string strPath = path;
-    strPath.push_back('\0');                    // terminate with a null character and allocate space for it.
-    std::string result = basename(&strPath[0]); // NOLINT(readability-container-data-pointer)
-    return result;
+    path.push_back('\0');      // terminate with a null character and allocate space for it.
+    return basename(&path[0]); // NOLINT(readability-container-data-pointer)
 }
 
 // mkdir --parents

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -43,10 +43,8 @@ void init_sysconf_vars();
 std::string get_username(uid_t uid);
 int is_uid_include_group(uid_t uid, gid_t gid);
 
-std::string mydirname(const char* path);
-std::string mydirname(const std::string& path);
-std::string mybasename(const char* path);
-std::string mybasename(const std::string& path);
+std::string mydirname(std::string path);
+std::string mybasename(std::string path);
 
 int mkdirp(const std::string& path, mode_t mode);
 std::string get_exist_directory_path(const std::string& path);

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <algorithm>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
@@ -38,19 +39,20 @@
 //-------------------------------------------------------------------
 std::string str(const struct timespec& value)
 {
-    std::ostringstream s;
-
     if(UTIME_OMIT == value.tv_nsec){
-        s << "UTIME_OMIT";
+        return "UTIME_OMIT";
     }else if(UTIME_NOW == value.tv_nsec){
-        s << "UTIME_NOW";
+        return "UTIME_NOW";
     }else{
-        s << value.tv_sec;
-        if(value.tv_nsec != 0){
-            s << "." << std::setfill('0') << std::setw(9) << value.tv_nsec;
+        char buf[64];
+        size_t len;
+        if(value.tv_nsec == 0){
+            len = std::snprintf(buf, sizeof(buf), "%ld", value.tv_sec);
+        }else{
+            len = std::snprintf(buf, sizeof(buf), "%ld.%09ld", value.tv_sec, value.tv_nsec);
         }
+        return std::string(buf, len);
     }
-    return s.str();
 }
 
 // This source code is from https://gist.github.com/jeremyfromearth/5694aa3a66714254752179ecf3c95582 .
@@ -159,8 +161,7 @@ static constexpr char encode_query_except_chars[]   = ".-_~=&%"; // For query pa
 static std::string rawUrlEncode(const std::string &s, const char* except_chars)
 {
     std::string result;
-    for (size_t i = 0; i < s.length(); ++i) {
-        unsigned char c = s[i];
+    for(unsigned char c : s){
         if((except_chars && nullptr != strchr(except_chars, c)) ||
            (c >= 'a' && c <= 'z') ||
            (c >= 'A' && c <= 'Z') ||


### PR DESCRIPTION
Logging should eagerly evaluate the log level to avoid unnecessary calls to parameters like calls to `STR_OBJTYPE`.  These contributed to slow Valgrind test run-times.