### PR TITLE
Convert always-true functions to void

### DIFF
--- a/src/fdcache_fdinfo.cpp
+++ b/src/fdcache_fdinfo.cpp
@@ -53,20 +53,12 @@ PseudoFdInfo::~PseudoFdInfo()
     Clear();        // call before destroying the mutex
 }
 
-bool PseudoFdInfo::Clear()
+void PseudoFdInfo::Clear()
 {
-    // cppcheck-suppress unmatchedSuppression
-    // cppcheck-suppress knownConditionTrueFalse
-    if(!CancelAllThreads()){
-        return false;
-    }
+    CancelAllThreads();
     {
         const std::lock_guard<std::mutex> lock(upload_list_lock);
-        // cppcheck-suppress unmatchedSuppression
-        // cppcheck-suppress knownConditionTrueFalse
-        if(!ResetUploadInfo()){
-            return false;
-        }
+        ResetUploadInfo();
     }
     CloseUploadFd();
 
@@ -75,8 +67,6 @@ bool PseudoFdInfo::Clear()
     }
     pseudo_fd   = -1;
     physical_fd = -1;
-
-    return true;
 }
 
 bool PseudoFdInfo::IsUploadingHasLock() const
@@ -172,50 +162,35 @@ bool PseudoFdInfo::Readable() const
     return true;
 }
 
-bool PseudoFdInfo::ClearUploadInfo(bool is_cancel_mp)
+void PseudoFdInfo::ClearUploadInfo(bool is_cancel_mp)
 {
     if(is_cancel_mp){
-        // cppcheck-suppress unmatchedSuppression
-        // cppcheck-suppress knownConditionTrueFalse
-        if(!CancelAllThreads()){
-            return false;
-        }
+        CancelAllThreads();
     }
 
     const std::lock_guard<std::mutex> lock(upload_list_lock);
-    return ResetUploadInfo();
+    ResetUploadInfo();
 }
 
-bool PseudoFdInfo::ResetUploadInfo()
+void PseudoFdInfo::ResetUploadInfo()
 {
     upload_id.clear();
     upload_list.clear();
     instruct_count  = 0;
     last_result     = 0;
-
-    return true;
 }
 
-bool PseudoFdInfo::RowInitialUploadInfo(const std::string& id, bool is_cancel_mp)
+void PseudoFdInfo::RowInitialUploadInfo(const std::string& id, bool is_cancel_mp)
 {
     if(is_cancel_mp){
-        // cppcheck-suppress unmatchedSuppression
-        // cppcheck-suppress knownConditionTrueFalse
-        if(!ClearUploadInfo(is_cancel_mp)){
-            return false;
-        }
+        ClearUploadInfo(is_cancel_mp);
     }else{
         const std::lock_guard<std::mutex> lock(upload_list_lock);
-        // cppcheck-suppress unmatchedSuppression
-        // cppcheck-suppress knownConditionTrueFalse
-        if(!ResetUploadInfo()){
-            return false;
-        }
+        ResetUploadInfo();
     }
 
     const std::lock_guard<std::mutex> lock(upload_list_lock);
     upload_id = id;
-    return true;
 }
 
 void PseudoFdInfo::IncreaseInstructionCount()
@@ -418,10 +393,7 @@ int PseudoFdInfo::PreMultipartUploadRequest(const std::string& strpath, const he
     }
 
     // reset upload_id
-    if(!RowInitialUploadInfo(new_upload_id, false/* not need to cancel */)){
-        S3FS_PRN_ERR("failed to setup multipart upload(set upload id to object)");
-        return -EIO;
-    }
+    RowInitialUploadInfo(new_upload_id, false/* not need to cancel */);
     S3FS_PRN_DBG("succeed to setup multipart upload(set upload id to object)");
 
     return 0;
@@ -576,7 +548,7 @@ int PseudoFdInfo::WaitAllThreadsExit()
     return result;
 }
 
