### PR TITLE
Fix inverted HTTP proxy scheme check in SetProxy

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -979,7 +979,7 @@ bool S3fsCurl::SetProxy(const char* url)
         pos += strlen("://");
 
         // Check if it is other than "http://"
-        if(is_prefix(tmpurl.c_str(), "http://")){
+        if(!is_prefix(tmpurl.c_str(), "http://")){
             is_http = false;
         }
     }else{


### PR DESCRIPTION
Commit eba1bf2 converted the previous find() != 0 comparison to is_prefix() without negating it, so proxy_http became false exactly when the proxy URL uses the http:// scheme.  As a result CURLOPT_PROXYUSERPWD was skipped for HTTP proxies (credentials from proxy_cred_file were silently dropped, causing 407 responses) and applied to non-HTTP proxies instead.