### PR TITLE
Use gsha256sum on macOS in integration tests

### DIFF
--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -172,7 +172,7 @@ function start_s3proxy {
         if [ ! -e "${S3PROXY_BINARY}" ]; then
             curl "https://github.com/gaul/s3proxy/releases/download/s3proxy-${S3PROXY_VERSION}/s3proxy" \
                 --fail --location --silent --output "/tmp/${S3PROXY_BINARY}"
-            echo "$S3PROXY_HASH" "/tmp/${S3PROXY_BINARY}" | sha256sum --check
+            echo "$S3PROXY_HASH" "/tmp/${S3PROXY_BINARY}" | "${SHA256SUM_BIN}" --check
             mv "/tmp/${S3PROXY_BINARY}" "${S3PROXY_BINARY}"
             chmod +x "${S3PROXY_BINARY}"
         fi
@@ -202,7 +202,7 @@ function start_s3proxy {
         if [ ! -e "${CHAOS_HTTP_PROXY_BINARY}" ]; then
             curl "https://github.com/bouncestorage/chaos-http-proxy/releases/download/chaos-http-proxy-${CHAOS_HTTP_PROXY_VERSION}/chaos-http-proxy" \
                 --fail --location --silent --output "/tmp/${CHAOS_HTTP_PROXY_BINARY}"
-            echo "$CHAOS_HTTP_PROXY_HASH" "/tmp/${CHAOS_HTTP_PROXY_BINARY}" | sha256sum --check
+            echo "$CHAOS_HTTP_PROXY_HASH" "/tmp/${CHAOS_HTTP_PROXY_BINARY}" | "${SHA256SUM_BIN}" --check
             mv "/tmp/${CHAOS_HTTP_PROXY_BINARY}" "${CHAOS_HTTP_PROXY_BINARY}"
             chmod +x "${CHAOS_HTTP_PROXY_BINARY}"
         fi

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -72,10 +72,12 @@ if [ "$(uname)" = "Darwin" ]; then
         export STDBUF_BIN=""
     fi
     export TRUNCATE_BIN="gtruncate"
+    export SHA256SUM_BIN="gsha256sum"
 else
     export STAT_BIN="stat"
     export STDBUF_BIN="stdbuf"
     export TRUNCATE_BIN="truncate"
+    export SHA256SUM_BIN="sha256sum"
 fi
 
 # [NOTE]


### PR DESCRIPTION
BSD sha256sum on Darwin lacks --check; mirror the STAT_BIN/TRUNCATE_BIN pattern by introducing SHA256SUM_BIN (gsha256sum on Darwin, sha256sum elsewhere) so test/small-integration-test.sh runs locally on macOS.