### PR TITLE
Propagate real errno consistently from filesystem failures

### DIFF
--- a/src/fdcache_auto.cpp
+++ b/src/fdcache_auto.cpp
@@ -80,6 +80,10 @@ FdEntity* AutoFdEntity::Open(const char* path, const headers_t* pmeta, off_t siz
 {
     Close();
 
+    // FdManager::Open writes pseudo_fd via reference only on the path that
+    // reaches FdEntity::Open. Initialise to -EIO so early-return failure
+    // paths still yield a meaningful negative errno through *error.
+    pseudo_fd = -EIO;
     if(nullptr == (pFdEntity = FdManager::get()->Open(pseudo_fd, path, pmeta, size, ts_times, flags, force_tmpfile, is_create, ignore_modify))){
         if(error){
             *error = pseudo_fd;

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -490,7 +490,8 @@ int FdEntity::Open(const headers_t* pmeta, off_t size, const FileTimes& ts_times
 
                 // could not open cache file or could not load stats data, so initialize it.
                 if(-1 == (physical_fd = open(cachepath.c_str(), O_CREAT|O_RDWR|O_TRUNC, 0600))){
-                    S3FS_PRN_ERR("failed to open file(%s). errno(%d)", cachepath.c_str(), errno);
+                    int open_errno = errno;
+                    S3FS_PRN_ERR("failed to open file(%s). errno(%d)", cachepath.c_str(), open_errno);
 
                     // remove cache stat file if it is existed
                     if(0 != (result = CacheFileStat::DeleteCacheFileStat(path.c_str()))){
@@ -498,7 +499,7 @@ int FdEntity::Open(const headers_t* pmeta, off_t size, const FileTimes& ts_times
                             S3FS_PRN_WARN("failed to delete current cache stat file(%s) by errno(%d), but continue...", path.c_str(), result);
                         }
                     }
-                    return result;
+                    return -open_errno;
                 }
                 need_save_csf = true;       // need to update page info
                 inode         = FdEntity::GetInode(physical_fd);
@@ -573,11 +574,12 @@ int FdEntity::Open(const headers_t* pmeta, off_t size, const FileTimes& ts_times
         // truncate cache(tmp) file
         if(is_truncate){
             if(0 != ftruncate(physical_fd, size) || 0 != fsync(physical_fd)){
-                S3FS_PRN_ERR("ftruncate(%s) or fsync returned err(%d)", cachepath.c_str(), errno);
+                int save_errno = errno;
+                S3FS_PRN_ERR("ftruncate(%s) or fsync returned err(%d)", cachepath.c_str(), save_errno);
                 pfile.reset();
                 physical_fd = -1;
                 inode       = 0;
-                return (0 == errno ? -EIO : -errno);
+                return (0 == save_errno ? -EIO : -save_errno);
             }
         }
 
@@ -634,7 +636,7 @@ int FdEntity::Open(const headers_t* pmeta, off_t size, const FileTimes& ts_times
 // So we do not check disk space for this option mode, if there is not enough
 // disk space this method will be failed.
 //
-bool FdEntity::LoadAll(int fd, off_t* size, bool force_load)
+int FdEntity::LoadAll(int fd, off_t* size, bool force_load)
 {
     const std::lock_guard<std::mutex> lock(fdent_lock);
 
@@ -642,14 +644,14 @@ bool FdEntity::LoadAll(int fd, off_t* size, bool force_load)
 
     if(-1 == physical_fd || !FindPseudoFdWithLock(fd)){
         S3FS_PRN_ERR("pseudo_fd(%d) and physical_fd(%d) for path(%s) is not opened yet", fd, physical_fd, path.c_str());
-        return false;
+        return -EBADF;
     }
 
     const std::lock_guard<std::mutex> data_lock(fdent_data_lock);
 
     if(force_load){
         if(!SetAllStatusUnloaded()){
-            return false;
+            return -EIO;
         }
     }
     //
@@ -658,12 +660,12 @@ bool FdEntity::LoadAll(int fd, off_t* size, bool force_load)
     int result;
     if(0 != (result = Load(/*start=*/ 0, /*size=*/ 0))){
         S3FS_PRN_ERR("could not download, result(%d)", result);
-        return false;
+        return result;
     }
     if(size){
         *size = pagelist.Size();
     }
-    return true;
+    return 0;
 }
 
 //
@@ -1088,8 +1090,8 @@ int FdEntity::NoCacheLoadAndPost(PseudoFdInfo* pseudo_obj, off_t start, off_t si
                 // after this, file length is (offset + size), but file does not use any disk space.
                 //
                 if(-1 == ftruncate(tmpfd, 0) || -1 == ftruncate(tmpfd, (offset + oneread))){
-                    S3FS_PRN_ERR("failed to truncate temporary file(physical_fd=%d).", tmpfd);
-                    result = -EIO;
+                    S3FS_PRN_ERR("failed to truncate temporary file(physical_fd=%d) by errno(%d).", tmpfd, errno);
+                    result = -errno;
                     break;
                 }
 

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -149,7 +149,7 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
         }
         int Open(const headers_t* pmeta, off_t size, const FileTimes& ts_times, int flags);
 
-        bool LoadAll(int fd, off_t* size = nullptr, bool force_load = false);
+        int LoadAll(int fd, off_t* size = nullptr, bool force_load = false);
         int Dup(int fd) {
             const std::lock_guard<std::mutex> lock(fdent_lock);
             return DupWithLock(fd);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -852,15 +852,19 @@ static int get_local_fent(AutoFdEntity& autoent, FdEntity **entity, const char* 
     }
     bool   force_tmpfile = S_ISREG(stobj.st_mode) ? false : true;
 
-    if(nullptr == (ent = autoent.Open(path, &meta, stobj.st_size, ts_times, flags, force_tmpfile, true, false))){
-        S3FS_PRN_ERR("Could not open file. errno(%d)", errno);
-        return -EIO;
+    int error = 0;
+    if(nullptr == (ent = autoent.Open(path, &meta, stobj.st_size, ts_times, flags, force_tmpfile, true, false, &error))){
+        if(0 == error){
+            error = -EIO;
+        }
+        S3FS_PRN_ERR("Could not open file. result(%d)", error);
+        return error;
     }
     // load
-    if(is_load && !ent->LoadAll(autoent.GetPseudoFd())){
-        S3FS_PRN_ERR("Could not load file. errno(%d)", errno);
+    if(is_load && 0 != (result = ent->LoadAll(autoent.GetPseudoFd()))){
+        S3FS_PRN_ERR("Could not load file. result(%d)", result);
         autoent.Close();
-        return -EIO;
+        return result;
     }
     *entity = ent;
     return 0;
@@ -1363,8 +1367,8 @@ static int s3fs_rmdir(const char* _path)
     }
 
     // directory must be empty
-    if(directory_empty(path) != 0){
-        return -ENOTEMPTY;
+    if(0 != (result = directory_empty(path))){
+        return result;
     }
 
     strpath = path;
@@ -1476,9 +1480,13 @@ static int s3fs_symlink(const char* _from, const char* _to)
         AutoFdEntity autoent;
         FdEntity*    ent;
         FileTimes    ts_times;      // Default: all time values are set UTIME_OMIT
-        if(nullptr == (ent = autoent.Open(strTo.c_str(), &headers, 0, ts_times, O_RDWR, true, true, false))){
-            S3FS_PRN_ERR("could not open tmpfile(errno=%d)", errno);
-            return -errno;
+        int error = 0;
+        if(nullptr == (ent = autoent.Open(strTo.c_str(), &headers, 0, ts_times, O_RDWR, true, true, false, &error))){
+            if(0 == error){
+                error = -EIO;
+            }
+            S3FS_PRN_ERR("could not open tmpfile(result=%d)", error);
+            return error;
         }
 
         // write(without space words)
@@ -2946,9 +2954,13 @@ static int s3fs_truncate(const char* _path, off_t size FUSE3_FILE_INFO_ARG)
         }
 
         FileTimes ts_times;     // Default: all time values are set UTIME_OMIT
-        if(nullptr == (ent = autoent.Open(path, &meta, size, ts_times, O_RDWR, false, true, ignore_modify))){
-            S3FS_PRN_ERR("could not open file(%s): errno=%d(ent is null(%p))", path, errno, ent);   // [NOTE] read ent to avoid errors with cppcheck etc
-            return -EIO;
+        int error = 0;
+        if(nullptr == (ent = autoent.Open(path, &meta, size, ts_times, O_RDWR, false, true, ignore_modify, &error))){
+            if(0 == error){
+                error = -EIO;
+            }
+            S3FS_PRN_ERR("could not open file(%s): result=%d(ent is null(%p))", path, error, ent);   // [NOTE] read ent to avoid errors with cppcheck etc
+            return error;
         }
 
 #ifdef __APPLE__
@@ -2981,9 +2993,13 @@ static int s3fs_truncate(const char* _path, off_t size FUSE3_FILE_INFO_ARG)
         meta["x-amz-meta-gid"]   = std::to_string(pcxt->gid);
 
         FileTimes ts_times;     // Default: all time values are set UTIME_OMIT
-        if(nullptr == (ent = autoent.Open(path, &meta, size, ts_times, O_RDWR, true, true, false))){
-            S3FS_PRN_ERR("could not open file(%s): errno=%d", path, errno);
-            return -EIO;
+        int error = 0;
+        if(nullptr == (ent = autoent.Open(path, &meta, size, ts_times, O_RDWR, true, true, false, &error))){
+            if(0 == error){
+                error = -EIO;
+            }
+            S3FS_PRN_ERR("could not open file(%s): result=%d", path, error);
+            return error;
         }
         if(0 != (result = ent->Flush(autoent.GetPseudoFd(), true))){
             S3FS_PRN_ERR("could not upload file(%s): result=%d", path, result);
@@ -3066,10 +3082,14 @@ static int s3fs_open(const char* _path, struct fuse_file_info* fi)
 
     FileTimes ts_times;     // Default: all time values are set UTIME_OMIT
     ts_times.SetAll(st);
-    if(nullptr == (ent = autoent.Open(path, &meta, st.st_size, ts_times, fi->flags, false, true, false))){
+    int error = 0;
+    if(nullptr == (ent = autoent.Open(path, &meta, st.st_size, ts_times, fi->flags, false, true, false, &error))){
+        if(0 == error){
+            error = -EIO;
+        }
         // remove stat cache
         StatCache::getStatCacheData()->DelStat(path);
-        return -EIO;
+        return error;
     }
 
     if (needs_flush){

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -222,10 +222,10 @@ int mkdirp(const std::string& path, mode_t mode)
             if(errno == EEXIST){
                 struct stat st;
                 if(0 != lstat(base.c_str(), &st) || !S_ISDIR(st.st_mode)){
-                    return EPERM;
+                    return -EPERM;
                 }
             }else{
-                return errno;
+                return -errno;
             }
         }
     }


### PR DESCRIPTION
Several callers were returning a hard-coded errno when an inner
failure already had a meaningful one to surface, or returning the
errno with the wrong sign:

- s3fs_rmdir treated every non-zero return from directory_empty as
  -ENOTEMPTY, so a transient -EIO from list_bucket reached userspace
  as "directory not empty".
- NoCacheLoadAndPost returned -EIO when ftruncate(2) failed, even
  though errno held the real reason (e.g. ENOSPC, EFBIG); every other
  ftruncate callsite in the same function already returns -errno.
- FdEntity::Open returned the cleanup helper's status (which is 0
  when cleanup succeeds) after open(2) failed, silently masking the
  real open failure. Capture errno before cleanup syscalls clobber
  it and return -open_errno explicitly.
- FdEntity::Open also read errno after pfile.reset() ran on the
  is_truncate path; reset calls fclose, which can change errno. Save
  errno before the cleanup and use the saved value.
- mkdirp returned positive errno from mkdir(2) failures while the
  rest of the codebase uses negative errno; if any caller propagated
  this to FUSE the kernel would treat it as success.
- FdEntity::LoadAll flattened Load(2)'s return into bool, and its
  caller mapped that to -EIO. Change LoadAll to return int so a
  failed download surfaces its real errno (network failure, ENOSPC,
  etc.) instead of being collapsed to EIO at the FUSE boundary.
- Five autoent.Open callers (get_local_fent, both branches of
  s3fs_truncate, s3fs_symlink, s3fs_open) returned -EIO or read the
  unrelated global errno on failure, even though AutoFdEntity::Open
  already accepts an int* error out-parameter that carries the real
  errno. Pass &error and return it, mirroring what s3fs_open's other
  branch already does.
- AutoFdEntity::Open assigned *error = pseudo_fd on failure, but
  FdManager::Open writes pseudo_fd via reference only on the path
  that reaches FdEntity::Open; its early-return paths (empty path,
  not-found-and-not-creating, MakeCachePath failure) leave pseudo_fd
  unchanged. Seed pseudo_fd to -EIO before the call so *error always
  carries a meaningful negative errno on failure. Each caller also
  guards with if(0 == error) error = -EIO; so the static analyzer
  can verify locally that get_local_fent never returns 0 while
  leaving *entity uninitialized.