### PR TITLE
Write log lines with write(2) instead of stdio

### DIFF
--- a/src/s3fs_logger.cpp
+++ b/src/s3fs_logger.cpp
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <cerrno>
 #include <cstdarg>
 #include <cstdlib>
 #include <iomanip>
@@ -25,6 +26,7 @@
 #include <sstream>
 #include <string>
 #include <sys/time.h>
+#include <unistd.h>
 
 #include "common.h"
 #include "s3fs_logger.h"
@@ -253,6 +255,43 @@ S3fsLog::Level S3fsLog::LowBumpupLogLevel() const
     return old;
 }
 
+void S3fsLog::Printf(FILE* fp, const char* fmt, ...)
+{
+    if(!fp){
+        return;
+    }
+    va_list va;
+    va_start(va, fmt);
+    int len = vsnprintf(nullptr, 0, fmt, va);
+    va_end(va);
+    if(len < 0){
+        return;
+    }
+
+    auto buf = std::make_unique<char[]>(static_cast<size_t>(len) + 1);
+    va_start(va, fmt);
+    vsnprintf(buf.get(), static_cast<size_t>(len) + 1, fmt, va);
+    va_end(va);
+
+    int fd = fileno(fp);
+    if(fd < 0){
+        return;
+    }
+    const char* p = buf.get();
+    auto remaining = static_cast<size_t>(len);
+    while(remaining > 0){
+        ssize_t w = write(fd, p, remaining);
+        if(w < 0){
+            if(errno == EINTR){
+                continue;
+            }
+            break;
+        }
+        p += w;
+        remaining -= static_cast<size_t>(w);
+    }
+}
+
 void s3fs_low_logprn(S3fsLog::Level level, const char* file, const char *func, int line, const char *fmt, ...)
 {
     va_list va;
@@ -266,9 +305,7 @@ void s3fs_low_logprn(S3fsLog::Level level, const char* file, const char *func, i
     va_end(va);
 
     if(foreground || S3fsLog::IsSetLogFile()){
-        S3fsLog::SeekEnd();
-        fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), file, func, line, message.get());
-        S3fsLog::Flush();
+        S3fsLog::Printf(S3fsLog::GetOutputLogFile(), "%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), file, func, line, message.get());
     }else{
         // TODO: why does this differ from s3fs_low_logprn2?
         syslog(S3fsLog::GetSyslogLevel(level), "%s%s:%s(%d): %s", instance_name.c_str(), file, func, line, message.get());
@@ -288,9 +325,7 @@ void s3fs_low_logprn2(S3fsLog::Level level, int nest, const char* file, const ch
     va_end(va);
 
     if(foreground || S3fsLog::IsSetLogFile()){
-        S3fsLog::SeekEnd();
-        fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), S3fsLog::GetS3fsLogNest(nest), file, func, line, message.get());
-        S3fsLog::Flush();
+        S3fsLog::Printf(S3fsLog::GetOutputLogFile(), "%s%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), S3fsLog::GetS3fsLogNest(nest), file, func, line, message.get());
     }else{
         syslog(S3fsLog::GetSyslogLevel(level), "%s%s%s", instance_name.c_str(), S3fsLog::GetS3fsLogNest(nest), message.get());
     }

--- a/src/s3fs_logger.h
+++ b/src/s3fs_logger.h
@@ -115,19 +115,11 @@ class S3fsLog
             return (logfp ? logfp : stderr);
         }
 
-        static void SeekEnd()
-        {
-            if(logfp){
-                fseek(logfp, 0, SEEK_END);
-            }
-        }
-
-        static void Flush()
-        {
-            if(logfp){
-                fflush(logfp);
-            }
-        }
+        // Format and write a single log line with one write(2) syscall.
+        // Bypasses stdio locking, which deadlocks under concurrent logging
+        // on MSYS2 (issue #2850); also makes log lines atomic on all platforms
+        // since logfp is opened with O_APPEND.
+        static void Printf(FILE* fp, const char* fmt, ...) __attribute__ ((format (printf, 2, 3)));
 
         static bool SetLogfile(const char* pfile);
         static bool ReopenLogfile();
@@ -165,9 +157,7 @@ void s3fs_low_logprn2(S3fsLog::Level level, int nest, const char* file, const ch
 #define S3FS_LOW_CURLDBG(fmt, ...) \
         do{ \
             if(foreground || S3fsLog::IsSetLogFile()){ \
-                S3fsLog::SeekEnd(); \
-                fprintf(S3fsLog::GetOutputLogFile(), "%s[CURL DBG] " fmt "%s\n", S3fsLog::GetCurrentTime().c_str(), __VA_ARGS__); \
-                S3fsLog::Flush(); \
+                S3fsLog::Printf(S3fsLog::GetOutputLogFile(), "%s[CURL DBG] " fmt "%s\n", S3fsLog::GetCurrentTime().c_str(), __VA_ARGS__); \
             }else{ \
                 syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::CRIT), "%s" fmt "%s", instance_name.c_str(), __VA_ARGS__); \
             } \
@@ -176,11 +166,9 @@ void s3fs_low_logprn2(S3fsLog::Level level, int nest, const char* file, const ch
 #define S3FS_LOW_LOGPRN_EXIT(fmt, ...) \
         do{ \
             if(foreground || S3fsLog::IsSetLogFile()){ \
-                S3fsLog::SeekEnd(); \
-                fprintf(S3fsLog::GetErrorLogFile(), "s3fs: " fmt "%s\n", __VA_ARGS__); \
-                S3fsLog::Flush(); \
+                S3fsLog::Printf(S3fsLog::GetErrorLogFile(), "s3fs: " fmt "%s\n", __VA_ARGS__); \
             }else{ \
-                fprintf(S3fsLog::GetErrorLogFile(), "s3fs: " fmt "%s\n", __VA_ARGS__); \
+                S3fsLog::Printf(S3fsLog::GetErrorLogFile(), "s3fs: " fmt "%s\n", __VA_ARGS__); \
                 syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::CRIT), "%ss3fs: " fmt "%s", instance_name.c_str(), __VA_ARGS__); \
             } \
         }while(0)
