### PR TITLE
Added check for existence of uploaded test file by curl

### DIFF
--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -438,6 +438,20 @@ function s3_cp() {
         "$@" \
         --request PUT --data-binary "@$TEMPNAME" "$S3_URL/$S3_PATH"
     rm -f "$TEMPNAME"
+
+    # [NOTE][FIXME]
+    # The purpose of this file upload is to prepare a test file that
+    # s3fs-fuse does not recognize.
+    # However, there are cases where the file cannot be read immediately
+    # after uploading, which causes the test to fail.
+    # This failure is not the essence of s3fs-fuse testing, so we will
+    # now make sure to check the existence of the file.
+    #
+    if ! s3_head "${S3_PATH}" >/dev/null 2>&1; then
+        # wait for retry
+        sleep 1
+        s3_head "${S3_PATH}" >/dev/null 2>&1
+    fi
 }
 
 function wait_for_port() {


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
During CI testing, we encountered cases where files could not be accessed immediately after being uploaded.
The cause of the problem (the phenomenon caused by the cause) was identified from the log of the failed test.
The cause of this issue is unknown, but since it was not an issue with s3fs-fuse processing, temporary I have modified the code so that the tests can be run reliably.

