### PR TITLE
Changed initialization for singletons of StatCache(avoid SIOF)

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -30,26 +30,13 @@
 //-------------------------------------------------------------------
 // Static
 //-------------------------------------------------------------------
-StatCache       StatCache::singleton;
 std::mutex      StatCache::stat_cache_lock;
 
 //-------------------------------------------------------------------
 // Constructor/Destructor
 //-------------------------------------------------------------------
-StatCache::StatCache() : pMountPointDir(nullptr), CacheSize(100'000)
+StatCache::StatCache() : pMountPointDir(std::make_shared<DirStatCache>("/")), CacheSize(100'000)
 {
-    if(this == StatCache::getStatCacheData()){
-        pMountPointDir = std::make_shared<DirStatCache>("/");
-    }else{
-        abort();
-    }
-}
-
-StatCache::~StatCache()
-{
-    if(this != StatCache::getStatCacheData()){
-        abort();
-    }
 }
 
 //-------------------------------------------------------------------

--- a/src/cache.h
+++ b/src/cache.h
@@ -45,7 +45,6 @@
 class StatCache
 {
     private:
-        static StatCache       singleton;
         static std::mutex      stat_cache_lock;
 
         std::shared_ptr<DirStatCache> pMountPointDir GUARDED_BY(stat_cache_lock);   // Top directory = Mount point
@@ -53,7 +52,7 @@ class StatCache
 
     private:
         StatCache();
-        ~StatCache();
+        ~StatCache() = default;
 
         bool AddStatHasLock(const std::string& key, const struct stat* pstbuf, const headers_t* pmeta, objtype_t type, bool notruncate) REQUIRES(StatCache::stat_cache_lock);
         bool TruncateCacheHasLock(bool check_only_oversize_case = true) REQUIRES(StatCache::stat_cache_lock);
@@ -69,6 +68,11 @@ class StatCache
         // Reference singleton
         static StatCache* getStatCacheData()
         {
+            // [NOTE]
+            // Occured SIOF issue in macOS, so the singleton of this class is
+            // initialized within this function.
+            //
+            static StatCache singleton;
             return &singleton;
         }
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2865

### Details
The error reported in #2865 on macOS is an initialization issue with the StatCache singleton object.
(see, SIOF: Static Initialization Order Fiasco)

The error in #2865 indicates that s3fs attempts to terminate because no bucket was specified during s3fs startup, but a fatal error occurs during the termination process.

This fatal error occurs during the destructuring of the StatCache singleton object, caused by a failure in the initialization of the static object declared as a singleton (StatCache).

This PR only addresses the SIOF issues confirmed at this time.
We will address any other issues that may occur in the future.
No test cases related to this issue will be added. (Implementing this as a permanent test is difficult.)