### PR TITLE
Fix portability bugs and reduce duplication in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,11 +20,12 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([s3fs],[1.97])
+AC_INIT([s3fs],[1.97],[https://github.com/s3fs-fuse/s3fs-fuse/issues])
 AC_CONFIG_HEADERS([config.h])
 
-AC_CANONICAL_TARGET
+AC_CANONICAL_HOST
 AM_INIT_AUTOMAKE([foreign])
+AM_SILENT_RULES([yes])
 
 AC_PROG_CXX
 AC_PROG_CC
@@ -45,7 +46,7 @@ dnl Also, it may be built-in.
 dnl
 FORTIFY_FLAG=""
 
-AC_MSG_CHECKING([checking _FORTIFY_SOURCE])
+AC_MSG_CHECKING([_FORTIFY_SOURCE])
 
 dnl
 dnl Compile a simple program and check the glibc warnings in the standard error output.
@@ -82,7 +83,7 @@ CXXFLAGS="-Wall -fno-exceptions -D_FILE_OFFSET_BITS=64 $FORTIFY_FLAG -std=$CPP_V
 dnl ----------------------------------------------
 dnl For macOS
 dnl ----------------------------------------------
-case "$target" in
+case "$host" in
    *-cygwin* | *-mingw* | *-msys* )
       # Do something specific for windows using winfsp
       CXXFLAGS="$CXXFLAGS -D_GNU_SOURCE=1"
@@ -109,8 +110,9 @@ found_fuse_t=no
 PKG_CHECK_MODULES([FUSE_T], [fuse-t >= ${min_fuse_t_version}], [found_fuse_t=yes], [found_fuse_t=no])
 
 AS_IF([test "$found_fuse_t" = "yes"],
-  [PKG_CHECK_MODULES([fuse_library_checking], [fuse-t >= ${min_fuse_t_version}])],
-  [PKG_CHECK_MODULES([fuse_library_checking], [fuse3 >= ${min_fuse_version}])])
+  [fuse_pkg="fuse-t >= ${min_fuse_t_version}"],
+  [fuse_pkg="fuse3 >= ${min_fuse_version}"])
+PKG_CHECK_MODULES([fuse_library_checking], [$fuse_pkg])
 
 dnl ----------------------------------------------
 dnl Choice SSL library
@@ -242,9 +244,7 @@ AC_MSG_CHECKING([compile s3fs with])
 case "${auth_lib}" in
 openssl)
   AC_MSG_RESULT(OpenSSL)
-  AS_IF([test "$found_fuse_t" = "yes"],
-    [PKG_CHECK_MODULES([DEPS], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.9 libcrypto >= 1.1.1 ])],
-    [PKG_CHECK_MODULES([DEPS], [fuse3 >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.9 libcrypto >= 1.1.1 ])])
+  PKG_CHECK_MODULES([DEPS], [$fuse_pkg libcurl >= 7.0 libxml-2.0 >= 2.9 libcrypto >= 1.1.1])
 
   saved_CPPFLAGS="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS $DEPS_CFLAGS"
@@ -267,9 +267,7 @@ gnutls)
   AS_IF([test "$gnutls_nettle" = ""], [AC_CHECK_LIB(gcrypt, gcry_control, [gnutls_nettle=0])])
   AS_IF([test $gnutls_nettle = 0],
     [
-      AS_IF([test "$found_fuse_t" = "yes"],
-        [PKG_CHECK_MODULES([DEPS], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.9 gnutls >= 2.12.0 ])],
-        [PKG_CHECK_MODULES([DEPS], [fuse3 >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.9 gnutls >= 2.12.0 ])])
+      PKG_CHECK_MODULES([DEPS], [$fuse_pkg libcurl >= 7.0 libxml-2.0 >= 2.9 gnutls >= 2.12.0])
       LIBS="-lgnutls -lgcrypt $LIBS"
       AC_MSG_CHECKING([gnutls is build with])
       AC_MSG_RESULT(gcrypt)
@@ -283,9 +281,7 @@ nettle)
   AS_IF([test "$gnutls_nettle" = ""], [AC_CHECK_LIB(nettle, nettle_MD5Init, [gnutls_nettle=1])])
   AS_IF([test $gnutls_nettle = 1],
     [
-      AS_IF([test "$found_fuse_t" = "yes"],
-        [PKG_CHECK_MODULES([DEPS], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.9 nettle >= 2.7.1 ])],
-        [PKG_CHECK_MODULES([DEPS], [fuse3 >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.9 nettle >= 2.7.1 ])])
+      PKG_CHECK_MODULES([DEPS], [$fuse_pkg libcurl >= 7.0 libxml-2.0 >= 2.9 nettle >= 2.7.1])
       LIBS="-lgnutls -lnettle $LIBS"
       AC_MSG_CHECKING([gnutls is build with])
       AC_MSG_RESULT(nettle)
@@ -294,9 +290,7 @@ nettle)
   ;;
 nss)
   AC_MSG_RESULT(NSS)
