### PR TITLE
Fix inverted AddStat check in readdir compat dir path

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3714,7 +3714,7 @@ static int readdir_multi_head(const std::string& strpath, const S3ObjList& head,
                     syncfiller.Fill(bpath, nullptr, 0);
                 }else{
                     // Add stat cache
-                    if(StatCache::getStatCacheData()->AddStat(dirpath, st, dummy_header, objtype_t::DIR_NOT_EXIST_OBJECT, false)){
+                    if(!StatCache::getStatCacheData()->AddStat(dirpath, st, dummy_header, objtype_t::DIR_NOT_EXIST_OBJECT, false)){
                         S3FS_PRN_ERR("failed adding stat cache [path=%s], so fill empty stat.", dirpath.c_str());
                         syncfiller.Fill(bpath, nullptr, 0);
                     }else{


### PR DESCRIPTION
Commit 5a2a7ca dropped the negation when rewriting this block, so a successful stat cache addition logged a spurious error and filled the readdir entry with an empty stat, while a failed addition silently took the success path.  Every other AddStat caller tests the negated result.