### PR TITLE
Improved message output when check bucket error occurs

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -43,6 +43,8 @@
 #include "addhead.h"
 #include "s3fs_xml.h"
 
+using namespace std::string_literals;
+
 //-------------------------------------------------------------------
 // Symbols
 //-------------------------------------------------------------------
@@ -1616,6 +1618,15 @@ bool S3fsCurl::GetResponseCode(long& responseCode, bool from_curl_handle) const
     return true;
 }
 
+bool S3fsCurl::GetCurlErrorString(std::string& strError) const
+{
+    if(CURLE_OK == curlCode){
+        return false;
+    }
+    strError = "CURL ERROR("s + std::to_string(curlCode) + "): "s + curl_easy_strerror(curlCode);
+    return true;
+}
+
 //
 // Reset all options for retrying
 //
@@ -1974,7 +1985,9 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
         }
 
         // Requests
-        curlCode = curl_easy_perform(hCurl.get());
+        if(CURLE_OK != (curlCode = curl_easy_perform(hCurl.get()))){
+            S3FS_PRN_ERR("CURL ERROR(%d) : %s", curlCode, curl_easy_strerror(curlCode));
+        }
 
         // Check result
         switch(curlCode){
@@ -2073,32 +2086,26 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
                 break;
 
             case CURLE_WRITE_ERROR:
-                S3FS_PRN_ERR("### CURLE_WRITE_ERROR");
                 sleep(2);
                 break; 
 
             case CURLE_OPERATION_TIMEDOUT:
-                S3FS_PRN_ERR("### CURLE_OPERATION_TIMEDOUT");
                 sleep(2);
                 break; 
 
             case CURLE_COULDNT_RESOLVE_HOST:
-                S3FS_PRN_ERR("### CURLE_COULDNT_RESOLVE_HOST");
                 sleep(2);
                 break; 
 
             case CURLE_COULDNT_CONNECT:
-                S3FS_PRN_ERR("### CURLE_COULDNT_CONNECT");
                 sleep(4);
                 break; 
 
             case CURLE_GOT_NOTHING:
-                S3FS_PRN_ERR("### CURLE_GOT_NOTHING");
                 sleep(4);
                 break; 
 
             case CURLE_ABORTED_BY_CALLBACK:
-                S3FS_PRN_ERR("### CURLE_ABORTED_BY_CALLBACK");
                 sleep(4);
                 {
                     const std::lock_guard<std::mutex> lock(S3fsCurl::curl_handles_lock);
@@ -2107,28 +2114,26 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
                 break; 
 
             case CURLE_PARTIAL_FILE:
-                S3FS_PRN_ERR("### CURLE_PARTIAL_FILE");
                 sleep(4);
                 break; 
 
             case CURLE_SEND_ERROR:
-                S3FS_PRN_ERR("### CURLE_SEND_ERROR");
                 sleep(2);
                 break;
 
             case CURLE_RECV_ERROR:
-                S3FS_PRN_ERR("### CURLE_RECV_ERROR");
                 sleep(2);
                 break;
 
             case CURLE_SSL_CONNECT_ERROR:
-                S3FS_PRN_ERR("### CURLE_SSL_CONNECT_ERROR");
                 sleep(2);
                 break;
 
-            case CURLE_SSL_CACERT:
-                S3FS_PRN_ERR("### CURLE_SSL_CACERT");
+            case CURLE_SSL_CERTPROBLEM:
+                result = -EIO;
+                break;
 
+            case CURLE_SSL_CACERT:              // = CURLE_SSL_PEER_CERTIFICATE
                 // try to locate cert, if successful, then set the
                 // option and continue
                 if(S3fsCurl::curl_ca_bundle.empty()){
@@ -2145,8 +2150,6 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
 
 #ifdef CURLE_PEER_FAILED_VERIFICATION
             case CURLE_PEER_FAILED_VERIFICATION:
-                S3FS_PRN_ERR("### CURLE_PEER_FAILED_VERIFICATION");
-
                 first_pos = S3fsCred::GetBucket().find_first_of('.');
                 if(first_pos != std::string::npos){
                     S3FS_PRN_INFO("curl returned a CURL_PEER_FAILED_VERIFICATION error");
@@ -2163,8 +2166,6 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
 
             // This should be invalid since curl option HTTP FAILONERROR is now off
             case CURLE_HTTP_RETURNED_ERROR:
-                S3FS_PRN_ERR("### CURLE_HTTP_RETURNED_ERROR");
-
                 if(0 != curl_easy_getinfo(hCurl, CURLINFO_RESPONSE_CODE, &responseCode)){
                     result = -EIO;
                 }else{
@@ -2181,13 +2182,12 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
 
             // Unknown CURL return code
             default:
-                S3FS_PRN_ERR("###curlCode: %d  msg: %s", curlCode, curl_easy_strerror(curlCode));
                 result = -EIO;
                 break;
         } // switch
 
         if(S3FSCURL_PERFORM_RESULT_NOTSET == result){
-            S3FS_PRN_INFO("### retrying...");
+            S3FS_PRN_INFO("Communication error(%d time): Retry up to the limit.", retrycnt);
 
             if(!RemakeHandle()){
                 S3FS_PRN_INFO("Failed to reset handle and internal data for retrying.");

--- a/src/curl.h
+++ b/src/curl.h
@@ -325,6 +325,7 @@ class S3fsCurl
         bool GetIAMCredentials(const char* cred_url, const char* iam_v2_token, const char* ibm_secret_access_key, std::string& response);
         bool GetIAMRoleFromMetaData(const char* cred_url, const char* iam_v2_token, std::string& token);
         bool GetResponseCode(long& responseCode, bool from_curl_handle = true) const;
+        bool GetCurlErrorString(std::string& strError) const;
         int RequestPerform(bool dontAddAuthHeaders=false);
         int DeleteRequest(const char* tpath);
         int GetIAMv2ApiToken(const char* token_url, int token_ttl, const char* token_ttl_hdr, std::string& response);


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2798

### Details
This PR is improved the system so that a curl error message is displayed when a curl error occurs during s3fs startup.
And revised the processing(debug message) after executing curl_easy_setopt, and added a missing error detection feature.