-bool PseudoFdInfo::CancelAllThreads()
+void PseudoFdInfo::CancelAllThreads()
 {
     bool need_cancel = false;
     {
@@ -590,7 +562,6 @@ bool PseudoFdInfo::CancelAllThreads()
     if(need_cancel){
         WaitAllThreadsExit();
     }
-    return true;
 }
 
 //

--- a/src/fdcache_fdinfo.h
+++ b/src/fdcache_fdinfo.h
@@ -52,16 +52,16 @@ class PseudoFdInfo
         Semaphore               uploaded_sem;                                   // use a semaphore to trigger an upload completion like event flag
 
     private:
-        bool Clear();
+        void Clear();
         void CloseUploadFd();
         bool OpenUploadFd();
-        bool ResetUploadInfo() REQUIRES(upload_list_lock);
-        bool RowInitialUploadInfo(const std::string& id, bool is_cancel_mp);
+        void ResetUploadInfo() REQUIRES(upload_list_lock);
+        void RowInitialUploadInfo(const std::string& id, bool is_cancel_mp);
         void IncreaseInstructionCount();
         bool GetUploadInfo(std::string& id, int& fd) const;
         bool ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy);
         bool InsertUploadPart(off_t start, off_t size, int part_num, bool is_copy, etagpair** ppetag);
-        bool CancelAllThreads();
+        void CancelAllThreads();
         bool ExtractUploadPartsFromUntreatedArea(off_t untreated_start, off_t untreated_size, mp_part_list_t& to_upload_list, filepart_list_t& cancel_upload_list, off_t max_mp_size);
         bool IsUploadingHasLock() const REQUIRES(upload_list_lock);
 
@@ -80,8 +80,8 @@ class PseudoFdInfo
         bool Readable() const;
 
         bool Set(int fd, int open_flags);
-        bool ClearUploadInfo(bool is_cancel_mp = false);
-        bool InitialUploadInfo(const std::string& id){ return RowInitialUploadInfo(id, true); }
+        void ClearUploadInfo(bool is_cancel_mp = false);
+        void InitialUploadInfo(const std::string& id){ RowInitialUploadInfo(id, true); }
 
         bool IsUploading() const;
         bool GetUploadId(std::string& id) const;

--- a/src/threadpoolman.cpp
+++ b/src/threadpoolman.cpp
@@ -212,13 +212,13 @@ void ThreadPoolMan::SetExitFlag(bool exit_flag)
     is_exit = exit_flag;
 }
 
-bool ThreadPoolMan::StopThreads()
+void ThreadPoolMan::StopThreads()
 {
     const std::lock_guard<std::mutex> lock(thread_list_lock);
 
     if(thread_list.empty()){
         S3FS_PRN_INFO("Any threads are running now, then nothing to do.");
-        return true;
+        return;
     }
 
     // all threads to exit
@@ -238,8 +238,6 @@ bool ThreadPoolMan::StopThreads()
     // reset semaphore(to zero)
     while(thpoolman_sem.try_acquire()){
     }
-
-    return true;
 }
 
 bool ThreadPoolMan::StartThreads(int count)
@@ -250,12 +248,7 @@ bool ThreadPoolMan::StartThreads(int count)
     }
 
     // stop all thread if they are running.
-    // cppcheck-suppress unmatchedSuppression
-    // cppcheck-suppress knownConditionTrueFalse
-    if(!StopThreads()){
-        S3FS_PRN_ERR("Failed to stop existed threads.");
-        return false;
-    }
+    StopThreads();
 
     // create all threads
     SetExitFlag(false);

--- a/src/threadpoolman.h
+++ b/src/threadpoolman.h
@@ -83,7 +83,7 @@ class ThreadPoolMan
         bool IsExit() const;
         void SetExitFlag(bool exit_flag);
 
-        bool StopThreads();
+        void StopThreads();
         bool StartThreads(int count);
         void SetInstruction(const thpoolman_param& pparam);
 


### PR DESCRIPTION
cppcheck's knownConditionTrueFalse warnings correctly flagged that these functions only ever return true, so the callers' "if(!func())" error handling was dead code. Return void instead and drop the dead branches; this also removes the cppcheck suppressions that were masking the warnings.

The following can never fail: PseudoFdInfo::{Clear, ClearUploadInfo, ResetUploadInfo, RowInitialUploadInfo, InitialUploadInfo, CancelAllThreads} and ThreadPoolMan::StopThreads.