### PR TITLE
Remove call to `strcpy`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,6 @@ Checks: '
     -cert-env33-c,
     -cert-err33-c,
     -cert-err58-cpp,
-    -clang-analyzer-security.insecureAPI.strcpy,
     -clang-analyzer-unix.BlockInCriticalSection,
     -concurrency-mt-unsafe,
     -cppcoreguidelines-avoid-c-arrays,

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4197,8 +4197,9 @@ static int s3fs_listxattr(const char* path, char* list, size_t size)
     char* setpos = list;
     for(auto xiter = xattrs.cbegin(); xiter != xattrs.cend(); ++xiter){
         if(!xiter->first.empty()){
-            strcpy(setpos, xiter->first.c_str());
-            setpos = &setpos[strlen(setpos) + 1];
+            size_t len = xiter->first.length() + 1;
+            memcpy(setpos, xiter->first.c_str(), len);
+            setpos += len;
         }
     }
 


### PR DESCRIPTION
This is safe but the `memcpy` approach is more efficient.  Also enable the clang-tidy check.  Suggested by Claude.