### PR TITLE
Fixed the initialization of variables that could potentially cause SIOF

### DIFF
--- a/src/addhead.cpp
+++ b/src/addhead.cpp
@@ -37,29 +37,11 @@
 static constexpr char ADD_HEAD_REGEX[] = "reg:";
 
 //-------------------------------------------------------------------
-// Class AdditionalHeader
-//-------------------------------------------------------------------
-AdditionalHeader AdditionalHeader::singleton;
-
-//-------------------------------------------------------------------
 // Class AdditionalHeader method
 //-------------------------------------------------------------------
-AdditionalHeader::AdditionalHeader()
-{
-    if(this == AdditionalHeader::get()){
-        is_enable = false;
-    }else{
-        abort();
-    }
-}
-
 AdditionalHeader::~AdditionalHeader()
 {
-    if(this == AdditionalHeader::get()){
-        Unload();
-    }else{
-        abort();
-    }
+    Unload();
 }
 
 bool AdditionalHeader::Load(const char* file)

--- a/src/addhead.h
+++ b/src/addhead.h
@@ -61,12 +61,11 @@ using addheadlist_t = std::vector<add_header>;
 class AdditionalHeader
 {
     private:
-        static AdditionalHeader singleton;
-        bool                    is_enable;
-        addheadlist_t           addheadlist;
+        bool            is_enable = false;
+        addheadlist_t   addheadlist;
 
     protected:
-        AdditionalHeader();
+        AdditionalHeader() = default;
         ~AdditionalHeader();
 
     public:
@@ -76,7 +75,11 @@ class AdditionalHeader
         AdditionalHeader& operator=(AdditionalHeader&&) = delete;
 
         // Reference singleton
-        static AdditionalHeader* get() { return &singleton; }
+        static AdditionalHeader* get()
+        {
+            static AdditionalHeader singleton;
+            return &singleton;
+        }
 
         bool Load(const char* file);
         void Unload();

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -77,7 +77,6 @@ static constexpr char NOCACHE_PATH_PREFIX_FORM[] = " __S3FS_UNEXISTED_PATH_%lx__
 //------------------------------------------------
 // FdManager class variable
 //------------------------------------------------
-FdManager       FdManager::singleton;
 std::mutex      FdManager::fd_manager_lock;
 std::mutex      FdManager::cache_cleanup_lock;
 std::mutex      FdManager::reserved_diskspace_lock;
@@ -435,7 +434,7 @@ bool FdManager::HasOpenEntityFd(const char* path)
 
     const FdEntity* ent;
     int         fd = -1;
-    if(nullptr == (ent = FdManager::singleton.GetFdEntityHasLock(path, fd, false))){
+    if(nullptr == (ent = FdManager::get()->GetFdEntityHasLock(path, fd, false))){
         return false;
     }
     return (0 < ent->GetOpenCount());
@@ -448,31 +447,20 @@ int FdManager::GetOpenFdCount(const char* path)
 {
     const std::lock_guard<std::mutex> lock(FdManager::fd_manager_lock);
 
-    return FdManager::singleton.GetPseudoFdCount(path);
+    return FdManager::get()->GetPseudoFdCount(path);
 }
 
 //------------------------------------------------
 // FdManager methods
 //------------------------------------------------
-FdManager::FdManager()
-{
-    if(this != FdManager::get()){
-        abort();
-    }
-}
-
 FdManager::~FdManager()
 {
-    if(this == FdManager::get()){
-        for(auto iter = fent.cbegin(); fent.cend() != iter; ++iter){
-            const FdEntity* ent = iter->second.get();
-            S3FS_PRN_WARN("To exit with the cache file opened: path=%s, refcnt=%d", ent->GetPath().c_str(), ent->GetOpenCount());
-        }
-        fent.clear();
-        except_fent.clear();
-    }else{
-        abort();
+    for(auto iter = fent.cbegin(); fent.cend() != iter; ++iter){
+        const FdEntity* ent = iter->second.get();
+        S3FS_PRN_WARN("To exit with the cache file opened: path=%s, refcnt=%d", ent->GetPath().c_str(), ent->GetOpenCount());
     }
+    fent.clear();
+    except_fent.clear();
 }
 
 FdEntity* FdManager::GetFdEntityHasLock(const char* path, int& existfd, bool newfd)

--- a/src/fdcache.h
+++ b/src/fdcache.h
@@ -34,7 +34,6 @@
 class FdManager
 {
   private:
-      static FdManager       singleton;
       static std::mutex      fd_manager_lock;
       static std::mutex      cache_cleanup_lock;
       static std::mutex      reserved_diskspace_lock;
@@ -65,7 +64,7 @@ class FdManager
       bool RawCheckAllCache(FILE* fp, const char* cache_stat_top_dir, const char* sub_path, int& total_file_cnt, int& err_file_cnt, int& err_dir_cnt);
 
   public:
-      FdManager();
+      FdManager() = default;
       ~FdManager();
       FdManager(const FdManager&) = delete;
       FdManager(FdManager&&) = delete;
@@ -73,7 +72,11 @@ class FdManager
       FdManager& operator=(FdManager&&) = delete;
 
       // Reference singleton
-      static FdManager* get() { return &singleton; }
+      static FdManager* get()
+      {
+          static FdManager  singleton;
+          return &singleton;
+      }
 
       static bool DeleteCacheDirectory();
       static int DeleteCacheFile(const char* path);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -82,7 +82,6 @@ static mode_t mp_mode             = 0;    // mode of mount point
 static mode_t mp_umask            = 0;    // umask for mount point
 static bool is_mp_umask           = false;// default does not set.
 static std::string mountpoint;
-static std::unique_ptr<S3fsCred> ps3fscred; // using only in this file
 static std::string mimetype_file;
 static bool nocopyapi             = false;
 static bool norenameapi           = false;
@@ -4458,7 +4457,7 @@ static void* s3fs_init(struct fuse_conn_info* conn, fuse_config* config)
 static void* s3fs_init(struct fuse_conn_info* conn)
 #endif
 {
-    S3FS_PRN_INIT_INFO("init v%s%s with %s, credential-library(%s)", VERSION, COMMIT_HASH_VAL, s3fs_crypt_lib_name(), ps3fscred->GetCredFuncVersion(false));
+    S3FS_PRN_INIT_INFO("init v%s%s with %s, credential-library(%s)", VERSION, COMMIT_HASH_VAL, s3fs_crypt_lib_name(), S3fsCred::get()->GetCredFuncVersion(false));
 
     // cache(remove cache dirs at first)
     if(is_remove_cache && (!CacheFileStat::DeleteCacheFileStatDirectory() || !FdManager::DeleteCacheDirectory())){
@@ -4471,7 +4470,7 @@ static void* s3fs_init(struct fuse_conn_info* conn)
     }
 
     // check loading IAM role name
-    if(!ps3fscred->LoadIAMRoleFromMetaData()){
+    if(!S3fsCred::get()->LoadIAMRoleFromMetaData()){
         S3FS_PRN_CRIT("could not load IAM role name from meta data.");
         s3fs_exit_fuseloop(EXIT_FAILURE);
         return nullptr;
@@ -4499,10 +4498,8 @@ static void* s3fs_init(struct fuse_conn_info* conn)
     }
 #endif
 
-    // Signal object
-    if(!S3fsSignals::Initialize()){
-        S3FS_PRN_ERR("Failed to initialize signal object, but continue...");
-    }
+    // Signal object(always true)
+    S3fsSignals::Initialize();
 
     return nullptr;
 }
@@ -4510,11 +4507,6 @@ static void* s3fs_init(struct fuse_conn_info* conn)
 static void s3fs_destroy(void*)
 {
     S3FS_PRN_INFO("destroy");
-
-    // Signal object
-    if(!S3fsSignals::Destroy()){
-        S3FS_PRN_WARN("Failed to clean up signal object.");
-    }
 
     ThreadPoolMan::Destroy();
 
@@ -4683,7 +4675,7 @@ static int s3fs_check_service()
     S3FS_PRN_INFO("check services.");
 
     // At first time for access S3, we check IAM role if it sets.
-    if(!ps3fscred->CheckIAMCredentialUpdate()){
+    if(!S3fsCred::get()->CheckIAMCredentialUpdate()){
         S3FS_PRN_CRIT("Failed to initialize IAM credential.");
         return EXIT_FAILURE;
     }
@@ -5325,7 +5317,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
         //
         // Detect options for credential
         //
-        else if(0 >= (ret = ps3fscred->DetectParam(arg))){
+        else if(0 >= (ret = S3fsCred::get()->DetectParam(arg))){
             if(0 > ret){
                 return -1;
             }
@@ -5858,8 +5850,7 @@ int main(int argc, char* argv[])
 
     // set credential object
     //
-    ps3fscred = std::make_unique<S3fsCred>();
-    if(!S3fsCurl::InitCredentialObject(ps3fscred.get())){
+    if(!S3fsCurl::InitCredentialObject(S3fsCred::get())){
         S3FS_PRN_EXIT("Failed to setup credential object to s3fs curl.");
         exit(EXIT_FAILURE);
     }
@@ -5994,7 +5985,7 @@ int main(int argc, char* argv[])
     //
     // Check the combination of parameters for credential
     //
-    if(!ps3fscred->CheckAllParams()){
+    if(!S3fsCred::get()->CheckAllParams()){
         S3fsCurl::DestroyS3fsCurl();
         s3fs_destroy_global_ssl();
         exit(EXIT_FAILURE);

--- a/src/s3fs_cred.h
+++ b/src/s3fs_cred.h
@@ -168,6 +168,12 @@ class S3fsCred
         static bool CheckForbiddenBucketParams();
 
     public:
+        static S3fsCred* get()
+        {
+            static S3fsCred s3fscred;
+            return &s3fscred;
+        }
+
         static bool SetBucket(const std::string& bucket);
         static const std::string& GetBucket();
 

--- a/src/sighandlers.cpp
+++ b/src/sighandlers.cpp
@@ -31,26 +31,11 @@
 //-------------------------------------------------------------------
 // Class S3fsSignals
 //-------------------------------------------------------------------
-std::unique_ptr<S3fsSignals> S3fsSignals::pSingleton;
-bool S3fsSignals::enableUsr1         = false;
+bool S3fsSignals::enableUsr1 = false;
 
 //-------------------------------------------------------------------
 // Class methods
 //-------------------------------------------------------------------
-bool S3fsSignals::Initialize()
-{
-    if(!S3fsSignals::pSingleton){
-        S3fsSignals::pSingleton = std::make_unique<S3fsSignals>();
-    }
-    return true;
-}
-
-bool S3fsSignals::Destroy()
-{
-    S3fsSignals::pSingleton.reset();
-    return true;
-}
-
 void S3fsSignals::HandlerUSR1(int sig)
 {
     if(SIGUSR1 != sig){
@@ -58,13 +43,7 @@ void S3fsSignals::HandlerUSR1(int sig)
         return;
     }
 
-    S3fsSignals* pSigobj = S3fsSignals::get();
-    if(!pSigobj){
-        S3FS_PRN_ERR("S3fsSignals object is not initialized.");
-        return;
-    }
-
-    if(!pSigobj->WakeupUsr1Thread()){
+    if(!S3fsSignals::get()->WakeupUsr1Thread()){
         S3FS_PRN_ERR("Failed to wakeup the thread for SIGUSR1.");
         return;
     }

--- a/src/sighandlers.h
+++ b/src/sighandlers.h
@@ -32,14 +32,16 @@
 class S3fsSignals
 {
     private:
-        static std::unique_ptr<S3fsSignals> pSingleton;
-        static bool         enableUsr1;
-
+        static bool                  enableUsr1;
         std::unique_ptr<std::thread> pThreadUsr1;
-        std::unique_ptr<Semaphore> pSemUsr1;
+        std::unique_ptr<Semaphore>   pSemUsr1;
 
     protected:
-        static S3fsSignals* get() { return pSingleton.get(); }
+        static S3fsSignals* get()
+        {
+            static S3fsSignals singleton;
+            return &singleton;
+        }
 
         static void HandlerUSR1(int sig);
         static void CheckCacheWorker(Semaphore* pSem);
@@ -62,8 +64,8 @@ class S3fsSignals
         S3fsSignals& operator=(const S3fsSignals&) = delete;
         S3fsSignals& operator=(S3fsSignals&&) = delete;
 
-        static bool Initialize();
-        static bool Destroy();
+        // Call get() to force the creation of a singleton object.
+        static bool Initialize() { (void)get(); return true; }
 
         static bool SetUsr1Handler(const char* path);
 };

--- a/src/threadpoolman.cpp
+++ b/src/threadpoolman.cpp
@@ -34,29 +34,28 @@
 //------------------------------------------------
 // ThreadPoolMan class variables
 //------------------------------------------------
-int                            ThreadPoolMan::worker_count = 10;    // default
-std::unique_ptr<ThreadPoolMan> ThreadPoolMan::singleton;
+int  ThreadPoolMan::worker_count   = 10;        // default
 
 //------------------------------------------------
 // ThreadPoolMan class methods
 //------------------------------------------------
 bool ThreadPoolMan::Initialize(int count)
 {
-    if(ThreadPoolMan::singleton){
+    auto& singleton = ThreadPoolMan::Slot();
+    if(singleton){
         S3FS_PRN_CRIT("Already singleton for Thread Manager exists.");
-        abort();
+        return false;
     }
     if(-1 != count){
         ThreadPoolMan::SetWorkerCount(count);
     }
-    ThreadPoolMan::singleton = std::make_unique<ThreadPoolMan>(ThreadPoolMan::worker_count);
-
+    singleton = std::make_unique<ThreadPoolMan>(ThreadPoolMan::worker_count);
     return true;
 }
 
 void ThreadPoolMan::Destroy()
 {
-    ThreadPoolMan::singleton.reset();
+    ThreadPoolMan::Slot().reset();
 }
 
 int ThreadPoolMan::SetWorkerCount(int count)
@@ -80,7 +79,8 @@ int ThreadPoolMan::SetWorkerCount(int count)
 
 bool ThreadPoolMan::Instruct(const thpoolman_param& param)
 {
-    if(!ThreadPoolMan::singleton){
+    auto& singleton = ThreadPoolMan::Slot();
+    if(!singleton){
         S3FS_PRN_WARN("The singleton object is not initialized yet.");
         return false;
     }
@@ -88,13 +88,14 @@ bool ThreadPoolMan::Instruct(const thpoolman_param& param)
         S3FS_PRN_ERR("Thread parameter Semaphore is null.");
         return false;
     }
-    ThreadPoolMan::singleton->SetInstruction(param);
+    singleton->SetInstruction(param);
     return true;
 }
 
 bool ThreadPoolMan::AwaitInstruct(const thpoolman_param& param)
 {
-    if(!ThreadPoolMan::singleton){
+    auto& singleton = ThreadPoolMan::Slot();
+    if(!singleton){
         S3FS_PRN_WARN("The singleton object is not initialized yet.");
         return false;
     }
@@ -111,7 +112,7 @@ bool ThreadPoolMan::AwaitInstruct(const thpoolman_param& param)
     local_param.pfunc = param.pfunc;
 
     // Set parameters and run thread worker
-    ThreadPoolMan::singleton->SetInstruction(local_param);
+    singleton->SetInstruction(local_param);
 
     // wait until the thread is complete
     await_sem.acquire();
@@ -186,10 +187,6 @@ ThreadPoolMan::ThreadPoolMan(int count) : is_exit(false), thpoolman_sem(0)
 {
     if(count < 1){
         S3FS_PRN_CRIT("Failed to creating singleton for Thread Manager, because thread count(%d) is under 1.", count);
-        abort();
-    }
-    if(ThreadPoolMan::singleton){
-        S3FS_PRN_CRIT("Already singleton for Thread Manager exists.");
         abort();
     }
 

--- a/src/threadpoolman.h
+++ b/src/threadpoolman.h
@@ -63,8 +63,7 @@ using thpoolman_params_t = std::list<thpoolman_param>;
 class ThreadPoolMan
 {
     private:
-        static int                            worker_count;
-        static std::unique_ptr<ThreadPoolMan> singleton;
+        static int            worker_count;
 
         std::atomic<bool>     is_exit;
         Semaphore             thpoolman_sem;
@@ -74,6 +73,11 @@ class ThreadPoolMan
         thpoolman_params_t    instruction_list GUARDED_BY(thread_list_lock);
 
     private:
+        static std::unique_ptr<ThreadPoolMan>& Slot()
+        {
+            static std::unique_ptr<ThreadPoolMan> singleton;
+            return singleton;
+        }
         static void Worker(ThreadPoolMan* psingleton, std::promise<int> promise);
 
         bool IsExit() const;


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2867 #2871

### Details
I have fixed a potential `Static Initialization Order Fiasco`(SIOF).

I replaced some class variables with an access function to ensure safe initialization.
Those variables were pointers to class objects, wrapped in `unique_ptr`, but `unique_ptr` is no longer used because access functions are now available.
Please note that `ThreadPoolMan::singleton` still uses a `unique_ptr`, as I wanted to maintain the current class structure.

These changes are strictly limited to the initialization process; the core logic remains unchanged.

