### PR TITLE
Revert #2783 to call PreventStatCacheExpire again

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1251,11 +1251,7 @@ static int s3fs_mkdir(const char* _path, mode_t mode)
     }
 
     // keep stat cache without checking expiration
-    //
-    // [FIXME]
-    // The process to prevent cache expiration needs to be revised.
-    // The following process will be pending until this is completed.
-    //PreventStatCacheExpire nocacheexpire;
+    PreventStatCacheExpire nocacheexpire;
 
     // check parent directory attribute.
     if(0 != (result = check_parent_object_access(path, W_OK | X_OK))){
@@ -1359,11 +1355,7 @@ static int s3fs_rmdir(const char* _path)
     FUSE_CTX_INFO("[path=%s]", path);
 
     // keep stat cache without checking expiration
-    //
-    // [FIXME]
-    // The process to prevent cache expiration needs to be revised.
-    // The following process will be pending until this is completed.
-    //PreventStatCacheExpire nocacheexpire;
+    PreventStatCacheExpire nocacheexpire;
 
     if(0 != (result = check_parent_object_access(path, W_OK | X_OK))){
         return result;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2783 #2833

### Details
We temporarily disabled some caching functionality due to PR #2783, but the cause was as described in #2833(There was no connection between the bug and this feature), so I will restore this functionality.

