### PR TITLE
Simplify Windows build by using WinFsp's bundled fuse3.pc

### DIFF
--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -97,39 +97,21 @@ On Windows, use [MSYS2](https://www.msys2.org/) to compile for itself.
    ```
 
 3. Clone this repository, then change directory into the cloned one.
-4. Copy WinFsp files to the directory:
+4. Copy WinFsp files to the directory, because compiler have trouble with spaces in path:
 
    ```sh
    cp -r "/c/Program Files (x86)/WinFsp" "./WinFsp"
    ```
 
-5. Write `fuse.pc` to resolve the package correctly:
-
-   ```sh
-   cat > ./fuse.pc << 'EOS'
-   arch=x64
-   prefix=${pcfiledir}/WinFsp
-   incdir=${prefix}/inc/fuse
-   implib=${prefix}/bin/winfsp-${arch}.dll
-
-   Name: fuse
-   Description: WinFsp FUSE compatible API
-   Version: 2.8.4
-   URL: http://www.secfs.net/winfsp/
-   Libs: "${implib}"
-   Cflags: -I"${incdir}"
-   EOS
-   ```
-
-6. Compile using the command line:
+5. Compile using the command line in MSYS2 MSYS shell:
 
    ```sh
    ./autogen.sh
-   PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(pwd)" ./configure
-   make CXXFLAGS="-I/usr/include"
+   PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(pwd)/WinFsp/lib" ./configure
+   make
    ```
 
-7. Copy binary files to distribute at one place:
+6. Copy binary files to distribute at one place:
 
    ```sh
    mkdir ./bin
@@ -138,4 +120,4 @@ On Windows, use [MSYS2](https://www.msys2.org/) to compile for itself.
    cp /usr/bin/msys-*.dll ./bin/
    ```
 
-8. Distribute these files.
+7. Distribute these files.

--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,7 @@ dnl ----------------------------------------------
 dnl For macOS
 dnl ----------------------------------------------
 case "$target" in
-   *-cygwin* )
+   *-cygwin* | *-mingw* | *-msys* )
       # Do something specific for windows using winfsp
       CXXFLAGS="$CXXFLAGS -D_GNU_SOURCE=1"
       min_fuse_version=2.8

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -2439,7 +2439,7 @@ int FdEntity::UploadPendingHasLock(int fd)
 // For systems where the fallocate function cannot be detected, use a dummy function.
 // ex. OSX
 //
-#if !defined(HAVE_FALLOCATE) || defined(__MSYS__)
+#ifndef HAVE_FALLOCATE
 static int fallocate(int /*fd*/, int /*mode*/, off_t /*offset*/, off_t /*len*/)
 {
     errno = ENOSYS;     // This is a bad idea, but the caller can handle it simply.


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2503

### Details
This PR fixes and simplifies the Windows (MSYS2/MinGW/Cygwin) build process by correcting the root causes of the compilation errors from #2503, which were misattributed in the previous fix (PR #2506).

**Root cause analysis:** The `sigwait`/`sigaction` errors in #2503 were caused by `_GNU_SOURCE` not being defined. The original reporter likely used the UCRT64 or MINGW64 shell (where `target` is `x86_64-w64-mingw32`), which did not match the `*-cygwin*` pattern in `configure.ac` and thus missed the branch that adds `-D_GNU_SOURCE=1`. The previous fix of `make CXXFLAGS="-I/usr/include"` worked not because `-I/usr/include` had any real effect, but because specifying `CXXFLAGS` replaced the default `-std=c++11`, which indirectly enabled GNU-specific code paths. Similarly, the `__MSYS__` guard for `fallocate` was a workaround that masked the same underlying issue.

**Changes:**
- **COMPILATION.md**: Remove the manual `fuse.pc` generation step — it is now obsolete since s3fs requires `fuse3.pc` instead of `fuse.pc`, and the manually written `fuse.pc` no longer works. WinFsp ships a `fuse3.pc` under `WinFsp/lib`, so setting `PKG_CONFIG_PATH` to include that directory is sufficient. Remove the `CXXFLAGS="-I/usr/include"` workaround — it had no real effect and only worked by accident (replacing `-std=c++11`). Clarify that the WinFsp directory copy is needed because the compiler has trouble with spaces in paths. Note that compilation should be done in the MSYS2 MSYS shell.
- **configure.ac**: Extend the Windows platform case pattern from `*-cygwin*` to `*-cygwin* | *-mingw* | *-msys*` so that it works even if the wrong MSYS2 shell (UCRT64/MINGW64) is used. This ensures `-D_GNU_SOURCE=1` is added to `CXXFLAGS` for all Windows targets, which is the actual fix for the `sigwait`/`sigaction` errors.
- **src/fdcache_entity.cpp**: Remove the `__MSYS__` special-case guard in the `fallocate` dummy function. With `_GNU_SOURCE` properly defined for all Windows targets, `HAVE_FALLOCATE` detection works correctly via `configure`, making the `__MSYS__` override unnecessary.