### PR TITLE
Use `std::move` where possible

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -177,18 +177,17 @@ bool StatCache::AddStat(const std::string& key, const struct stat& stbuf, objtyp
     return AddStatHasLock(key, &stbuf, nullptr, type, notruncate);
 }
 
-bool StatCache::AddS3ObjList(const std::string& key, const S3ObjList& list)
+bool StatCache::AddS3ObjList(std::string key, const S3ObjList& list)
 {
     const std::lock_guard<std::mutex> lock(StatCache::stat_cache_lock);
 
-    std::string _key = key;
-    if('/' != _key.back()){
-        _key += '/';
+    if('/' != key.back()){
+        key += '/';
     }
 
     // Add
-    if(!pMountPointDir->AddS3ObjList(_key, list)){
-        S3FS_PRN_DBG("failed to add s3objlist to stat cache entry[path=%s]", _key.c_str());
+    if(!pMountPointDir->AddS3ObjList(key, list)){
+        S3FS_PRN_DBG("failed to add s3objlist to stat cache entry[path=%s]", key.c_str());
         return false;
     }
 
@@ -196,7 +195,7 @@ bool StatCache::AddS3ObjList(const std::string& key, const S3ObjList& list)
     if(TruncateCacheHasLock(true)){
         S3FS_PRN_DBG("Some expired caches have been truncated.");
     }
-    S3FS_PRN_INFO3("add s3objlist to stat cache entry[path=%s]", _key.c_str());
+    S3FS_PRN_INFO3("add s3objlist to stat cache entry[path=%s]", key.c_str());
 
     // for debug
     //pMountPointDir->Dump(true);

--- a/src/cache.h
+++ b/src/cache.h
@@ -104,7 +104,7 @@ class StatCache
         bool AddStat(const std::string& key, const struct stat& stbuf, const headers_t& meta, objtype_t type, bool notruncate = false);
         bool AddStat(const std::string& key, const struct stat& stbuf, objtype_t type, bool notruncate = false);
         bool AddNegativeStat(const std::string& key);
-        bool AddS3ObjList(const std::string& key, const S3ObjList& list);
+        bool AddS3ObjList(std::string key, const S3ObjList& list);
 
         // Update meta stats
         bool UpdateStat(const std::string& key, const struct stat& stbuf, const headers_t& meta);

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -640,7 +640,7 @@ bool S3fsCurl::PushbackSseKeys(const std::string& input)
     std::string raw_key;
     if(onekey.length() > 256 / 8){
         std::string p_key(s3fs_decode64(onekey.c_str(), onekey.size()));
-        raw_key = p_key;
+        raw_key = std::move(p_key);
         base64_key = onekey;
     } else {
         base64_key = s3fs_base64(reinterpret_cast<const unsigned char*>(onekey.c_str()), onekey.length());
@@ -657,7 +657,7 @@ bool S3fsCurl::PushbackSseKeys(const std::string& input)
     sseckeymap_t md5map;
     md5map.clear();
     md5map[strMd5] = base64_key;
-    S3fsCurl::sseckeys.push_back(md5map);
+    S3fsCurl::sseckeys.push_back(std::move(md5map));
 
     return true;
 }
@@ -2696,9 +2696,8 @@ bool S3fsCurl::GetIAMRoleFromMetaData(const char* cred_url, const char* iam_v2_t
     return (0 == result);
 }
 
-bool S3fsCurl::AddSseRequestHead(sse_type_t ssetype, const std::string& input, bool is_copy)
+bool S3fsCurl::AddSseRequestHead(sse_type_t ssetype, std::string ssevalue, bool is_copy)
 {
-    std::string ssevalue = input;
     switch(ssetype){
         case sse_type_t::SSE_DISABLE:
             return true;

--- a/src/curl.h
+++ b/src/curl.h
@@ -240,7 +240,7 @@ class S3fsCurl
         void insertV2Headers(const std::string& access_key_id, const std::string& secret_access_key, const std::string& access_token);
         void insertIBMIAMHeaders(const std::string& access_key_id, const std::string& access_token);
         bool insertAuthHeaders();
-        bool AddSseRequestHead(sse_type_t ssetype, const std::string& ssevalue, bool is_copy);
+        bool AddSseRequestHead(sse_type_t ssetype, std::string ssevalue, bool is_copy);
         bool PreHeadRequest(const char* tpath, size_t ssekey_pos = SIZE_MAX);
         bool PreHeadRequest(const std::string& tpath, size_t ssekey_pos = SIZE_MAX) {
             return PreHeadRequest(tpath.c_str(), ssekey_pos);

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -186,7 +186,7 @@ std::string get_canonical_headers(const struct curl_slist* list, bool only_amz)
             strhead += ":";
             strhead += strval;
         }else{
-            strhead = trim(lower(strhead));
+            strhead = trim(lower(std::move(strhead)));
         }
         if(only_amz && strhead.substr(0, 5) != "x-amz"){
             continue;

--- a/src/s3objlist.cpp
+++ b/src/s3objlist.cpp
@@ -103,7 +103,7 @@ bool S3ObjList::insert(const char* name, const char* etag, bool is_dir)
         if(etag){
             newobject.etag = etag;
         }
-        objects[newname] = newobject;
+        objects[newname] = std::move(newobject);
     }
 
     // add normalization
@@ -131,7 +131,7 @@ bool S3ObjList::insert_normalized(const char* name, const char* normalized, objt
         s3obj_entry newobject;
         newobject.normalname = normalized;
         newobject.type       = type;
-        objects[name]        = newobject;
+        objects[name]        = std::move(newobject);
     }
     return true;
 }
@@ -353,7 +353,7 @@ bool S3ObjList::MakeHierarchizedList(s3obj_list_t& list, bool haveSlash)
             if(haveSlash){
                 strtmp += "/";
             }
-            list.push_back(strtmp);
+            list.push_back(std::move(strtmp));
         }
     }
     return true;


### PR DESCRIPTION
Also pass parameters by value instead of `const&` when local copies are required.  Suggested by Claude.