### PR TITLE
Remove HEAD recheck for backends conflating "dir" with "dir/"

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -477,35 +477,19 @@ static int get_object_attribute(const char* path, struct stat* pstbuf, headers_t
         }else if(is_symlink_fmt(*pmeta)){
             *pObjType = objtype_t::SYMLINK;
         }else if(is_dir_fmt(*pmeta)){
-            if('/' != *strpath.rbegin() && std::string::npos == strpath.find("_$folder$", 0)){
-                // check to send a head request for "dir/"
-                //
-                // [NOTE][FIXME]
-                // Some backends, a Head request to a "dir" path will succeed when only the
-                // "dir/" object exists(s3proxy is one of them).
-                // When detected as "dir" in this way, the directory type is no longer accurate,
-                // so the Head request must be re-examined as "dir/".
-                // In this case, the AWS S3 server fails to detect "dir". So in most cases, this
-                // process should have little impact on performance. (Currently, s3fs-fuse tests
-                // are affected by this process.)
-                //
-                std::string recheckPath = strpath + "/";
-                headers_t   recheckHead;
-                if(0 == head_request(recheckPath, recheckHead)){
-                    if(is_dir_fmt(recheckHead)){
-                        strpath   = recheckPath;
-                        *pmeta    = recheckHead;
-                    }else{
-                        S3FS_PRN_ERR("Both objects \"%s\" and \"%s\" were found, but \"%s\" is a directory and \"%s\" is not a directory. \"%s\" will be ignored.", strpath.c_str(), recheckPath.c_str(), strpath.c_str(), recheckPath.c_str(), recheckPath.c_str());
-                    }
-                }
-                if('/' != *strpath.rbegin() && is_need_check_obj_detail(*pmeta)){
-                    // check a case of that "object" does not have attribute and "object" is possible to be directory.
-                    if(-ENOTEMPTY == directory_empty(strpath.c_str())){
-                        // found "non-existed directory object".
-                        strpath  += "/";
-                        *pObjType = objtype_t::DIR_NOT_EXIST_OBJECT;
-                    }
+            // [NOTE]
+            // A no-slash path here is an old style(before 1.63) "dir" object and
+            // is classified as objtype_t::DIR_NOT_TERMINATE_SLASH below.
+            // A backend that conflates "dir" with the "dir/" directory marker
+            // (ex. s3proxy older than 3.3.0) also returns 200 here when only
+            // "dir/" exists; it is treated the same way and handled gracefully.
+            //
+            if('/' != *strpath.rbegin() && std::string::npos == strpath.find("_$folder$", 0) && is_need_check_obj_detail(*pmeta)){
+                // check a case of that "object" does not have attribute and "object" is possible to be directory.
+                if(-ENOTEMPTY == directory_empty(strpath.c_str())){
+                    // found "non-existed directory object".
+                    strpath  += "/";
+                    *pObjType = objtype_t::DIR_NOT_EXIST_OBJECT;
                 }
             }
         }

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -391,6 +391,25 @@ function test_external_directory_creation {
     rm -f directory/"${TEST_TEXT_FILE}"
 }
 
+function test_external_no_slash_directory_object {
+    describe "Test old style directory object without trailing slash ..."
+    local OBJECT_NAME; OBJECT_NAME=$(basename "${PWD}")/no_slash_dir
+    s3_cp "${TEST_BUCKET_1}/${OBJECT_NAME}" --header "Content-Type: application/x-directory" < /dev/null
+    [ -d no_slash_dir ]
+    # updating metadata replaces the old style "dir" object with "dir/"
+    chmod 700 no_slash_dir
+    get_permissions no_slash_dir | grep -q 700$
+    touch no_slash_dir/"${TEST_TEXT_FILE}"
+    rm no_slash_dir/"${TEST_TEXT_FILE}"
+    rmdir no_slash_dir
+    if s3_head "${TEST_BUCKET_1}/${OBJECT_NAME}"; then
+        return 1
+    fi
+    if s3_head "${TEST_BUCKET_1}/${OBJECT_NAME}/"; then
+        return 1
+    fi
+}
+
 function test_external_modification {
     describe "Test external modification to an object ..."
     echo "old" > "${TEST_TEXT_FILE}"
@@ -2929,6 +2948,7 @@ function add_all_tests {
     add_tests test_list
     add_tests test_remove_nonempty_directory
     add_tests test_external_directory_creation
+    add_tests test_external_no_slash_directory_object
     add_tests test_external_modification
     add_tests test_external_creation
     add_tests test_read_external_object


### PR DESCRIPTION
get_object_attribute() re-probed "dir/" whenever a HEAD request for "dir" (no trailing slash) returned a directory-format response, because some backends (s3proxy nio2 providers before 3.3.0) incorrectly answered 200 for "dir" when only the "dir/" object existed.  Real S3 treats the two keys as distinct, so on AWS the recheck always returned 404 and cost one extra request for every cache-miss stat of an old style "dir" object.

s3proxy fixed the conflation in 3.3.0 (gaul/s3proxy@f461ef75), which the integration tests already use, so drop the recheck.  A backend that still conflates the keys now classifies such a path as DIR_NOT_TERMINATE_SLASH, which s3fs already handles gracefully as an old style (pre-1.63) directory object.

Also add an integration test covering no-slash directory objects.