### PR TITLE
Demote per-write timestamp setter logs to DBG

### DIFF
--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -752,7 +752,7 @@ bool FdEntity::GetStatsHasLock(struct stat& st) const
 
 int FdEntity::SetCtimeHasLock(struct timespec time)
 {
-    S3FS_PRN_INFO3("[path=%s][physical_fd=%d][time=%s]", path.c_str(), physical_fd, str(time).c_str());
+    S3FS_PRN_DBG("[path=%s][physical_fd=%d][time=%s]", path.c_str(), physical_fd, str(time).c_str());
 
     if(!valid_timespec(time)){
         return 0;
@@ -764,7 +764,7 @@ int FdEntity::SetCtimeHasLock(struct timespec time)
 
 int FdEntity::SetAtimeHasLock(struct timespec time)
 {
-    S3FS_PRN_INFO3("[path=%s][physical_fd=%d][time=%s]", path.c_str(), physical_fd, str(time).c_str());
+    S3FS_PRN_DBG("[path=%s][physical_fd=%d][time=%s]", path.c_str(), physical_fd, str(time).c_str());
 
     if(!valid_timespec(time)){
         return 0;
@@ -776,7 +776,7 @@ int FdEntity::SetAtimeHasLock(struct timespec time)
 
 int FdEntity::SetMtimeHasLock(struct timespec time)
 {
-    S3FS_PRN_INFO3("[path=%s][physical_fd=%d][time=%s]", path.c_str(), physical_fd, str(time).c_str());
+    S3FS_PRN_DBG("[path=%s][physical_fd=%d][time=%s]", path.c_str(), physical_fd, str(time).c_str());
 
     if(!valid_timespec(time)){
         return 0;


### PR DESCRIPTION
FdEntity::SetCtimeHasLock, SetAtimeHasLock, and SetMtimeHasLock each log their entry at S3FS_PRN_INFO3 — the default info log level — even though every callsite that drives them at scale (s3fs_write line 3165, the per-FUSE-write timestamp update) is itself at DBG.  The result is that at dbglevel=info the on-disk log shows two timestamp-update lines for every page-sized FUSE write while the write itself is invisible, which inverts the normal "operation louder than its bookkeeping" rule and produces ~13000 SetCtime/SetMtime pairs per 25 MB multipart-mix write through fuse-t.

s3fs_read, s3fs_write, FdEntity::Read, and FdEntity::Write all use DBG for their entry trace.  Bring the timestamp setters into line so the per-write hot path is uniformly silent at info.  SetFileTimesHasLock (:794) stays at INFO3 — it's invoked from open/utimens, not per-write.

The rest of S3FS_PRN_INFO3 in the codebase (cache add/update/delete, the four RowFlush variants, NoCacheLoadAndPost) all fire at most once per high-level operation and are unaffected.