### PR TITLE
Fix ETag collection in multipart_put_head_request for multi-part copies

### DIFF
--- a/src/s3fs_threadreqs.cpp
+++ b/src/s3fs_threadreqs.cpp
@@ -443,7 +443,7 @@ void* get_object_req_threadworker(S3fsCurl& s3fscurl, void* arg)
 void* multipart_put_head_req_threadworker(S3fsCurl& s3fscurl, void* arg)
 {
     std::unique_ptr<multipart_put_head_req_thparam> pthparam(static_cast<multipart_put_head_req_thparam*>(arg));
-    if(!pthparam || !pthparam->ppartdata || !pthparam->pthparam_lock || !pthparam->pretrycount || !pthparam->presult){
+    if(!pthparam || !pthparam->petag || !pthparam->pthparam_lock || !pthparam->pretrycount || !pthparam->presult){
         return reinterpret_cast<void*>(-EIO);
     }
 
@@ -467,13 +467,15 @@ void* multipart_put_head_req_threadworker(S3fsCurl& s3fscurl, void* arg)
 
         if(CURLE_OK == curlCode){
             if(responseCode < 400){
-                // add into stat cache
+                // set etag for this part
                 {
                     const std::lock_guard<std::mutex> lock(*(pthparam->pthparam_lock));
 
                     auto etag = simple_parse_xml(s3fscurl.GetBodyData().c_str(), s3fscurl.GetBodyData().size(), "ETag");
-                    pthparam->ppartdata->uploaded    = etag.has_value();
-                    pthparam->ppartdata->petag->etag = peeloff(std::move(etag).value_or(""));
+                    if(!etag){
+                        S3FS_PRN_WARN("Put Head Request(%s->%s) could not parse ETag in response body.", pthparam->from.c_str(), pthparam->to.c_str());
+                    }
+                    pthparam->petag->etag = peeloff(std::move(etag).value_or(""));
                 }
                 result = 0;
                 break;
@@ -1301,7 +1303,6 @@ int multipart_put_head_request(const std::string& strfrom, const std::string& st
     // common variables
     Semaphore    multi_head_sem(0);
     std::mutex   thparam_lock;
-    filepart     partdata;
     int          req_count  = 0;
     int          retrycount = 0;
     int          req_result = 0;
@@ -1309,17 +1310,23 @@ int multipart_put_head_request(const std::string& strfrom, const std::string& st
     for(bytes_remaining = size; 0 < bytes_remaining; bytes_remaining -= chunk){
         chunk = bytes_remaining > S3fsCurl::GetMultipartCopySize() ? S3fsCurl::GetMultipartCopySize() : bytes_remaining;
 
-        partdata.add_etag_list(list);
+        // [NOTE]
+        // Each part needs its own etagpair in the list because the worker
+        // threads run in parallel and store the response ETag through this
+        // pointer.  (etaglist_t is a std::list, so pointers remain stable.)
+        //
+        list.emplace_back(nullptr, static_cast<int>(list.size()) + 1);
+        etagpair* petag = &list.back();
 
         // parameter for thread worker (freed in multipart_put_head_req_threadworker)
         auto thargs           = std::make_unique<multipart_put_head_req_thparam>();
         thargs->from          = strfrom;
         thargs->to            = strto;
         thargs->upload_id     = upload_id;
-        thargs->part_number   = partdata.get_part_number();
+        thargs->part_number   = petag->part_num;
         thargs->meta          = meta;
         thargs->pthparam_lock = &thparam_lock;
-        thargs->ppartdata     = &partdata;
+        thargs->petag         = petag;
         thargs->pretrycount   = &retrycount;
         thargs->presult       = &req_result;
 
@@ -1375,6 +1382,11 @@ int multipart_put_head_request(const std::string& strfrom, const std::string& st
 
     // completion process
     if(0 != (result = complete_multipart_upload_request(strto, upload_id, list))){
+        S3FS_PRN_ERR("error completing multipart upload(errno=%d).", result);
+        int result2;
+        if(0 != (result2 = abort_multipart_upload_request(strto, upload_id))){
+            S3FS_PRN_ERR("error aborting multipart upload(errno=%d).", result2);
+        }
         return result;
     }
 

--- a/src/s3fs_threadreqs.h
+++ b/src/s3fs_threadreqs.h
@@ -176,7 +176,7 @@ struct multipart_put_head_req_thparam
     int         part_number   = 0;
     headers_t   meta;
     std::mutex* pthparam_lock = nullptr;
-    filepart*   ppartdata     = nullptr;
+    etagpair*   petag         = nullptr;
     int*        pretrycount   = nullptr;
     int*        presult       = nullptr;
 };

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -717,6 +717,32 @@ function test_multipart_copy {
     rm_test_file "${BIG_FILE}-copy"
 }
 
+function test_multipart_copy_chmod {
+    describe "Testing chmod with multi-part copy ..."
+
+    # BIG_FILE_LENGTH(25MB) >= multipart_threshold(25MB), so updating the
+    # metadata goes through put_headers() -> multipart_put_head_request(),
+    # and with multipart_copy_size=10 the server-side copy uses 3 parts.
+    ../../junk_data $((BIG_FILE_BLOCK_SIZE * BIG_FILE_COUNT)) > "${TEMP_DIR}/${BIG_FILE}"
+    dd if="${TEMP_DIR}/${BIG_FILE}" of="${BIG_FILE}" bs="${BIG_FILE_BLOCK_SIZE}" count="${BIG_FILE_COUNT}"
+
+    chmod 613 "${BIG_FILE}"
+
+    local permissions; permissions=$(get_permissions "${BIG_FILE}")
+    if [ "${permissions}" != "613" ]; then
+        echo "chmod expected 613, got ${permissions}"
+        return 1
+    fi
+
+    # Verify the copy did not corrupt the contents
+    if ! cmp "${TEMP_DIR}/${BIG_FILE}" "${BIG_FILE}"; then
+        return 1
+    fi
+
+    rm -f "${TEMP_DIR}/${BIG_FILE}"
+    rm_test_file "${BIG_FILE}"
+}
+
 function test_multipart_mix {
     describe "Testing multi-part mix ..."
 
@@ -2965,6 +2991,9 @@ function add_all_tests {
     add_tests test_rename_before_close
     add_tests test_multipart_upload
     add_tests test_multipart_copy
+    if s3fs_args | grep -q multipart_copy_size; then
+        add_tests test_multipart_copy_chmod
+    fi
 
     if ! uname | grep -q Darwin || ! s3fs_args | grep -q nocopyapi; then
         # FIXME:

--- a/test/small-integration-test.sh
+++ b/test/small-integration-test.sh
@@ -56,7 +56,7 @@ if [ -n "${ALL_TESTS}" ]; then
         nomultipart
         sigv2
         sigv4
-        "singlepart_copy_limit=10"  # limit size to exercise multipart code paths
+        "singlepart_copy_limit=10 -o multipart_copy_size=10"  # limit sizes to exercise multipart copy code paths
         #use_sse  # TODO: S3Proxy does not support SSE
         #use_sse=custom:/tmp/ssekey  # TODO: S3Proxy does not support SSE
         "use_cache=${CACHE_DIR} -o ensure_diskfree=${ENSURE_DISKFREE_SIZE} -o fake_diskfree=${FAKE_FREE_DISK_SIZE} -o streamupload"


### PR DESCRIPTION
The thread-pool refactoring (efc2331) replaced the per-request S3fsCurl objects with a single stack filepart shared by every queued UploadPartCopy worker.  Each loop iteration repointed partdata.petag at the newly appended list entry, so all workers stored their response ETag through whatever the pointer held last (racing with the enqueue loop as well).  With two or more parts, parts 1..N-1 kept empty ETags and CompleteMultipartUpload always failed with EIO.

Any metadata update (chmod/chown/utimens/setxattr) or rename of a file larger than multipart_copy_size (512MB default) takes this path via put_headers()/rename_large_object() and therefore always failed, also stranding the incomplete multipart upload.

Give each worker its own etagpair in the (pointer-stable) etag list, matching multipart_upload_part_req_thparam, and abort the multipart upload when the completion request fails so it is not leaked.

Previously every copy in the test suite fit in a single part, which is why this went unnoticed.  Set multipart_copy_size=10 in the singlepart_copy_limit test configuration so that copies of the 25MB BIG_FILE split into three UploadPartCopy parts, making test_multipart_copy fail without this change.  Also add test_multipart_copy_chmod to cover the metadata-update entry point (put_headers), which reaches multipart_put_head_request for files at or above multipart_threshold.