### PR TITLE
Remove openSUSE Leap 15 reaching EOL from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
           - rockylinux/rockylinux:8
           - fedora:44
           - fedora:43
-          - opensuse/leap:15
           - opensuse/leap:16.0
           - alpine:3.23
 

--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -318,8 +318,7 @@ elif [ "${CONTAINER_FULLNAME}" = "fedora:44" ] ||
         procps
     )
 
-elif [ "${CONTAINER_FULLNAME}" = "opensuse/leap:15" ] ||
-     [ "${CONTAINER_FULLNAME}" = "opensuse/leap:16.0" ]; then
+elif [ "${CONTAINER_FULLNAME}" = "opensuse/leap:16.0" ]; then
     PACKAGE_MANAGER_BIN="zypper"
     PACKAGE_UPDATE_OPTIONS="refresh"
     PACKAGE_INSTALL_OPTIONS="install -y"


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
In the OpenSUSE/Leap:15 CI environment, the installation of libxml2-devel is failing.
This is because libxml2-devel depends on readline-devel, which requires libncurses6, resulting in a version mismatch in the current package.
It seems that running dist-upgrade is necessary to resolve this issue.

@juliogonzalez
Is this solution acceptable?

