### PR TITLE
Add error logging to scope_guard cleanup functions

### DIFF
--- a/src/fdcache_fdinfo.cpp
+++ b/src/fdcache_fdinfo.cpp
@@ -118,7 +118,11 @@ bool PseudoFdInfo::OpenUploadFd()
         S3FS_PRN_ERR("Could not duplicate physical file descriptor(errno=%d)", errno);
         return false;
     }
-    scope_guard guard([&]() { close(fd); });
+    scope_guard guard([fd]() {
+        if(-1 == close(fd)){
+            S3FS_PRN_ERR("close() failed for fd %d - errno(%d)", fd, errno);
+        }
+    });
 
     if(0 != lseek(fd, 0, SEEK_SET)){
         S3FS_PRN_ERR("Could not seek physical file descriptor(errno=%d)", errno);

--- a/src/fdcache_stat.cpp
+++ b/src/fdcache_stat.cpp
@@ -264,7 +264,11 @@ bool CacheFileStat::RawOpen(bool readonly)
             return false;
         }
     }
-    scope_guard guard([&]() { close(tmpfd); });
+    scope_guard guard([tmpfd, sfile_path]() {
+        if(-1 == close(tmpfd)){
+            S3FS_PRN_ERR("close() failed for %s - errno(%d)", sfile_path.c_str(), errno);
+        }
+    });
 
     // lock
     if(-1 == flock(tmpfd, LOCK_EX)){

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -5116,7 +5116,11 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
                     S3FS_PRN_EXIT("failed to open MOUNTPOINT: %s: %s", mountpoint.c_str(), strerror(errno));
                     return -1;
                 }
-                scope_guard dir_guard([dp]() { closedir(dp); });
+                scope_guard dir_guard([dp]() {
+                    if(-1 == closedir(dp)){
+                        S3FS_PRN_ERR("closedir() failed for %s - errno(%d)", mountpoint.c_str(), errno);
+                    }
+                });
 
                 while((ent = readdir(dp)) != nullptr){
                     if(strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0){

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -308,7 +308,11 @@ bool delete_files_in_dir(const char* dir, bool is_remove_own)
         S3FS_PRN_ERR("could not open dir(%s) - errno(%d)", dir, errno);
         return false;
     }
-    scope_guard dir_guard([dp]() { closedir(dp); });
+    scope_guard dir_guard([dp, dir]() {
+        if(-1 == closedir(dp)){
+            S3FS_PRN_ERR("closedir() failed for %s - errno(%d)", dir, errno);
+        }
+    });
 
     for(dent = readdir(dp); dent; dent = readdir(dp)){
         if(0 == strcmp(dent->d_name, "..") || 0 == strcmp(dent->d_name, ".")){


### PR DESCRIPTION
The scope_guard lambdas for close() and closedir() now check the return value and log an error with errno if the call fails. The error messages include the file or directory path to aid debugging.