### PR TITLE
Run test_posix_acl

### DIFF
--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -86,6 +86,7 @@ if [ "${CONTAINER_FULLNAME}" = "ubuntu:26.04" ]; then
     PACKAGE_INSTALL_OPTIONS="install -y"
 
     INSTALL_PACKAGES=(
+        acl
         attr
         autoconf
         autotools-dev
@@ -112,6 +113,7 @@ elif [ "${CONTAINER_FULLNAME}" = "ubuntu:24.04" ]; then
     PACKAGE_INSTALL_OPTIONS="install -y"
 
     INSTALL_PACKAGES=(
+        acl
         attr
         autoconf
         autotools-dev
@@ -138,6 +140,7 @@ elif [ "${CONTAINER_FULLNAME}" = "ubuntu:22.04" ]; then
     PACKAGE_INSTALL_OPTIONS="install -y"
 
     INSTALL_PACKAGES=(
+        acl
         attr
         autoconf
         autotools-dev
@@ -166,6 +169,7 @@ elif [ "${CONTAINER_FULLNAME}" = "debian:trixie" ]; then
     PACKAGE_INSTALL_OPTIONS="install -y"
 
     INSTALL_PACKAGES=(
+        acl
         attr
         autoconf
         autotools-dev
@@ -194,6 +198,7 @@ elif [ "${CONTAINER_FULLNAME}" = "debian:bookworm" ] ||
     PACKAGE_INSTALL_OPTIONS="install -y"
 
     INSTALL_PACKAGES=(
+        acl
         attr
         autoconf
         autotools-dev
@@ -231,6 +236,7 @@ elif [ "${CONTAINER_FULLNAME}" = "rockylinux/rockylinux:10" ] ||
     PACKAGE_INSTALL_ADDITIONAL_OPTIONS="--allowerasing"
 
     INSTALL_PACKAGES=(
+        acl
         attr
         automake
         curl
@@ -263,6 +269,7 @@ elif [ "${CONTAINER_FULLNAME}" = "rockylinux/rockylinux:8" ]; then
     PACKAGE_INSTALL_OPTIONS="install -y"
 
     INSTALL_PACKAGES=(
+        acl
         attr
         automake
         curl
@@ -294,6 +301,7 @@ elif [ "${CONTAINER_FULLNAME}" = "fedora:44" ] ||
     PACKAGE_INSTALL_OPTIONS="install -y"
 
     INSTALL_PACKAGES=(
+        acl
         attr
         automake
         curl
@@ -324,6 +332,7 @@ elif [ "${CONTAINER_FULLNAME}" = "opensuse/leap:16.0" ]; then
     PACKAGE_INSTALL_OPTIONS="install -y"
 
     INSTALL_PACKAGES=(
+        acl
         attr
         automake
         curl
@@ -348,6 +357,7 @@ elif [ "${CONTAINER_FULLNAME}" = "alpine:3.24" ]; then
     PACKAGE_INSTALL_OPTIONS="add --no-progress --no-cache"
 
     INSTALL_PACKAGES=(
+        acl
         attr
         autoconf
         automake

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -1938,7 +1938,6 @@ function test_posix_acl {
     local POSIX_ACL_TEST_FILE2="posix_acl_dir1/posix_acl_file2"
     local POSIX_ACL_TEST_FILE3="posix_acl_dir2/posix_acl_file3"
     local POSIX_ACL_TEST_FILE4="posix_acl_dir2/posix_acl_file4"
-    mkdir "${POSIX_ACL_TEST_DIR2}"
     touch "${POSIX_ACL_TEST_FILE1}"
 
     #
@@ -3087,7 +3086,11 @@ function add_all_tests {
             add_tests test_update_parent_directory_time
         fi
     fi
-    if ! s3fs_args | grep -q use_xattr; then
+    # [NOTE]
+    # Requires the xattr handlers, which are registered only with use_xattr
+    # (always passed by start_s3fs).  macOS has no setfacl/getfacl.
+    #
+    if ! uname | grep -q Darwin && command -v setfacl >/dev/null 2>&1; then
         add_tests test_posix_acl
     fi
 


### PR DESCRIPTION
test_posix_acl has never run since its introduction in 2e77920: its gate skipped the test whenever use_xattr was present, but the test requires the xattr handlers which are registered only with use_xattr, and start_s3fs has always passed use_xattr=1.  Gate on setfacl being available instead (and not macOS, which lacks it), install the acl package in the CI containers, and remove a redundant mkdir in the test which failed with EEXIST because cp -r had already recreated the directory two steps earlier.