### PR TITLE
Fix deadlock in mix_multipart_upload_request on schedule failure

### DIFF
--- a/src/s3fs_threadreqs.cpp
+++ b/src/s3fs_threadreqs.cpp
@@ -1139,7 +1139,7 @@ int mix_multipart_upload_request(const std::string& path, headers_t& meta, int u
             // Each part must be larger than MIN_MULTIPART_SIZE and smaller than FIVE_GB, then loop.
             // This loop breaks if result is not 0.
             //
-            for(off_t processed_bytes = 0, request_bytes = 0; processed_bytes < iter->bytes && 0 == result; processed_bytes += request_bytes){
+            for(off_t processed_bytes = 0, request_bytes = 0; processed_bytes < iter->bytes; processed_bytes += request_bytes){
                 // Set temporary part sizes
                 request_bytes = std::min(S3fsCurl::GetMultipartCopySize(), (iter->bytes - processed_bytes));
 
@@ -1169,6 +1169,7 @@ int mix_multipart_upload_request(const std::string& path, headers_t& meta, int u
                     S3FS_PRN_ERR("Failed setup instruction for Mix Multipart Upload Copy Part Request by error(%d) [path=%s][start=%lld][size=%lld][part_num=%d]", result, path.c_str(), static_cast<long long int>(iter->offset + processed_bytes), static_cast<long long int>(request_bytes), (req_count + 1));
                     // [NOTE]
                     // This loop breaks because result is not 0.
+                    break;
                 }
                 ++req_count;
             }


### PR DESCRIPTION
When ThreadPoolMan::Instruct fails, multipart_upload_part_request returns -EIO without scheduling a worker, so the upload semaphore is never signaled for that part. The multipart upload copy loop incremented req_count unconditionally at the end of every iteration, so on a scheduling failure req_count grew one larger than the number of in-flight workers. The subsequent drain loop

    while(req_count > 0){ upload_sem.acquire(); --req_count; }

then blocked forever waiting for a release that no worker would ever produce. Because this code runs under FdEntity's fdent_lock and fdent_data_lock (via RowFlushHasLock -> RowFlushMixMultipart), every subsequent read, write, or flush against the same FdEntity also hung.

The for loop's 0 == result continuation only guards the next iteration. The body of the failing iteration still ran to its end, including the increment. The sibling modified branch and the simpler multipart_upload_request already break on scheduling failure and gate ++req_count behind successful scheduling. Apply the same pattern to the copy loop and drop the now-redundant 0 == result clause from the for condition, so that the drain count matches the actual worker count.