### PR TITLE
Temporarily bypass a test fails to delete directories in macOS

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -2124,8 +2124,20 @@ function test_truncate_cache() {
         ls "${dir}"
     done
 
-    # shellcheck disable=SC2046
-    rm -rf $(seq 2)
+    # NOTE: Related Issue #2833
+    # When using macos-fuse-t to delete multiple directories containing files in bulk,
+    # the command to delete directories may be called before the files are deleted,
+    # sometimes resulting in failure.
+    # Until this issue is resolved, please delete directories one by one.
+    #
+    if ! uname | grep -q Darwin; then
+        # shellcheck disable=SC2046
+        rm -rf $(seq 2)
+    else
+        for dir in $(seq 2); do
+            rm -rf "${dir}"
+        done
+    fi
 }
 
 function test_cache_file_stat() {


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2833

### Details
As shown in #2833, the failure of the `test_truncate_cache` test is unlikely to be due to a bug in s3fs-fuse.
Therefore, we will modify the content of the `test_truncate_cache` test on macOS to avoid the bug in #2833 and prevent the test from failing.
This is a temporary workaround for #2833 and will be reverted once the issue is resolved.

