### PR TITLE
Use try_emplace and insert_or_assign for map insertions

### DIFF
--- a/src/cache_node.cpp
+++ b/src/cache_node.cpp
@@ -1134,7 +1134,7 @@ bool DirStatCache::AddHasLock(const std::string& strpath, const struct stat* pst
             }
 
             // add as a child
-            children[strLeafName] = std::move(pstatcache);
+            children.try_emplace(strLeafName, std::move(pstatcache));
 
         }else{
             // create and add as a direct child
@@ -1199,7 +1199,7 @@ bool DirStatCache::AddHasLock(const std::string& strpath, const struct stat* pst
             }
 
             // add as a child
-            children[strLeafName] = std::move(pstatcache);
+            children.try_emplace(strLeafName, std::move(pstatcache));
         }
     }
 

--- a/src/curl_share.cpp
+++ b/src/curl_share.cpp
@@ -210,15 +210,9 @@ CURLSH* S3fsCurlShare::GetCurlShareHandle()
     }
 
     // set map
-    S3fsCurlShare::ShareHandles.emplace(ThreadId, std::move(hShare));
-    S3fsCurlShare::ShareLocks.emplace(ThreadId, std::move(pLocks));
+    handle_iter = S3fsCurlShare::ShareHandles.try_emplace(ThreadId, std::move(hShare)).first;
+    S3fsCurlShare::ShareLocks.try_emplace(ThreadId, std::move(pLocks));
 
-    // For clang-tidy measures
-    handle_iter = S3fsCurlShare::ShareHandles.find(ThreadId);
-    if(handle_iter == S3fsCurlShare::ShareHandles.end()){
-        S3FS_PRN_ERR("Failed to insert curl share to map.");
-        return nullptr;
-    }
     return handle_iter->second.get();
 }
 

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -586,7 +586,7 @@ FdEntity* FdManager::Open(int& fd, const char* path, const headers_t* pmeta, off
 
         if(!cache_path.empty()){
             // using cache
-            return (fent[path] = std::move(ent)).get();
+            return fent.try_emplace(path, std::move(ent)).first->second.get();
         }else{
             // not using cache, so the key of fdentity is set not really existing path.
             // (but not strictly unexisting path.)
@@ -597,7 +597,7 @@ FdEntity* FdManager::Open(int& fd, const char* path, const headers_t* pmeta, off
             //
             std::string tmppath;
             FdManager::MakeRandomTempPath(path, tmppath);
-            return (fent[tmppath] = std::move(ent)).get();
+            return fent.try_emplace(tmppath, std::move(ent)).first->second.get();
         }
     }else{
         return nullptr;
@@ -750,7 +750,7 @@ void FdManager::Rename(const std::string &from, const std::string &to)
         }
 
         // set new fd entity to map
-        fent[fentmapkey] = std::move(ent);
+        fent.insert_or_assign(fentmapkey, std::move(ent));
     }
 }
 

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -248,7 +248,7 @@ int FdEntity::DupWithLock(int fd)
     const PseudoFdInfo* org_pseudoinfo = iter->second.get();
     auto ppseudoinfo = std::make_unique<PseudoFdInfo>(physical_fd, (org_pseudoinfo ? org_pseudoinfo->GetFlags() : 0));
     int             pseudo_fd      = ppseudoinfo->GetPseudoFd();
-    pseudo_fd_map[pseudo_fd]       = std::move(ppseudoinfo);
+    pseudo_fd_map.try_emplace(pseudo_fd, std::move(ppseudoinfo));
 
     return pseudo_fd;
 }
@@ -264,7 +264,7 @@ int FdEntity::OpenPseudoFd(int flags)
     }
     auto ppseudoinfo = std::make_unique<PseudoFdInfo>(physical_fd, flags);
     int             pseudo_fd   = ppseudoinfo->GetPseudoFd();
-    pseudo_fd_map[pseudo_fd]    = std::move(ppseudoinfo);
+    pseudo_fd_map.try_emplace(pseudo_fd, std::move(ppseudoinfo));
 
     return pseudo_fd;
 }
