### PR TITLE
Bypass test_symlink on macOS

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -2946,7 +2946,15 @@ function add_all_tests {
     add_tests test_utimens_during_multipart
     add_tests test_special_characters
     add_tests test_hardlink
-    add_tests test_symlink
+
+    # TODO: Related Issue #2832
+    # The symlink test fails on macOS.
+    # This is a bug not caused by s3fs-fuse. Therefore, the test will be temporarily bypassed.
+    # This condition will be removed once the related issue is resolved.
+    #
+    if ! uname | grep -q Darwin; then
+        add_tests test_symlink
+    fi
     if ! uname | grep -q Darwin; then
         add_tests test_mknod
         add_tests test_extended_attributes


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2832

### Details
This bypasses the failure of symlink tests in macOS CI.
This is a temporary measure until issue #2832 is resolved.
Without this bypass, other tests in macOS CI can not be run.

