### PR TITLE
Exercise max_dirty_data mid-write flush in tests

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -861,6 +861,25 @@ function test_multipart_mix {
     fi
 }
 
+function test_max_dirty_data_flush {
+    describe "Testing mid-write flush by max_dirty_data ..."
+
+    local MAX_DIRTY_DATA_FILE="max-dirty-data-test.bin"
+
+    # Writing 64MB crosses max_dirty_data=50, forcing a flush while the file
+    # is still open for writing; the final flush at close then combines
+    # copying the already-uploaded head with uploading the modified tail.
+    ../../junk_data $((64 * 1024 * 1024)) > "${TEMP_DIR}/${MAX_DIRTY_DATA_FILE}"
+    cp "${TEMP_DIR}/${MAX_DIRTY_DATA_FILE}" "${MAX_DIRTY_DATA_FILE}"
+
+    if ! cmp "${TEMP_DIR}/${MAX_DIRTY_DATA_FILE}" "${MAX_DIRTY_DATA_FILE}"; then
+        return 1
+    fi
+
+    rm -f "${TEMP_DIR}/${MAX_DIRTY_DATA_FILE}"
+    rm_test_file "${MAX_DIRTY_DATA_FILE}"
+}
+
 function test_utimens_during_multipart {
     describe "Testing utimens calling during multipart copy ..."
 
@@ -3029,6 +3048,9 @@ function add_all_tests {
         # Please pay attention to future developments in macos-fuse-t.
         #
         add_tests test_multipart_mix
+    fi
+    if s3fs_args | grep -q max_dirty_data; then
+        add_tests test_max_dirty_data_flush
     fi
 
     add_tests test_utimens_during_multipart

--- a/test/small-integration-test.sh
+++ b/test/small-integration-test.sh
@@ -48,7 +48,7 @@ export CACHE_DIR
 export ENSURE_DISKFREE_SIZE
 if [ -n "${ALL_TESTS}" ]; then
     FLAGS=(
-        "use_cache=${CACHE_DIR} -o ensure_diskfree=${ENSURE_DISKFREE_SIZE} -o fake_diskfree=${FAKE_FREE_DISK_SIZE} -o use_xattr -o update_parent_dir_stat"
+        "use_cache=${CACHE_DIR} -o ensure_diskfree=${ENSURE_DISKFREE_SIZE} -o fake_diskfree=${FAKE_FREE_DISK_SIZE} -o use_xattr -o update_parent_dir_stat -o max_dirty_data=50"  # max_dirty_data at its minimum to exercise mid-write flushes
         enable_content_md5
         disable_noobj_cache
         "max_stat_cache_size=100"


### PR DESCRIPTION
The forced flush in s3fs_write when dirty data reaches max_dirty_data never ran in the test suite: the default threshold is 5GB and no test config lowered it.  Set max_dirty_data=50 (its minimum) in the use_cache test configuration and add a test writing 64MB through one descriptor, which now flushes a complete multipart upload mid-write and then performs a second multipart upload at close that combines copying the already-uploaded head with uploading the modified tail.  The existing 64MB test_truncate_shrink_file also crosses the threshold in this configuration and gains the same mid-write flush coverage.