### PR TITLE
Skip sudo mdutil when Spotlight indexing is already disabled

### DIFF
--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -267,7 +267,10 @@ function start_s3fs {
     #
     local DIRECT_IO_OPT=""
     if [ "$(uname)" = "Darwin" ]; then
-       sudo mdutil -a -i off
+       # Skip sudo when indexing is already disabled, e.g., non-interactive runs
+       if mdutil -a -s | grep -q -i 'enabled'; then
+           sudo mdutil -a -i off
+       fi
     fi
 
     # Set environment variables or options for proxy.


### PR DESCRIPTION
This allows make check to run non-interactively on macOS, where sudo cannot prompt for a password.  mdutil -a -i off only needs to run when some volume still has indexing enabled.