### PR TITLE
Bugfix：urlencode prefix when CheckBucket

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3168,7 +3168,7 @@ int S3fsCurl::CheckBucket(const char* check_path, bool compat_dir, bool force_no
                 query_string += '&';
             }
             query_string += "prefix=";
-            query_string += &check_path[1]; // skip first '/' character
+            query_string += urlEncodePath(&check_path[1]); // skip first '/' character
         }
     }
     if(!query_string.empty()){


### PR DESCRIPTION
The prefix is not urlencoded in CheckBucket, so if I mount with a prefix with special characters inside it, such as "?prefix=%3D%3F", and I don't have the access right to the prefix, this function does not check the right prefix.

