### PR TITLE
Changed to not call PreventStatCacheExpire

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1251,7 +1251,11 @@ static int s3fs_mkdir(const char* _path, mode_t mode)
     }
 
     // keep stat cache without checking expiration
-    PreventStatCacheExpire nocacheexpire;
+    //
+    // [FIXME]
+    // The process to prevent cache expiration needs to be revised.
+    // The following process will be pending until this is completed.
+    //PreventStatCacheExpire nocacheexpire;
 
     // check parent directory attribute.
     if(0 != (result = check_parent_object_access(path, W_OK | X_OK))){
@@ -1355,7 +1359,11 @@ static int s3fs_rmdir(const char* _path)
     FUSE_CTX_INFO("[path=%s]", path);
 
     // keep stat cache without checking expiration
-    PreventStatCacheExpire nocacheexpire;
+    //
+    // [FIXME]
+    // The process to prevent cache expiration needs to be revised.
+    // The following process will be pending until this is completed.
+    //PreventStatCacheExpire nocacheexpire;
 
     if(0 != (result = check_parent_object_access(path, W_OK | X_OK))){
         return result;


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Current s3fs is preventing removing the stat cache data during rmdir/mkdir operations, but I found it has a problem.
Thus I have commented out this prevention measure.
_(I will restore it after correcting the problematic processing, but for now I will not call it.)_

Normally, when s3fs retrieves stat data for files (and directories), it checks the expiration date of the stat cache if one exists.
For current rmdir/mkdir, bypass the cache out check.
However, the following issue was discovered with this logic.
That is if there is cached data that has already passed its expiration date, processing will continue without caching that data out.
This could result in inconsistencies.

This issue is thought to have caused the test_truncate_cache test to fail during the cleanup process (directory deletion) after the test is completed.

#### Further observation
This issue may have caused test times on macOS and other systems to be extremely long.

