### PR TITLE
Default integration tests to HTTP against S3Proxy

### DIFF
--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -73,7 +73,9 @@ S3FS=../src/s3fs
 # CHAOS HTTP PROXY does not support HTTPS.
 #
 if [ -z "${CHAOS_HTTP_PROXY}" ] && [ -z "${CHAOS_HTTP_PROXY_OPT}" ]; then
-    : "${S3_URL:="https://127.0.0.1:8080"}"
+    # Default to S3Proxy's HTTP listener (port 8081). The HTTPS listener
+    # on 8080 is still up; override S3_URL to use it if needed.
+    : "${S3_URL:="http://127.0.0.1:8081"}"
 else
     : "${S3_URL:="http://127.0.0.1:8080"}"
 fi


### PR DESCRIPTION
S3Proxy listens on both an HTTP (8081) and HTTPS (8080) port. The default test S3_URL was the HTTPS port, which forced a full TLS handshake for every request. The test driver uses a fresh curl per operation with no connection keep-alive, so RSA signing and X25519 ECDH math run once per call.

Java Flight Recorder samples on S3Proxy under load confirmed the hot stacks were in TLS:

  sun.security.rsa.RSAPSSSignature.engineSign
  sun.security.rsa.RSACore.rsa / crtCrypt
  java.math.BigInteger.oddModPow / modPow
  sun.security.ec.XECOperations.pointMultiply
  sun.security.util.math.intpoly.IntegerPolynomial25519.mult

Switching the default to the HTTP listener removes that per-request handshake. The HTTPS listener is still up, so anyone wanting to exercise the TLS code path can set S3_URL=https://127.0.0.1:8080 (or any other endpoint) on the command line; this is the path already used by run_tests_using_sanitizers.sh.

Benchmark on macos-fuse-t (single flag, full test_main.sh, runs to same failure point in both):

  HTTPS: 43.55s, 43.70s -> ~43.6s avg
  HTTP : 29.18s, 31.35s -> ~30.3s avg
  saving: ~13s per flag (~30%); ~140s across ALL_TESTS=1 11-flag matrix

<!-- --------------------------------------------------------------------------
 Please describe the purpose of the pull request(such as resolving the issue)
 and what the fix/update is.
--------------------------------------------------------------------------- -->

### Relevant Issue (if applicable)
<!-- If there are Issues related to this PullRequest, please list it. -->

### Details
<!-- Please describe the details of PullRequest. -->

