### PR TITLE
Demote ThreadPoolMan::Worker generic error log to DBG

### DIFF
--- a/src/threadpoolman.cpp
+++ b/src/threadpoolman.cpp
@@ -165,7 +165,7 @@ void ThreadPoolMan::Worker(ThreadPoolMan* psingleton, std::promise<int> promise)
         // run function
         void* retval;
         if(nullptr != (retval = param.pfunc(s3fscurl, param.args))){
-            S3FS_PRN_WARN("The instruction function returned with something error code(%ld).", reinterpret_cast<long>(retval));
+            S3FS_PRN_DBG("The instruction function returned with something error code(%ld).", reinterpret_cast<long>(retval));
         }
         if(param.psem){
             param.psem->release();


### PR DESCRIPTION
ThreadPoolMan::Worker logs every non-zero return from the instruction function at S3FS_PRN_WARN with the catch-all message "The instruction function returned with something error code(%ld)".  This fires for every -ENOENT a worker propagates, which on macOS happens on a normal schedule for the negative-cache probes against AppleDouble (._X) and .fuse_hidden* sidecar files plus the per-listing missing-object checks: ~16k of these lines appeared in a single 26-minute macos-14 CI run, dwarfing real warnings.

The worker functions themselves already log context (path, request type) at INFO3 on entry, and the curl layer logs the HTTP status, so the WARN at the generic Worker level adds no new information for expected-error paths and drowns out the actual warnings it was meant to surface.  Move it to DBG; callers that wrap a worker can still log at WARN with their own context if a particular -ENOENT is unexpected.