### PR TITLE
Return early from s3fs_write when underlying write fails

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3158,6 +3158,7 @@ static int s3fs_write(const char* _path, const char* buf, size_t size, off_t off
 
     if(0 > (res = ent->Write(static_cast<int>(fi->fh), buf, offset, size))){
         S3FS_PRN_WARN("failed to write file(%s). result=%zd", path, res);
+        return static_cast<int>(res);
     }
 
     int    result;


### PR DESCRIPTION
Previously a failed ent->Write() only logged a warning and continued, bumping mtime/ctime and possibly triggering RowFlush, which would upload the partial state and update the stat cache as if the write had succeeded.