### PR TITLE
Modernize Makefile.am

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ config.log
 config.status
 config.sub
 configure
+configure~
 configure.scan
 configure.ac~
 depcomp

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,22 +20,16 @@
 
 SUBDIRS=src test doc
 
-EXTRA_DIST=doc default_commit_hash
+EXTRA_DIST=default_commit_hash
 
-dist-hook:
-	rm -rf `find $(distdir)/doc -type d -name .svn`
-	rm -f `find $(distdir)/doc -type f -name Makefile`
-
-release : dist ../utils/release.sh
-	../utils/release.sh $(DIST_ARCHIVES)
-
-.PHONY: cppcheck shellcheck
+.PHONY: cppcheck shellcheck clang-tidy
 
 clang-tidy:
-	make -C src/ clang-tidy
-	make -C test/ clang-tidy
+	$(MAKE) -C src clang-tidy
+	$(MAKE) -C test clang-tidy
 
 cppcheck:
+	pjd_dir=$$(find test -maxdepth 1 -type d -name 'pjd-pjdfstest*' 2>/dev/null); \
 	cppcheck --quiet --error-exitcode=1 \
             --inline-suppr \
             --std=@CPP_VERSION@ \
@@ -45,7 +39,7 @@ cppcheck:
             -D HAVE_MALLOC_TRIM \
             -U CURLE_PEER_FAILED_VERIFICATION \
             -U ENOATTR \
-            -i test/pjd-pjdfstest* \
+            $${pjd_dir:+-i "$$pjd_dir"} \
             --enable=warning,style,information,missingInclude \
             --suppress=missingIncludeSystem \
             --suppress=unmatchedSuppression \
@@ -73,11 +67,11 @@ shellcheck:
 	$(SHELLCHECK_CMD) --version; \
 	echo ""; \
 	echo "* Check all sh files with ShellCheck"; \
-	LC_ALL=C.UTF-8 $(SHELLCHECK_CMD) $(SHELLCHECK_SH_OPT) $(SHELLCHECK_COMMON_IGN) $$(find . -type f -name \*.sh | grep -v pjd-pjdfstest | xargs grep -l '^#![[:space:]]*/bin/sh$$') || exit 1; \
+	LC_ALL=C.UTF-8 $(SHELLCHECK_CMD) $(SHELLCHECK_SH_OPT) $(SHELLCHECK_COMMON_IGN) $$(find . -type d -name 'pjd-pjdfstest*' -prune -o -type f -name '*.sh' -print | xargs grep -l '^#![[:space:]]*/bin/sh$$') || exit 1; \
 	echo "-> No error was detected."; \
 	echo ""; \
 	echo "* Check all bash files with ShellCheck"; \
-	LC_ALL=C.UTF-8 $(SHELLCHECK_CMD) $(SHELLCHECK_BASH_OPT) $(SHELLCHECK_COMMON_IGN) $$(find . -type f -name \*.sh | grep -v pjd-pjdfstest | xargs grep -l '^#![[:space:]]*/bin/bash$$') || exit 1; \
+	LC_ALL=C.UTF-8 $(SHELLCHECK_CMD) $(SHELLCHECK_BASH_OPT) $(SHELLCHECK_COMMON_IGN) $$(find . -type d -name 'pjd-pjdfstest*' -prune -o -type f -name '*.sh' -print | xargs grep -l '^#![[:space:]]*/bin/bash$$') || exit 1; \
 	echo "-> No error was detected.";
 
 #

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,6 +24,17 @@ if USE_GNUTLS_NETTLE
     AM_CPPFLAGS += -DUSE_GNUTLS_NETTLE
 endif
 
+AUTH_SOURCES =
+if USE_SSL_OPENSSL
+    AUTH_SOURCES += openssl_auth.cpp
+endif
+if USE_SSL_GNUTLS
+    AUTH_SOURCES += gnutls_auth.cpp
+endif
+if USE_SSL_NSS
+    AUTH_SOURCES += nss_auth.cpp
+endif
+
 s3fs_SOURCES = \
     s3fs.cpp \
     s3fs_global.cpp \
@@ -55,16 +66,8 @@ s3fs_SOURCES = \
     sighandlers.cpp \
     threadpoolman.cpp \
     syncfiller.cpp \
-    common_auth.cpp
-if USE_SSL_OPENSSL
-    s3fs_SOURCES += openssl_auth.cpp
-endif
-if USE_SSL_GNUTLS
-    s3fs_SOURCES += gnutls_auth.cpp
-endif
-if USE_SSL_NSS
-    s3fs_SOURCES += nss_auth.cpp
-endif
+    common_auth.cpp \
+    $(AUTH_SOURCES)
 
 s3fs_LDADD = $(DEPS_LIBS)
 
@@ -73,16 +76,14 @@ noinst_PROGRAMS = \
     test_page_list \
     test_string_util
 
-test_curl_util_SOURCES = common_auth.cpp curl_util.cpp string_util.cpp test_curl_util.cpp s3fs_global.cpp s3fs_logger.cpp
-if USE_SSL_OPENSSL
-    test_curl_util_SOURCES += openssl_auth.cpp
-endif
-if USE_SSL_GNUTLS
-    test_curl_util_SOURCES += gnutls_auth.cpp
-endif
-if USE_SSL_NSS
-    test_curl_util_SOURCES += nss_auth.cpp
-endif
+test_curl_util_SOURCES = \
+    common_auth.cpp \
+    curl_util.cpp \
+    string_util.cpp \
+    test_curl_util.cpp \
+    s3fs_global.cpp \
+    s3fs_logger.cpp \
+    $(AUTH_SOURCES)
 
 test_curl_util_LDADD = $(DEPS_LIBS)
 


### PR DESCRIPTION
- Remove the dist-hook that stripped .svn directories (s3fs left SVN over a decade ago) and the release target that invoked ../utils/release.sh, a path that has not existed in this repo since the 2010 SVN import.
- Drop the redundant `doc` entry from EXTRA_DIST; SUBDIRS plus AC_CONFIG_FILES already distribute everything under doc/.
- Use $(MAKE) -C instead of bare `make -C` in the clang-tidy target so parallel builds and non-GNU make work, and add clang-tidy to .PHONY.
- Factor the three USE_SSL_* if/endif blocks into a single AUTH_SOURCES variable shared by s3fs_SOURCES and test_curl_util_SOURCES.
- Skip the pjd-pjdfstest subtree in the shellcheck recipe via `find ... -name 'pjd-pjdfstest*' -prune -o ...` instead of filtering paths with `grep -v` after the fact. find avoids descending into the pruned tree, and the directory-name prune is more precise than a substring filter.
- Replace the brittle `-i test/pjd-pjdfstest*` shell glob in the cppcheck recipe with a recipe-time find that captures the actual directory name (the suffix changes per checkout), then conditionally pass `-i "$pjd_dir"` only when a match exists.
- Ignore configure~ alongside configure.ac~.