### PR TITLE
Replace fixed sleeps in test startup with short polls

### DIFF
--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -129,7 +129,7 @@ else
 fi
 
 # This function execute the function parameters $1 times
-# before giving up, with 1 second delays.
+# before giving up, with 0.1 second delays.
 function retry {
     local N="$1"
     shift
@@ -142,7 +142,7 @@ function retry {
         if [ "${rc}" -eq 0 ]; then
             break
         fi
-        sleep 1
+        sleep 0.1
         echo "Retrying: $*"
     done
 
@@ -352,27 +352,32 @@ function start_s3fs {
             "${@}" &
         echo $! >&3
     ) 3>pid | "${STDBUF_COMMAND_LINE[@]}" awk "{print \"s3fs: \" \$0}" &
-    sleep 1
+    # Poll for the pid file rather than sleeping a fixed second.
+    for _ in $(seq 50); do
+        [ -s pid ] && break
+        sleep 0.1
+    done
     S3FS_PID=$(<pid)
     export S3FS_PID
     rm -f pid
 
     if [ "$(uname)" = "Darwin" ]; then
         local TRYCOUNT=0
-        while [ "${TRYCOUNT}" -le "${RETRIES:=20}" ]; do
+        local MAX_TRIES=$(( ${RETRIES:=20} * 10 ))
+        while [ "${TRYCOUNT}" -le "${MAX_TRIES}" ]; do
             _DF_RESULT=$(df 2>/dev/null)
             if echo "${_DF_RESULT}" | grep -q "${TEST_BUCKET_MOUNT_POINT_1}"; then
                 break;
             fi
-            sleep 1
+            sleep 0.1
             TRYCOUNT=$((TRYCOUNT + 1))
         done
-        if [ "${TRYCOUNT}" -gt "${RETRIES}" ]; then
-            echo "Waited ${TRYCOUNT} seconds, but it could not be mounted."
+        if [ "${TRYCOUNT}" -gt "${MAX_TRIES}" ]; then
+            echo "Waited ${RETRIES} seconds, but it could not be mounted."
             exit 1
         fi
     else
-        retry "${RETRIES:=20}" grep -q "${TEST_BUCKET_MOUNT_POINT_1}" /proc/mounts || exit 1
+        retry "$(( ${RETRIES:=20} * 10 ))" grep -q "${TEST_BUCKET_MOUNT_POINT_1}" /proc/mounts || exit 1
     fi
 
     # Quick way to start system up for manual testing with options under test
@@ -388,11 +393,11 @@ function stop_s3fs {
     # Retry in case file system is in use
     if [ "$(uname)" = "Darwin" ]; then
         if df | grep -q "${TEST_BUCKET_MOUNT_POINT_1}"; then
-            retry 10 df "|" grep -q "${TEST_BUCKET_MOUNT_POINT_1}" "&&" umount "${TEST_BUCKET_MOUNT_POINT_1}"
+            retry 100 df "|" grep -q "${TEST_BUCKET_MOUNT_POINT_1}" "&&" umount "${TEST_BUCKET_MOUNT_POINT_1}"
         fi
     else
         if grep -q "${TEST_BUCKET_MOUNT_POINT_1}" /proc/mounts; then
-            retry 10 grep -q "${TEST_BUCKET_MOUNT_POINT_1}" /proc/mounts "&&" fusermount3 -u "${TEST_BUCKET_MOUNT_POINT_1}"
+            retry 100 grep -q "${TEST_BUCKET_MOUNT_POINT_1}" /proc/mounts "&&" fusermount3 -u "${TEST_BUCKET_MOUNT_POINT_1}"
         fi
     fi
 }

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -401,14 +401,14 @@ function s3_cp() {
 
 function wait_for_port() {
     local PORT="$1"
-    for _ in $(seq 30); do
+    for _ in $(seq 300); do
         if exec 3<>"/dev/tcp/127.0.0.1/${PORT}";
         then
             exec 3<&-  # Close for read
             exec 3>&-  # Close for write
             break
         fi
-        sleep 1
+        sleep 0.1
     done
 }
 


### PR DESCRIPTION
Three integration-test startup paths each waited 1s per iteration:
  - unconditional sleep after launching s3fs in the background, used to give the subshell time to write its pid file
  - macOS mount-poll loop waiting for the s3fs mount to appear in df
  - wait_for_port polling for S3Proxy's listener

Replace the unconditional sleep with a poll on the pid file and shrink the per-iteration sleep on the two existing poll loops from 1s to 0.1s. All three loops now use a 0.1s tick. Total wait budgets are unchanged (5s, 20s, 30s), but the loops exit promptly once the resource is ready.

Local benchmark on macos-fuse-t with S3Proxy, single-test mode: ~3.13s -> ~1.53s per run (~51% reduction); ~17s saved across the ALL_TESTS=1 11-flag matrix.