@@ -189,9 +177,7 @@ void s3fs_low_logprn2(S3fsLog::Level level, int nest, const char* file, const ch
 #define S3FS_PRN_INIT_INFO(fmt, ...) \
         do{ \
             if(foreground || S3fsLog::IsSetLogFile()){ \
-                S3fsLog::SeekEnd(); \
-                fprintf(S3fsLog::GetOutputLogFile(), "%s%s%s%s:%s(%d): " fmt "%s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(S3fsLog::Level::INFO), S3fsLog::GetS3fsLogNest(0), __FILE__, __func__, __LINE__, __VA_ARGS__, ""); \
-                S3fsLog::Flush(); \
+                S3fsLog::Printf(S3fsLog::GetOutputLogFile(), "%s%s%s%s:%s(%d): " fmt "%s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(S3fsLog::Level::INFO), S3fsLog::GetS3fsLogNest(0), __FILE__, __func__, __LINE__, __VA_ARGS__, ""); \
             }else{ \
                 syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::INFO), "%s%s" fmt "%s", instance_name.c_str(), S3fsLog::GetS3fsLogNest(0), __VA_ARGS__, ""); \
             } \
@@ -200,9 +186,7 @@ void s3fs_low_logprn2(S3fsLog::Level level, int nest, const char* file, const ch
 #define S3FS_PRN_LAUNCH_INFO(fmt, ...) \
         do{ \
             if(foreground || S3fsLog::IsSetLogFile()){ \
-                S3fsLog::SeekEnd(); \
-                fprintf(S3fsLog::GetOutputLogFile(), "%s%s" fmt "%s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(S3fsLog::Level::INFO), __VA_ARGS__, ""); \
-                S3fsLog::Flush(); \
+                S3fsLog::Printf(S3fsLog::GetOutputLogFile(), "%s%s" fmt "%s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(S3fsLog::Level::INFO), __VA_ARGS__, ""); \
             }else{ \
                 syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::INFO), "%s" fmt "%s", instance_name.c_str(), __VA_ARGS__, ""); \
             } \
@@ -212,9 +196,7 @@ void s3fs_low_logprn2(S3fsLog::Level level, int nest, const char* file, const ch
 #define S3FS_LOW_CACHE(fp, fmt, ...) \
         do{ \
             if(foreground || S3fsLog::IsSetLogFile()){ \
-                S3fsLog::SeekEnd(); \
-                fprintf(fp, fmt "%s\n", __VA_ARGS__); \
-                S3fsLog::Flush(); \
+                S3fsLog::Printf(fp, fmt "%s\n", __VA_ARGS__); \
             }else{ \
                 syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::INFO), "%s: " fmt "%s", instance_name.c_str(), __VA_ARGS__); \
             } \


### PR DESCRIPTION
fprintf on MSYS2 deadlocks under concurrent logging because the runtime's per-FILE stdio lock interacts badly with its signal-aware wait primitive, hanging s3fs during readdir on Windows (issue #2850).

Format each line into a buffer and emit it with a single write(2) call. Since logfp is opened with O_APPEND, the kernel guarantees atomic appends, so log lines also no longer interleave across threads on other platforms.

Fixes #2850.