### PR TITLE
Inline IsS3fsLogLevel and make Level ordinal to shrink .text

### DIFF
--- a/src/s3fs_logger.cpp
+++ b/src/s3fs_logger.cpp
@@ -47,11 +47,6 @@ bool                    S3fsLog::time_stamp       = true;
 //-------------------------------------------------------------------
 // S3fsLog class : class methods
 //-------------------------------------------------------------------
-bool S3fsLog::IsS3fsLogLevel(S3fsLog::Level level)
-{
-    return static_cast<int>(level) == (static_cast<int>(S3fsLog::debug_level) & static_cast<int>(level));
-}
-
 std::string S3fsLog::GetCurrentTime()
 {
     std::ostringstream current_time;

--- a/src/s3fs_logger.h
+++ b/src/s3fs_logger.h
@@ -41,12 +41,15 @@
 class S3fsLog
 {
     public:
+        // Ordinal severity, ascending verbosity: a message at `level` is shown
+        // when level <= debug_level (see IsS3fsLogLevel). CRIT is the floor and
+        // is therefore always logged.
         enum class Level : uint8_t {
             CRIT = 0,          // LEVEL_CRIT
             ERR  = 1,          // LEVEL_ERR
-            WARN = 3,          // LEVEL_WARNING
-            INFO = 7,          // LEVEL_INFO
-            DBG  = 15          // LEVEL_DEBUG
+            WARN = 2,          // LEVEL_WARNING
+            INFO = 3,          // LEVEL_INFO
+            DBG  = 4           // LEVEL_DEBUG
         };
 
     protected:
@@ -68,7 +71,10 @@ class S3fsLog
         Level LowBumpupLogLevel() const;
 
     public:
-        static bool IsS3fsLogLevel(Level level);
+        static bool IsS3fsLogLevel(Level level)
+        {
+            return static_cast<int>(level) <= static_cast<int>(debug_level);
+        }
         static bool IsS3fsLogCrit()  { return IsS3fsLogLevel(Level::CRIT); }
         static bool IsS3fsLogErr()   { return IsS3fsLogLevel(Level::ERR);  }
         static bool IsS3fsLogWarn()  { return IsS3fsLogLevel(Level::WARN); }
@@ -77,22 +83,20 @@ class S3fsLog
 
         static constexpr int GetSyslogLevel(Level level)
         {
-            int masked = static_cast<int>(level) & static_cast<int>(Level::DBG);
-            return ( static_cast<int>(Level::DBG)  == masked ? LOG_DEBUG   :
-                     static_cast<int>(Level::INFO) == masked ? LOG_INFO    :
-                     static_cast<int>(Level::WARN) == masked ? LOG_WARNING :
-                     static_cast<int>(Level::ERR)  == masked ? LOG_ERR     : LOG_CRIT );
+            return ( Level::DBG  == level ? LOG_DEBUG   :
+                     Level::INFO == level ? LOG_INFO    :
+                     Level::WARN == level ? LOG_WARNING :
+                     Level::ERR  == level ? LOG_ERR     : LOG_CRIT );
         }
 
         static std::string GetCurrentTime();
 
         static constexpr const char* GetLevelString(Level level)
         {
-            int masked = static_cast<int>(level) & static_cast<int>(Level::DBG);
-            return ( static_cast<int>(Level::DBG)  == masked ? "[DBG] " :
-                     static_cast<int>(Level::INFO) == masked ? "[INF] " :
-                     static_cast<int>(Level::WARN) == masked ? "[WAN] " :
-                     static_cast<int>(Level::ERR)  == masked ? "[ERR] " : "[CRT] " );
+            return ( Level::DBG  == level ? "[DBG] " :
+                     Level::INFO == level ? "[INF] " :
+                     Level::WARN == level ? "[WAN] " :
+                     Level::ERR  == level ? "[ERR] " : "[CRT] " );
         }
 
         static constexpr const char* GetS3fsLogNest(int nest)


### PR DESCRIPTION
Two related fixes to the log-level guard that fronts every S3FS_PRN_* call site (~1,000 of them):

1. IsS3fsLogLevel was defined out-of-line in s3fs_logger.cpp, so without LTO every guard compiled to a function call -- even though its siblings (GetSyslogLevel, IsSetLogFile, the IsS3fsLog* helpers) are all inline in the header. Move it into the header. Each guard now folds to a direct test of debug_level instead of a call: -1,602 bytes .text, ~1,055 calls removed.

2. Level used a nested-bitmask encoding {CRIT=0,ERR=1,WARN=3,INFO=7,DBG=15} with a subset test, level == (debug_level & level). Since debug_level is only ever assigned a canonical level (SetLogLevel from the dbglevel= string, or BumpupLogLevel cycling through them) and levels are never OR'd or ordered-compared anywhere, that subset test is exactly equivalent to an ordinal threshold. Switch to {0,1,2,3,4} with level <= debug_level and drop the now-defunct "& DBG" masking in GetSyslogLevel/GetLevelString. Every inlined guard collapses from movzbl+and+cmp to a single cmpb (and frees a scratch register): -5,061 bytes more.

Total -6,663 bytes .text (-0.92%). No behavioral change: the threshold and the [CRT]/[ERR]/[WAN]/[INF]/[DBG] tags were verified at runtime across dbglevel=info/dbg, the syslog mapping stays monotonic, and CRIT remains the always-logged floor. Unit tests pass.