### PR TITLE
Capture Size and LastModified from ListObjects responses

### DIFF
--- a/src/s3fs_xml.cpp
+++ b/src/s3fs_xml.cpp
@@ -319,7 +319,7 @@ bool is_truncated(xmlDocPtr doc)
     return 0 == strcasecmp(reinterpret_cast<const char*>(strTruncate.get()), "true");
 }
 
-int append_objects_from_xml_ex(const char* path, xmlDocPtr doc, xmlXPathContextPtr ctx, const char* ex_contents, const char* ex_key, const char* ex_etag, int isCPrefix, S3ObjList& head, bool prefix)
+int append_objects_from_xml_ex(const char* path, xmlDocPtr doc, xmlXPathContextPtr ctx, const char* ex_contents, const char* ex_key, const char* ex_etag, const char* ex_size, const char* ex_lastmod, int isCPrefix, S3ObjList& head, bool prefix)
 {
     xmlNodeSetPtr content_nodes;
 
@@ -336,6 +336,8 @@ int append_objects_from_xml_ex(const char* path, xmlDocPtr doc, xmlXPathContextP
 
     bool is_dir;
     std::string stretag;
+    std::string strlastmod;
+    off_t       objsize;
     int i;
     for(i = 0; i < content_nodes->nodeNr; i++){
         ctx->node = content_nodes->nodeTab[i];
@@ -358,8 +360,10 @@ int append_objects_from_xml_ex(const char* path, xmlDocPtr doc, xmlXPathContextP
             S3FS_PRN_WARN("name is something wrong. but continue.");
             break;
         case get_object_name_result::SUCCESS: {
-            is_dir  = isCPrefix ? true : false;
-            stretag = "";
+            is_dir     = isCPrefix ? true : false;
+            stretag    = "";
+            strlastmod = "";
+            objsize    = -1;
 
             if(!isCPrefix && ex_etag){
                 // Get ETag
@@ -377,6 +381,38 @@ int append_objects_from_xml_ex(const char* path, xmlDocPtr doc, xmlXPathContextP
                 }
             }
 
+            if(!isCPrefix && ex_size){
+                // Get Size
+                unique_ptr_xmlXPathObject Size(xmlXPathEvalExpression(reinterpret_cast<const xmlChar*>(ex_size), ctx), xmlXPathFreeObject);
+                if(nullptr != Size){
+                    if(xmlXPathNodeSetIsEmpty(Size->nodesetval)){
+                        S3FS_PRN_INFO("Size->nodesetval is empty.");
+                    }else{
+                        xmlNodeSetPtr size_nodes = Size->nodesetval;
+                        unique_ptr_xmlChar psize(xmlNodeListGetString(doc, size_nodes->nodeTab[0]->xmlChildrenNode, 1), xmlFree);
+                        if(psize){
+                            objsize = cvt_strtoofft(reinterpret_cast<const char*>(psize.get()), /*base=*/ 10);
+                        }
+                    }
+                }
+            }
+
+            if(!isCPrefix && ex_lastmod){
+                // Get LastModified
+                unique_ptr_xmlXPathObject LastModified(xmlXPathEvalExpression(reinterpret_cast<const xmlChar*>(ex_lastmod), ctx), xmlXPathFreeObject);
+                if(nullptr != LastModified){
+                    if(xmlXPathNodeSetIsEmpty(LastModified->nodesetval)){
+                        S3FS_PRN_INFO("LastModified->nodesetval is empty.");
+                    }else{
+                        xmlNodeSetPtr lastmod_nodes = LastModified->nodesetval;
+                        unique_ptr_xmlChar plastmod(xmlNodeListGetString(doc, lastmod_nodes->nodeTab[0]->xmlChildrenNode, 1), xmlFree);
+                        if(plastmod){
+                            strlastmod = reinterpret_cast<const char*>(plastmod.get());
+                        }
+                    }
+                }
+            }
+
             // [NOTE]
             // The XML data passed to this function is CR code(\r) encoded.
             // The function below decodes that encoded CR code.
@@ -386,7 +422,7 @@ int append_objects_from_xml_ex(const char* path, xmlDocPtr doc, xmlXPathContextP
             if(prefix){
                 head.AddCommonPrefix(decname);
             }
-            if(!head.insert(decname.c_str(), (!stretag.empty() ? stretag.c_str() : nullptr), is_dir)){
+            if(!head.insert(decname.c_str(), (!stretag.empty() ? stretag.c_str() : nullptr), is_dir, objsize, (!strlastmod.empty() ? strlastmod.c_str() : nullptr))){
                 S3FS_PRN_ERR("insert_object returns with error.");
                 return -1;
             }
@@ -409,6 +445,8 @@ int append_objects_from_xml(const char* path, xmlDocPtr doc, S3ObjList& head)
     std::string ex_cprefix  = "//";
     std::string ex_prefix;
     std::string ex_etag;
+    std::string ex_size;
+    std::string ex_lastmod;
 
     if(!doc){
         return -1;
@@ -427,15 +465,19 @@ int append_objects_from_xml(const char* path, xmlDocPtr doc, S3ObjList& head)
         ex_cprefix += "s3:";
         ex_prefix  += "s3:";
         ex_etag    += "s3:";
+        ex_size    += "s3:";
+        ex_lastmod += "s3:";
     }
     ex_contents+= "Contents";
     ex_key     += "Key";
     ex_cprefix += "CommonPrefixes";
     ex_prefix  += "Prefix";
     ex_etag    += "ETag";
+    ex_size    += "Size";
+    ex_lastmod += "LastModified";
 
-    if(-1 == append_objects_from_xml_ex(prefix.c_str(), doc, ctx.get(), ex_contents.c_str(), ex_key.c_str(), ex_etag.c_str(), 0, head, /*prefix=*/ false) ||
-       -1 == append_objects_from_xml_ex(prefix.c_str(), doc, ctx.get(), ex_cprefix.c_str(), ex_prefix.c_str(), nullptr, 1, head, /*prefix=*/ true) )
+    if(-1 == append_objects_from_xml_ex(prefix.c_str(), doc, ctx.get(), ex_contents.c_str(), ex_key.c_str(), ex_etag.c_str(), ex_size.c_str(), ex_lastmod.c_str(), 0, head, /*prefix=*/ false) ||
+       -1 == append_objects_from_xml_ex(prefix.c_str(), doc, ctx.get(), ex_cprefix.c_str(), ex_prefix.c_str(), nullptr, nullptr, nullptr, 1, head, /*prefix=*/ true) )
     {
         S3FS_PRN_ERR("append_objects_from_xml_ex returns with error.");
         return -1;

--- a/src/s3fs_xml.h
+++ b/src/s3fs_xml.h
@@ -86,7 +86,7 @@ class s3fsXmlBufferParserError
 // Functions
 //-------------------------------------------------------------------
 bool is_truncated(xmlDocPtr doc);
-int append_objects_from_xml_ex(const char* path, xmlDocPtr doc, xmlXPathContextPtr ctx, const char* ex_contents, const char* ex_key, const char* ex_etag, int isCPrefix, S3ObjList& head, bool prefix);
+int append_objects_from_xml_ex(const char* path, xmlDocPtr doc, xmlXPathContextPtr ctx, const char* ex_contents, const char* ex_key, const char* ex_etag, const char* ex_size, const char* ex_lastmod, int isCPrefix, S3ObjList& head, bool prefix);
 int append_objects_from_xml(const char* path, xmlDocPtr doc, S3ObjList& head);
 unique_ptr_xmlChar get_next_continuation_token(xmlDocPtr doc);
 unique_ptr_xmlChar get_next_marker(xmlDocPtr doc);

--- a/src/s3objlist.cpp
+++ b/src/s3objlist.cpp
@@ -38,7 +38,7 @@
 // will be set to type. If it is not a directory(file, symbolic link), type will
 // be set to objtype_t::UNKNOWN.
 //
-bool S3ObjList::insert(const char* name, const char* etag, bool is_dir)
+bool S3ObjList::insert(const char* name, const char* etag, bool is_dir, off_t size, const char* last_modified)
 {
     if(!name || '\0' == name[0]){
         return false;
@@ -95,6 +95,12 @@ bool S3ObjList::insert(const char* name, const char* etag, bool is_dir)
         if(etag){
             iter->second.etag = etag;  // over write
         }
+        if(0 <= size){
+            iter->second.size = size;
+        }
+        if(last_modified){
+            iter->second.last_modified = last_modified;
+        }
     }else{
         // add new object
         s3obj_entry newobject;
@@ -102,6 +108,12 @@ bool S3ObjList::insert(const char* name, const char* etag, bool is_dir)
         newobject.type    = type;
         if(etag){
             newobject.etag = etag;
+        }
+        if(0 <= size){
+            newobject.size = size;
+        }
+        if(last_modified){
+            newobject.last_modified = last_modified;
         }
         objects[newname] = std::move(newobject);
     }
@@ -189,6 +201,32 @@ std::string S3ObjList::GetETag(const char* name) const
         return "";
     }
     return ps3obj->etag;
+}
+
+off_t S3ObjList::GetSize(const char* name) const
+{
+    const s3obj_entry* ps3obj;
+
+    if(!name || '\0' == name[0]){
+        return -1;
+    }
+    if(nullptr == (ps3obj = GetS3Obj(name))){
+        return -1;
+    }
+    return ps3obj->size;
+}
+
+std::string S3ObjList::GetLastModified(const char* name) const
+{
+    const s3obj_entry* ps3obj;
+
+    if(!name || '\0' == name[0]){
+        return "";
+    }
+    if(nullptr == (ps3obj = GetS3Obj(name))){
+        return "";
+    }
+    return ps3obj->last_modified;
 }
 
 bool S3ObjList::IsDir(const char* name) const
@@ -301,10 +339,12 @@ void S3ObjList::Dump(const std::string& indent, std::ostringstream& oss) const
     oss << indent << "S3ObjList::objects = {" << std::endl;
     for(auto oiter = objects.cbegin(); objects.cend() != oiter; ++oiter){
         oss << child_indent << "[" << oiter->first << "] = {" << std::endl;
-        oss << child_member_indent << "normalname = " << oiter->second.normalname        << std::endl;
-        oss << child_member_indent << "orgname    = " << oiter->second.orgname           << std::endl;
-        oss << child_member_indent << "etag       = " << oiter->second.etag              << std::endl;
-        oss << child_member_indent << "type       = " << STR_OBJTYPE(oiter->second.type) << std::endl;
+        oss << child_member_indent << "normalname    = " << oiter->second.normalname        << std::endl;
+        oss << child_member_indent << "orgname       = " << oiter->second.orgname           << std::endl;
+        oss << child_member_indent << "etag          = " << oiter->second.etag              << std::endl;
+        oss << child_member_indent << "size          = " << oiter->second.size              << std::endl;
+        oss << child_member_indent << "last_modified = " << oiter->second.last_modified     << std::endl;
+        oss << child_member_indent << "type          = " << STR_OBJTYPE(oiter->second.type) << std::endl;
         oss << child_indent << "}" << std::endl;
     }
     oss << indent << "}" << std::endl;

--- a/src/s3objlist.h
+++ b/src/s3objlist.h
@@ -23,6 +23,7 @@
 
 #include <map>
 #include <string>
+#include <sys/types.h>
 #include <utility>
 #include <vector>
 #include <sstream>
@@ -36,6 +37,8 @@ struct s3obj_entry{
     std::string normalname;                 // normalized name: if empty, object is normalized name.
     std::string orgname;                    // original name: if empty, object is original name.
     std::string etag;
+    off_t       size = -1;                  // Size from ListObjects <Contents>; -1 if unknown (e.g. CommonPrefix).
+    std::string last_modified;              // LastModified from ListObjects <Contents>, raw ISO 8601 string; empty if unknown.
     objtype_t   type = objtype_t::UNKNOWN;  // only set for directories, UNKNOWN for non-directories.
 };
 
@@ -61,10 +64,12 @@ class S3ObjList
 
     public:
         bool IsEmpty() const { return objects.empty(); }
-        bool insert(const char* name, const char* etag = nullptr, bool is_dir = false);
+        bool insert(const char* name, const char* etag = nullptr, bool is_dir = false, off_t size = -1, const char* last_modified = nullptr);
         std::string GetOrgName(const char* name) const;
         std::string GetNormalizedName(const char* name) const;
         std::string GetETag(const char* name) const;
+        off_t GetSize(const char* name) const;
+        std::string GetLastModified(const char* name) const;
         const std::vector<std::string>& GetCommonPrefixes() const { return common_prefixes; }
         void AddCommonPrefix(std::string prefix) { common_prefixes.push_back(std::move(prefix)); }
         bool IsDir(const char* name) const;


### PR DESCRIPTION
Extends the LIST XML parser and S3ObjList to retain Size and LastModified from <Contents> entries. CommonPrefixes still carry neither, since those elements lack the fields. No behavior change on its own — the values are populated but not yet consumed. Groundwork for future readdir/getattr paths that fabricate stat from LIST data instead of issuing per-object HEAD requests. References #1482.