### PR TITLE
Strictly mapping 500 range in HTTP  response to errno codes

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1661,9 +1661,6 @@ bool S3fsCurl::RemakeHandle()
     headdata.clear();
     LastResponseCode   = S3FSCURL_RESPONSECODE_NOTSET;
 
-    // retry count up
-    retry_count++;
-
     // set from backup
     postdata           = b_postdata;
     postdata_remaining = b_postdata_remaining;
@@ -1956,6 +1953,20 @@ bool S3fsCurl::RemakeHandle()
 }
 
 //
+// Sleep Method with Exponential Backoff and Jitter
+//
+// [NOTE]
+// The primary objective of this process is to prevent secondary server
+// failures caused by spikes in simultaneous retries.
+//
+void S3fsCurl::WaitBeforeRetry()
+{
+    unsigned int sleep_time = 2 << retry_count;
+    sleep(sleep_time + static_cast<unsigned int>(random()) % sleep_time);
+    retry_count++;
+}
+
+//
 // returns curl return code
 //
 int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
@@ -2065,22 +2076,71 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
                         result = -EIO;
                         break;
 
+                    case 429:
+                        if((retrycnt + 1) < S3fsCurl::retries){
+                            S3FS_PRN_INFO3("HTTP response code 429 was returned, slowing down");
+                            S3FS_PRN_DBG("Body Text: %s", bodydata.c_str());
+                            WaitBeforeRetry();
+                        }else{
+                            S3FS_PRN_INFO3("HTTP response code 429 was returned, returning EAGAIN");
+                            result = -EAGAIN;
+                        }
+                        break;
+
+                    case 500:
+                        // [NOTE]
+                        // The 500 error message occurs when the server is unable to process the request at
+                        // that time, and may be resolved by retrying the request.
+                        //
+                        if((retrycnt + 1) < S3fsCurl::retries){
+                            S3FS_PRN_INFO3("HTTP response code 500 was returned, slowing down");
+                            S3FS_PRN_DBG("Body Text: %s", bodydata.c_str());
+                            WaitBeforeRetry();
+                        }else{
+                            S3FS_PRN_INFO3("HTTP response code 500 was returned, returning EIO");
+                            result = -EIO;
+                        }
+                        break;
+
                     case 501:
                         S3FS_PRN_INFO3("HTTP response code 501 was returned, returning ENOTSUP");
                         S3FS_PRN_DBG("Body Text: %s", bodydata.c_str());
                         result = -ENOTSUP;
                         break;
 
-                    case 429:
-                    case 500:
-                    case 503: {
-                        S3FS_PRN_INFO3("HTTP response code %ld was returned, slowing down", responseCode);
-                        S3FS_PRN_DBG("Body Text: %s", bodydata.c_str());
-                        // Add jitter to avoid thundering herd.
-                        unsigned int sleep_time = 2 << retry_count;
-                        sleep(sleep_time + static_cast<unsigned int>(random()) % sleep_time);
+                    case 502:
+                        if((retrycnt + 1) < S3fsCurl::retries){
+                            S3FS_PRN_INFO3("HTTP response code 502 was returned, slowing down");
+                            S3FS_PRN_DBG("Body Text: %s", bodydata.c_str());
+                            WaitBeforeRetry();
+                        }else{
+                            S3FS_PRN_INFO3("HTTP response code 502 was returned, returning EWOULDBLOCK");
+                            result = -EWOULDBLOCK;
+                        }
                         break;
-                    }
+
+                    case 503:
+                        if((retrycnt + 1) < S3fsCurl::retries){
+                            S3FS_PRN_INFO3("HTTP response code 503 was returned, slowing down");
+                            S3FS_PRN_DBG("Body Text: %s", bodydata.c_str());
+                            WaitBeforeRetry();
+                        }else{
+                            S3FS_PRN_INFO3("HTTP response code 503 was returned, returning EAGAIN");
+                            result = -EAGAIN;
+                        }
+                        break;
+
+                    case 504:
+                        if((retrycnt + 1) < S3fsCurl::retries){
+                            S3FS_PRN_INFO3("HTTP response code 504 was returned, slowing down");
+                            S3FS_PRN_DBG("Body Text: %s", bodydata.c_str());
+                            WaitBeforeRetry();
+                        }else{
+                            S3FS_PRN_INFO3("HTTP response code 504 was returned, returning ETIMEDOUT");
+                            result = -ETIMEDOUT;
+                        }
+                        break;
+
                     default:
                         S3FS_PRN_ERR("HTTP response code %ld, returning EIO. Body Text: %s", responseCode, bodydata.c_str());
                         result = -EIO;

--- a/src/curl.h
+++ b/src/curl.h
@@ -235,6 +235,7 @@ class S3fsCurl
         // methods
         bool ResetHandle() REQUIRES(S3fsCurl::curl_handles_lock);
         bool RemakeHandle();