-  AS_IF([test "$found_fuse_t" = "yes"],
-        [PKG_CHECK_MODULES([DEPS], [fuse-t >= ${min_fuse_t_version} libcurl >= 7.0 libxml-2.0 >= 2.9 nss >= 3.15.0 ])],
-        [PKG_CHECK_MODULES([DEPS], [fuse3 >= ${min_fuse_version} libcurl >= 7.0 libxml-2.0 >= 2.9 nss >= 3.15.0 ])])
+  PKG_CHECK_MODULES([DEPS], [$fuse_pkg libcurl >= 7.0 libxml-2.0 >= 2.9 nss >= 3.15.0])
   ;;
 *)
   AC_MSG_ERROR([unknown ssl library type.])
@@ -345,7 +339,7 @@ dnl ----------------------------------------------
 dnl check CURLoption
 dnl ----------------------------------------------
 dnl CURLOPT_TCP_KEEPALIVE (is supported by 7.25.0 and later)
-AC_MSG_CHECKING([checking CURLOPT_TCP_KEEPALIVE])
+AC_MSG_CHECKING([CURLOPT_TCP_KEEPALIVE])
 AC_COMPILE_IFELSE(
   [AC_LANG_PROGRAM([[#include <curl/curl.h>]],
                    [[CURLoption opt = CURLOPT_TCP_KEEPALIVE;]])
@@ -359,7 +353,7 @@ AC_COMPILE_IFELSE(
 )
 
 dnl CURLOPT_SSL_ENABLE_ALPN (is supported by 7.36.0 and later)
-AC_MSG_CHECKING([checking CURLOPT_SSL_ENABLE_ALPN])
+AC_MSG_CHECKING([CURLOPT_SSL_ENABLE_ALPN])
 AC_COMPILE_IFELSE(
   [AC_LANG_PROGRAM([[#include <curl/curl.h>]],
                    [[CURLoption opt = CURLOPT_SSL_ENABLE_ALPN;]])
@@ -373,7 +367,7 @@ AC_COMPILE_IFELSE(
 )
 
 dnl CURLOPT_KEEP_SENDING_ON_ERROR (is supported by 7.51.0 and later)
-AC_MSG_CHECKING([checking CURLOPT_KEEP_SENDING_ON_ERROR])
+AC_MSG_CHECKING([CURLOPT_KEEP_SENDING_ON_ERROR])
 AC_COMPILE_IFELSE(
   [AC_LANG_PROGRAM([[#include <curl/curl.h>]],
                    [[CURLoption opt = CURLOPT_KEEP_SENDING_ON_ERROR;]])
@@ -389,12 +383,12 @@ AC_COMPILE_IFELSE(
 dnl ----------------------------------------------
 dnl dl library
 dnl ----------------------------------------------
-AC_CHECK_LIB([dl], [dlopen, dlclose, dlerror, dlsym], [], [AC_MSG_ERROR([Could not found dlopen, dlclose, dlerror and dlsym])])
+AC_SEARCH_LIBS([dlopen], [dl], [], [AC_MSG_ERROR([Could not find dlopen])])
 
 dnl ----------------------------------------------
 dnl build date
 dnl ----------------------------------------------
-AC_SUBST([MAN_PAGE_DATE], [$(date -r doc/man/s3fs.1.in +"%B %Y")])
+AC_SUBST([MAN_PAGE_DATE], ["m4_esyscmd_s([LC_ALL=C date "+%B %Y"])"])
 
 dnl ----------------------------------------------
 dnl output files
@@ -409,7 +403,7 @@ dnl ----------------------------------------------
 dnl short commit hash
 dnl ----------------------------------------------
 AC_CHECK_PROG([GITCMD], [git --version], [yes], [no])
-AS_IF([test -d .git], [DOTGITDIR=yes], [DOTGITDIR=no])
+AS_IF([test -e .git], [DOTGITDIR=yes], [DOTGITDIR=no])
 
 AC_MSG_CHECKING([github short commit hash])
 if test "x${GITCMD}" = "xyes" -a "x${DOTGITDIR}" = "xyes"; then


### PR DESCRIPTION
- AC_CHECK_LIB([dl], [dlopen, dlclose, dlerror, dlsym], ...) misused the macro (second arg must be a single function name); replace with AC_SEARCH_LIBS so dlopen is detected correctly and -ldl is only linked when actually needed (e.g. pre-glibc-2.34).

- MAN_PAGE_DATE used GNU-only "date -r FILE", which is broken on macOS/BSD where -r expects seconds since epoch. Bake the date in at autoreconf time with m4_esyscmd_s for portability and stable values across configure runs from a release tarball.

- AS_IF([test -d .git], ...) misclassifies git worktrees and submodule checkouts (where .git is a file). Use -e so the commit-hash embedding works in those checkouts.

- Switch from AC_CANONICAL_TARGET / $target to AC_CANONICAL_HOST / $host since the OS-specific branches care about where the binary runs, not codegen target.

- Collapse four duplicated fuse-t-vs-fuse3 PKG_CHECK_MODULES branches via a single $fuse_pkg variable.

- AC_MSG_CHECKING([checking ...]) emitted "checking checking ..."; drop the redundant word in four call sites.

- Add AM_SILENT_RULES([yes]) for tidier default build output (V=1 restores verbose mode).

- Add bug-report URL to AC_INIT so it appears in ./configure --help.

- Fix typo: "Could not found" -> "Could not find".