### PR TITLE
chore: use AC_CONFIG_HEADERS instead of deprecated AC_CONFIG_HEADER

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
 AC_INIT([s3fs],[1.97])
-AC_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 
 AC_CANONICAL_TARGET
 AM_INIT_AUTOMAKE([foreign])


### PR DESCRIPTION
## Summary

`configure.ac` uses the singular `AC_CONFIG_HEADER` macro, which has been deprecated in Autoconf for years. `autoupdate` (run by `autogen.sh`) already rewrites it to the plural `AC_CONFIG_HEADERS` form on every build, so this just makes the committed source match the modern macro and stop relying on the obsolete spelling.

## Notes

- `AC_PREREQ` is **intentionally left at 2.69** — RockyLinux 8/9 and Debian bullseye in the CI matrix still ship autoconf 2.69, and no macro in this file needs anything newer.

## Testing

Ran `./autogen.sh` in a `rockylinux/rockylinux:8` container (autoconf 2.69, the oldest in the CI matrix): completes without error and generates both `configure` and `config.h.in`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)