@@ -618,7 +618,7 @@ int FdEntity::Open(const headers_t* pmeta, off_t size, const FileTimes& ts_times
     // create new pseudo fd, and set it to map
     auto ppseudoinfo = std::make_unique<PseudoFdInfo>(physical_fd, flags);
     int             pseudo_fd   = ppseudoinfo->GetPseudoFd();
-    pseudo_fd_map[pseudo_fd]    = std::move(ppseudoinfo);
+    pseudo_fd_map.try_emplace(pseudo_fd, std::move(ppseudoinfo));
 
     // if there is untreated area, set it to pseudo object.
     if(0 < truncated_size){

--- a/src/s3objlist.cpp
+++ b/src/s3objlist.cpp
@@ -44,7 +44,6 @@ bool S3ObjList::insert(const char* name, const char* etag, bool is_dir, off_t si
         return false;
     }
 
-    s3obj_t::iterator iter;
     std::string newname;
     std::string orgname = name;
     objtype_t   type    = objtype_t::UNKNOWN;
@@ -73,49 +72,32 @@ bool S3ObjList::insert(const char* name, const char* etag, bool is_dir, off_t si
     // Check derived name object.
     if(is_dir || IS_DIR_OBJ(type)){
         std::string chkname = newname.substr(0, newname.length() - 1);
-        if(objects.cend() != (iter = objects.find(chkname))){
+        if(auto iter = objects.find(chkname); objects.cend() != iter){
             // found "dir" object --> remove it.
             objects.erase(iter);
         }
     }else{
         std::string chkname = newname + "/";
-        if(objects.cend() != (iter = objects.find(chkname))){
+        if(objects.cend() != objects.find(chkname)){
             // found "dir/" object --> not add new object.
             // and add normalization
             return insert_normalized(orgname.c_str(), chkname.c_str(), type);
         }
     }
 
-    // Add object
-    if(objects.cend() != (iter = objects.find(newname))){
-        // Found same object --> update information.
-        iter->second.normalname.clear();
-        iter->second.orgname = orgname;
-        iter->second.type    = type;
-        if(etag){
-            iter->second.etag = etag;  // over write
-        }
-        if(0 <= size){
-            iter->second.size = size;
-        }
-        if(last_modified){
-            iter->second.last_modified = last_modified;
-        }
-    }else{
-        // add new object
-        s3obj_entry newobject;
-        newobject.orgname = orgname;
-        newobject.type    = type;
-        if(etag){
-            newobject.etag = etag;
-        }
-        if(0 <= size){
-            newobject.size = size;
-        }
-        if(last_modified){
-            newobject.last_modified = last_modified;
-        }
-        objects[newname] = std::move(newobject);
+    // Add new object or update the information of the found same object.
+    s3obj_entry& entry = objects.try_emplace(newname).first->second;
+    entry.normalname.clear();
+    entry.orgname = orgname;
+    entry.type    = type;
+    if(etag){
+        entry.etag = etag;  // over write
+    }
+    if(0 <= size){
+        entry.size = size;
+    }
+    if(last_modified){
+        entry.last_modified = last_modified;
     }
 
     // add normalization


### PR DESCRIPTION
Replace operator[] insertions of move-only or expensive values with C++17 map operations:

- StatCacheNode children, FdManager::Open and the FdEntity pseudo_fd_map insert at keys just checked or generated to be absent, so try_emplace constructs the mapped smart pointer in place instead of default-constructing one and assigning.
- FdManager::Rename keeps its overwrite semantics via insert_or_assign, since the rename target key can legitimately exist.
- S3ObjList::insert looked up the key and then updated or inserted through separate branches whose bodies had converged; a single try_emplace removes the second lookup and unifies them.  The entry members all have default initializers, so filling a freshly inserted entry matches the old new-object branch exactly.  Also drop the now write-only iterator, scoping the remaining use with an if-initializer.
- S3fsCurlShare::GetCurlShareHandle re-found the handle it had just emplaced to avoid returning a moved-from pointer; using the iterator that try_emplace returns removes the extra lookup and the cannot-happen error branch.