### PR TITLE
Test truncate growing an existing large file

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -112,6 +112,26 @@ function test_truncate_shrink_file {
     rm_test_file "${BIG_TRUNCATE_TEST_FILE}"
 }
 
+function test_truncate_grow_file {
+    describe "Testing truncate growing large binary file ..."
+
+    local BIG_GROW_TEST_FILE="big-grow-test.bin"
+    local t_size=$((1024 * 1024 * 30 + 64))
+
+    ../../junk_data $((25 * 1024 * 1024)) > "${TEMP_DIR}/${BIG_GROW_TEST_FILE}"
+    cp "${TEMP_DIR}/${BIG_GROW_TEST_FILE}" "${BIG_GROW_TEST_FILE}"
+
+    "${TRUNCATE_BIN}" "${TEMP_DIR}/${BIG_GROW_TEST_FILE}" -s "${t_size}"
+    "${TRUNCATE_BIN}" "${BIG_GROW_TEST_FILE}" -s "${t_size}"
+
+    if ! cmp "${TEMP_DIR}/${BIG_GROW_TEST_FILE}" "${BIG_GROW_TEST_FILE}"; then
+       return 1
+    fi
+
+    rm -f "${TEMP_DIR}/${BIG_GROW_TEST_FILE}"
+    rm_test_file "${BIG_GROW_TEST_FILE}"
+}
+
 function test_truncate_shrink_read_file {
     describe "Testing truncate(shrink) and read file ..."
 
@@ -2992,6 +3012,7 @@ function add_all_tests {
     add_tests test_truncate_upload
     add_tests test_truncate_empty_file
     add_tests test_truncate_shrink_file
+    add_tests test_truncate_grow_file
     add_tests test_truncate_shrink_read_file
     add_tests test_unlink_open_file
     add_tests test_mv_file


### PR DESCRIPTION
The suite covered truncate-shrink of a large object and truncate-grow from zero, but never growing an existing uploaded object.  Growing marks the extension untreated in FdEntity::Open, so the following flush combines copying the unmodified head with uploading the zero-filled tail under the mix engine, and takes distinct paths under the nomultipart, nocopyapi, and streamupload configurations.