### PR TITLE
Wait between dir deletions in test_truncate_cache on macOS

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -2130,12 +2130,21 @@ function test_truncate_cache() {
     # sometimes resulting in failure.
     # Until this issue is resolved, please delete directories one by one.
     #
+    # On macOS with -o update_parent_dir_stat there is a second race: each
+    # unlink schedules an async update_mctime_parent_directory PUT against
+    # the parent directory marker. If rm advances to rmdir before that PUT
+    # settles, s3fs_rmdir's check_parent_object_access can read a transient
+    # mode value out of the stat cache and return -EACCES (surfaces as
+    # "rm: <dir>: Permission denied"). Wait between iterations so the
+    # parent's metadata update is committed before the next rm runs.
+    #
     if ! uname | grep -q Darwin; then
         # shellcheck disable=SC2046
         rm -rf $(seq 2)
     else
         for dir in $(seq 2); do
             rm -rf "${dir}"
+            wait_ostype 1 "Darwin"
         done
     fi
 }


### PR DESCRIPTION
test_truncate_cache cleans up its two dirs one at a time on Darwin because of issue #2833 (rmdir vs unlink ordering in macos-fuse-t, addressed by 5aeff88).  A second race surfaces with the use_cache flag config that also sets -o update_parent_dir_stat: every s3fs_unlink schedules an async update_mctime_parent_directory PUT that rewrites the parent dir marker's metadata.  When rm advances to rmdir before that PUT settles, s3fs_rmdir's check_parent_object_access reads a transient mode value out of the stat cache and returns -EACCES, surfacing as "rm: <dir>: Permission denied" and failing the test.  The race is real on master + S3Proxy 3.0.0 too but rare; the S3Proxy 3.1.0 upgrade's slower per-request TLS handshake (Jetty 12) widens the window enough to hit it on macos-14 CI.

Add a 1-second wait_ostype after each rm -rf on Darwin so the parent dir's metadata PUT commits before the next rm runs.  Mirrors the existing post-touch wait at the top of the same function.