### PR TITLE
Fix file descriptor leaks in error paths

### DIFF
--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -423,6 +423,7 @@ std::unique_ptr<FILE, decltype(&s3fs_fclose)> FdManager::MakeTempFile() {
     }
     if (-1 == unlink(cfn)) {
         S3FS_PRN_ERR("failed to delete tmp file. errno(%d)", errno);
+        close(fd);
         return {nullptr, &s3fs_fclose};
     }
     return {fdopen(fd, "rb+"), &s3fs_fclose};


### PR DESCRIPTION
Close file descriptors before returning on error in three locations:
                                            
- `FdManager::MakeTempFile()`: fd leaked when `unlink()` failed after successful `mkstemp()`
- `FdEntity::Open()`: `physical_fd` leaked when `fstat()` failed after opening cache file
- `FdEntity::Open()`: `physical_fd` leaked when `OpenMirrorFile()` failed
                                          
These leaks would accumulate over time when error conditions occurred, eventually exhausting the process file descriptor limit. 