### PR TITLE
fix build on FreeBSD

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -32,6 +32,9 @@
 #include <dirent.h>  // NOLINT(misc-include-cleaner)
 #include <sys/types.h>
 #include <getopt.h>  // NOLINT(misc-include-cleaner)
+#ifdef __FreeBSD__
+#include <sys/wait.h> // WEXITSTATUS and WIFEXITED
+#endif
 
 #include "common.h"
 #include "s3fs.h"  // NOLINT(misc-include-cleaner)


### PR DESCRIPTION
```
s3fs.cpp:5051:28: error: use of undeclared identifier 'WIFEXITED'
 5051 |     return (result !=-1 && WIFEXITED(result) && WEXITSTATUS(result) == 0);
      |                            ^
s3fs.cpp:5051:49: error: use of undeclared identifier 'WEXITSTATUS'
 5051 |     return (result !=-1 && WIFEXITED(result) && WEXITSTATUS(result) == 0);
```