### PR TITLE
Accept POSIX touch -a mtime behavior on newer macOS

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -1120,10 +1120,12 @@ function test_update_time_touch_a() {
         fi
     else
         # [macos] fuse-t
-        # atime/ctime/mtime are all updated.
+        # atime/ctime are updated.  mtime depends on the macOS NFS client:
+        # older versions (e.g. macOS 14) update it while newer versions
+        # (e.g. macOS 26) preserve it like POSIX requires.
         #
-        if [ "${base_atime}" = "${atime}" ] || [ "${base_ctime}" = "${ctime}" ] || [ "${base_mtime}" = "${mtime}" ]; then
-            echo "touch with -a option expected updated ctime: $base_ctime != $ctime, atime: $base_atime != $atime and same mtime: $base_mtime != $mtime"
+        if [ "${base_atime}" = "${atime}" ] || [ "${base_ctime}" = "${ctime}" ]; then
+            echo "touch with -a option expected updated ctime: $base_ctime != $ctime and atime: $base_atime != $atime"
             return 1
         fi
     fi
@@ -1362,10 +1364,12 @@ function test_update_directory_time_touch_a {
         fi
     else
         # [macos] fuse-t
-        # atime/ctime/mtime are all updated.
+        # atime/ctime are updated.  mtime depends on the macOS NFS client:
+        # older versions (e.g. macOS 14) update it while newer versions
+        # (e.g. macOS 26) preserve it like POSIX requires.
         #
-        if [ "${base_atime}" = "${atime}" ] || [ "${base_ctime}" = "${ctime}" ] || [ "${base_mtime}" = "${mtime}" ]; then
-            echo "touch with -a option expected updated ctime: $base_ctime != $ctime, atime: $base_atime != $atime and same mtime: $base_mtime != $mtime"
+        if [ "${base_atime}" = "${atime}" ] || [ "${base_ctime}" = "${ctime}" ]; then
+            echo "touch with -a option expected updated ctime: $base_ctime != $ctime and atime: $base_atime != $atime"
             return 1
         fi
     fi


### PR DESCRIPTION
macOS 26's NFS client honors UTIME_OMIT, so touch -a via fuse-t preserves mtime as POSIX requires, while macOS 14 updates atime/ctime/mtime together.  Only require atime and ctime updates on Darwin so both behaviors pass.