### PR TITLE
Changed string::assign to explicitly specify last argument

### DIFF
--- a/src/cache_node.cpp
+++ b/src/cache_node.cpp
@@ -1480,7 +1480,7 @@ bool DirStatCache::GetChildLeafNameHasLock(const std::string& strpath, std::stri
         return false;
     }
 
-    strLeafName.assign(strpath, GetPathHasLock().size());
+    strLeafName.assign(strpath, GetPathHasLock().size(), std::string::npos);
     if(strLeafName.empty()){
         return false;
     }


### PR DESCRIPTION
### Relevant Issue (if applicable)
https://github.com/s3fs-fuse/s3fs-fuse/issues/2772#issuecomment-3868137428

### Details
In CentOS7 + devtools-7(gcc (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5)), the definition of std::string::assign is slightly different from other versions, causing the build to fail.
This is because there is no default value for `n` in `std::string& assign(const std::string& str, size_type pos, size_type n=npos)`.
This can be avoided by specifying `n` explicitly. Alternatively, or we can use std::string& assign(const char* pstr, size_type pos).
(This PR fixes by the former.)

Of course, I didn't want to make this change for suppoting C++03, but this single fix allows us to continue building on CentOS7.
There's also the question of how long we'll support CentOS7, but I would like to make this fix for now.

