### PR TITLE
Remove stale cppcheck suppressions

### DIFF
--- a/src/fdcache_page.h
+++ b/src/fdcache_page.h
@@ -70,7 +70,6 @@ using fdpage_list_t = std::vector<struct fdpage>;
 class CacheFileStat;
 class FdEntity;
 
-// cppcheck-suppress copyCtorAndEqOperator
 class PageList
 {
     friend class FdEntity;    // only one method access directly pages.

--- a/src/s3fs_cred.h
+++ b/src/s3fs_cred.h
@@ -41,7 +41,6 @@ using iamcredmap_t = std::map<std::string, std::string>;
 // secret key, tokens, etc.) used by S3fs.
 // Operations related to Credentials are aggregated in this class.
 //
-// cppcheck-suppress ctuOneDefinitionRuleViolation       ; for stub in test_curl_util.cpp
 class S3fsCred
 {
     private:

--- a/src/test_util.h
+++ b/src/test_util.h
@@ -70,7 +70,6 @@ inline void assert_strequals(const char *x, const char *y, const char *file, int
 {
   if(x == nullptr && y == nullptr){
       return;
-  // cppcheck-suppress nullPointerRedundantCheck
   } else if(x == nullptr || y == nullptr || strcmp(x, y) != 0){
       std::cerr << (x ? x : "null") << " != " << (y ? y : "null") << " at " << file << ":" << line << std::endl;
       abort();
@@ -81,7 +80,6 @@ inline void assert_bufequals(const char *x, size_t len1, const char *y, size_t l
 {
     if(x == nullptr && y == nullptr){
         return;
-    // cppcheck-suppress nullPointerRedundantCheck
     } else if(x == nullptr || y == nullptr || len1 != len2 || memcmp(x, y, len1) != 0){
         std::cerr << (x ? std::string(x, len1) : "null") << " != " << (y ? std::string(y, len2) : "null") << " at " << file << ":" << line << std::endl;
         abort();


### PR DESCRIPTION
These suppress warnings that cppcheck no longer emits:

- copyCtorAndEqOperator (fdcache_page.h): PageList has explicitly deleted both the copy constructor and copy assignment operator since #2257, so the warning can no longer fire.
- nullPointerRedundantCheck (test_util.h): false positive fixed in modern cppcheck.
- ctuOneDefinitionRuleViolation (s3fs_cred.h): no longer emitted for the S3fsCred test stub in test_curl_util.cpp.