### PR TITLE
Use scope_guard for directory handles to prevent leaks

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -5116,14 +5116,14 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
                     S3FS_PRN_EXIT("failed to open MOUNTPOINT: %s: %s", mountpoint.c_str(), strerror(errno));
                     return -1;
                 }
+                scope_guard dir_guard([dp]() { closedir(dp); });
+
                 while((ent = readdir(dp)) != nullptr){
                     if(strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0){
-                        closedir(dp);
                         S3FS_PRN_EXIT("MOUNTPOINT directory %s is not empty. if you are sure this is safe, can use the 'nonempty' mount option.", mountpoint.c_str());
                         return -1;
                     }
                 }
-                closedir(dp);
             }
 #endif
 #endif


### PR DESCRIPTION
This PR replaces manual `closedir()`  calls with the existing `scope_guard` RAII pattern in directory-traversing functions. This ensures directory handles are properly closed even when exceptions occur.

**Problem:**

The affected functions iterate over directories using `opendir()`/`readdir()`/`closedir()`. They contain:

1. `std::string` operations that can throw `std::bad_alloc`
2. Recursive calls that propagate exceptions from deeper levels

When an exception is thrown, execution bypasses the manual closedir() calls, causing directory handle leaks. In long-running processes with deep directory trees, this can eventually exhaust the file descriptor limit.

**Solution:**

Use the existing scope_guard class (defined in `s3fs_util.h`) to ensure `closedir()` is called when the scope exits, regardless of how it exits:

```
scope_guard guard([dp]() { closedir(dp); });
```

**Hint:**

The code in `s3fs.cpp` was correct and was only modified for consistency with the rest of the codebase.
