### PR TITLE
Fix infinite loop in DirStatCache::TruncateCacheHasLock

### DIFF
--- a/src/cache_node.cpp
+++ b/src/cache_node.cpp
@@ -1429,6 +1429,7 @@ bool DirStatCache::TruncateCacheHasLock()
         std::string strLeafName;
         bool        hasNestedChildren = false;
         if(!GetChildLeafNameHasLock(iter->second->GetPathHasLock(), strLeafName, hasNestedChildren)){
+            ++iter;
             continue;
         }
 


### PR DESCRIPTION
The for-loop has no increment expression and relies on each branch to advance the iterator. The early-continue path when GetChildLeafNameHasLock returns false skipped the advancement, causing an infinite loop on any malformed child entry whose path is shorter than this directory's path or whose leaf name is empty.