### PR TITLE
Restrict update parent dir timestamp to only successful modification

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1285,10 +1285,12 @@ static int s3fs_mkdir(const char* _path, mode_t mode)
         S3FS_PRN_ERR("succeed to create the directory(%s), but could not add stat cache.", path);
     }
 
-    // update parent directory timestamp
-    int update_result;
-    if(0 != (update_result = update_mctime_parent_directory(path))){
-        S3FS_PRN_ERR("succeed to create the directory(%s), but could not update timestamp of its parent directory(result=%d).", path, update_result);
+    if(0 == result){
+        // update parent directory timestamp
+        int update_result;
+        if(0 != (update_result = update_mctime_parent_directory(path))){
+            S3FS_PRN_ERR("succeed to create the directory(%s), but could not update timestamp of its parent directory(result=%d).", path, update_result);
+        }
     }
 
     return result;
@@ -1428,10 +1430,12 @@ static int s3fs_rmdir(const char* _path)
         }
     }
 
-    // update parent directory timestamp
-    int update_result;
-    if(0 != (update_result = update_mctime_parent_directory(path))){
-        S3FS_PRN_ERR("succeed to remove the directory(%s), but could not update timestamp of its parent directory(result=%d).", path, update_result);
+    if(0 == result){
+        // update parent directory timestamp
+        int update_result;
+        if(0 != (update_result = update_mctime_parent_directory(path))){
+            S3FS_PRN_ERR("succeed to remove the directory(%s), but could not update timestamp of its parent directory(result=%d).", path, update_result);
+        }
     }
 
     return result;
@@ -1521,10 +1525,12 @@ static int s3fs_symlink(const char* _from, const char* _to)
         }
     }
 
-    // update parent directory timestamp
-    int update_result;
-    if(0 != (update_result = update_mctime_parent_directory(strTo.c_str()))){
-        S3FS_PRN_ERR("succeed to create symbolic link(%s), but could not update timestamp of its parent directory(result=%d).", strTo.c_str(), update_result);
+    if(0 == result){
+        // update parent directory timestamp
+        int update_result;
+        if(0 != (update_result = update_mctime_parent_directory(strTo.c_str()))){
+            S3FS_PRN_ERR("succeed to create symbolic link(%s), but could not update timestamp of its parent directory(result=%d).", strTo.c_str(), update_result);
+        }
     }
 
     return result;
@@ -1987,14 +1993,16 @@ static int s3fs_rename(const char* _from, const char* _to)
         }
     }
 
-    // update parent directory timestamp
-    //
-    // [NOTE]
-    // already updated timestamp for original path in above functions.
-    //
-    int update_result;
-    if(0 != (update_result = update_mctime_parent_directory(to))){
-        S3FS_PRN_ERR("succeed to create the file/directory(%s), but could not update timestamp of its parent directory(result=%d).", to, update_result);
+    if(0 == result){
+        // update parent directory timestamp
+        //
+        // [NOTE]
+        // already updated timestamp for original path in above functions.
+        //
+        int update_result;
+        if(0 != (update_result = update_mctime_parent_directory(to))){
+            S3FS_PRN_ERR("succeed to create the file/directory(%s), but could not update timestamp of its parent directory(result=%d).", to, update_result);
+        }
     }
 
     return result;
@@ -3262,7 +3270,7 @@ static int s3fs_flush(const char* _path, struct fuse_file_info* fi)
             StatCache::getStatCacheData()->DelStat(strpath);
         }
 
-        if(is_new_file){
+        if(is_new_file && 0 == result){
             // update parent directory timestamp
             int update_result;
             if(0 != (update_result = update_mctime_parent_directory(path))){
@@ -3301,7 +3309,7 @@ static int s3fs_fsync(const char* _path, int datasync, struct fuse_file_info* fi
             ent->MarkDirtyMetadata();
         }
 
-        if(is_new_file){
+        if(is_new_file && 0 == result){
             // update parent directory timestamp
             int update_result;
             if(0 != (update_result = update_mctime_parent_directory(path))){


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2866

### Details
The update_mctime_parent_directory function was sometimes called  even if the previous operation failed.
This has been corrected so that it is only called after a successful  operation.