+        void WaitBeforeRetry();
         bool ClearInternalData();
         bool insertV4Headers(const std::string& access_key_id, const std::string& secret_access_key, const std::string& access_token);
         void insertV2Headers(const std::string& access_key_id, const std::string& secret_access_key, const std::string& access_token);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -436,7 +436,17 @@ static int get_object_attribute(const char* path, struct stat* pstbuf, headers_t
 
         *pObjType = objtype_t::FILE;       // Since can't access the object, set as a file.
 
-    }else if(0 != result){
+    }else if(-ENOENT == result){
+        // [NOTE]
+        // Only on a -ENOENT error should the check for a compatible object(without a trailing
+        // "/" and with the _$folder$ suffix) be performed.
+        // Performing this check after receiving any other error(-EIO, -ETIMEOUT, etc.) can lead
+        // to serious problems. For example, if the system experiences a transient error, even
+        // though the target object actually exists, a compatible object will also not exist
+        // (because the object exists), resulting in the object being considered non-existent.
+        // As a result, the caller may unintentionally overwrite the existing object and create
+        // a new one (see #2581).
+        //
         if(overcheck && !is_bucket_mountpoint){
             // when support_compat_dir is disabled, strpath maybe have "_$folder$".
             if('/' != *strpath.rbegin() && std::string::npos == strpath.find("_$folder$", 0)){
@@ -487,7 +497,7 @@ static int get_object_attribute(const char* path, struct stat* pstbuf, headers_t
             }
         }
 
-    }else{
+    }else if(0 == result){
         if(is_reg_fmt(*pmeta)){
             *pObjType = objtype_t::FILE;
         }else if(is_symlink_fmt(*pmeta)){
@@ -525,6 +535,11 @@ static int get_object_attribute(const char* path, struct stat* pstbuf, headers_t
                 }
             }
         }
+    }else{
+        // Currently, this block handles the following errors, which are propagated as-is.
+        // (result = -EIO / -EAGAIN / -EFBIG / -ENAMETOOLONG / -EREMOTE / -ENOTSUP / -EWOULDBLOCK / -ETIMEDOUT)
+        //
+        return result;
     }
 
     // set headers for mount point from default stat
@@ -667,7 +682,7 @@ static int check_object_access(const char* path, int mask, struct stat* pstbuf)
     S3FS_PRN_DBG("[pid=%u,uid=%u,gid=%u]", (unsigned int)(pcxt->pid), (unsigned int)(pcxt->uid), (unsigned int)(pcxt->gid));
 
     if(0 != (result = get_object_attribute(path, pst))){
-        // If there is not the target file(object), result is -ENOENT.
+        // If any error occurs(including -ENOENT)
         return result;
     }
     if(0 == pcxt->uid){
@@ -740,7 +755,7 @@ static int check_object_owner(const char* path, struct stat* pstbuf)
         return -EIO;
     }
     if(0 != (result = get_object_attribute(path, pst))){
-        // If there is not the target file(object), result is -ENOENT.
+        // If any error occurs(including -ENOENT)
         return result;
     }
     // check owner
@@ -1792,17 +1807,22 @@ static int rename_directory(const char* from, const char* to)
     // Initiate and Add base directory into mvnode struct.
     //
     strto += "/";
-    if(0 == chk_dir_object_type(strfrom.c_str(), normpath, strfrom, nullptr, &ObjType) && IS_DIR_OBJ(ObjType)){
-        if(objtype_t::DIR_NOT_EXIST_OBJECT != ObjType){
-            normdir = false;
-        }else{
-            normdir = true;
-            strfrom = from;               // from directory is not removed, but from directory attr is needed.
-        }
-        mvnodes.emplace_back(strfrom, strto, true, normdir);
-    }else{
-        // Something wrong about "from" directory.
+    if(0 != (result = chk_dir_object_type(strfrom.c_str(), normpath, strfrom, nullptr, &ObjType))){
+        // The directory's existence has already been verified prior to this call.
+        // Consequently, a failure here constitutes a fatal error, as any further
+        // processing would be bound to fail.
+        return result;
     }
+    if(!IS_DIR_OBJ(ObjType)){
+        return -ENOENT;
+    }
+    if(objtype_t::DIR_NOT_EXIST_OBJECT != ObjType){
+        normdir = false;
+    }else{
+        normdir = true;
+        strfrom = from;                   // from directory is not removed, but from directory attr is needed.
+    }
+    mvnodes.emplace_back(strfrom, strto, true, normdir);
 
     //
     // get a list of all the objects
@@ -2562,7 +2582,7 @@ static int update_mctime_parent_directory(const char* _path)
     // on the parent directory.
     //
     if(0 != (result = get_object_attribute(parentpath.c_str(), &stbuf))){
-        // If there is not the target file(object), result is -ENOENT.
+        // If any error occurs(including -ENOENT)
         return result;
     }
     if(!S_ISDIR(stbuf.st_mode)){
@@ -2976,8 +2996,8 @@ static int s3fs_truncate(const char* _path, off_t size FUSE3_FILE_INFO_ARG)
         }
 #endif
 
-    }else{
-        // Not found -> Make tmpfile(with size)
+    }else if(-ENOENT == result){
+        // Creates a sized temporary file only if it doesn't exist(-ENOENT).
         const struct fuse_context* pcxt;
         if(nullptr == (pcxt = fuse_get_context())){
             return -EIO;
@@ -3005,6 +3025,10 @@ static int s3fs_truncate(const char* _path, off_t size FUSE3_FILE_INFO_ARG)
             return result;
         }
         StatCache::getStatCacheData()->DelStat(path);
+
+    }else{
+        // other than -ENOENT
+        S3FS_PRN_ERR("failed to check existence of file(%s): result=%d", path, result);
     }
 
     return result;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2581

### Details
This PR strictly handles HTTP responses in the 500 range (and 429) from the S3 server, mapping them to `errno`(negative) codes.

This PR will change the return code from `S3fsCurl::RequestPerform` as follows:

| HTTP response code | return code(=errno)     |
| ------------------ | ----------------------- |
| 429                | -EAGAIN(after retrying) |
| 501                | -ENOTSUP                |
| 500                | -EIO                    |
| 502                | -ECONNRESET             |
| 503                | -EAGAIN                 |
| 504                | -ETIMEDOUT              |

This addresses the issue pointed out in #2581.

For example, if a HEAD request receives a 503 response, `get_object_attribute` will return `-EAGAIN`.
This means that, for example, when `cat`ing a file, it will look like this:

```
$ cat <file>
  cat: <file>: Resource temporarily unavailable
```

