### PR TITLE
Use std::string_view in leaf string utilities

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -481,7 +481,7 @@ size_t S3fsCurl::HeaderCallback(void* data, size_t blockSize, size_t numBlocks, 
     if(getline(ss, key, ':')){
         // Force to lower, only "x-amz"
         std::string lkey = lower(key);
-        if(is_prefix(lkey.c_str(), "x-amz")){
+        if(is_prefix(lkey, "x-amz")){
             key = lkey;
         }
         std::string value;
@@ -747,7 +747,7 @@ bool S3fsCurl::FinalCheckSse()
 
             // SSL/TLS is required for KMS
             //
-            if(!is_prefix(s3host.c_str(), "https://")){
+            if(!is_prefix(s3host, "https://")){
                 S3FS_PRN_ERR("The sse type is SSE-KMS, but it is not configured to use SSL/TLS. SSE-KMS requires SSL/TLS communication.");
                 return false;
             }
@@ -977,7 +977,7 @@ bool S3fsCurl::SetProxy(const char* url)
         pos += strlen("://");
 
         // Check if it is other than "http://"
-        if(!is_prefix(tmpurl.c_str(), "http://")){
+        if(!is_prefix(tmpurl, "http://")){
             is_http = false;
         }
     }else{
@@ -2317,9 +2317,9 @@ std::string S3fsCurl::CalcSignature(const std::string& method, const std::string
         StringCQ += uriencode + "\n";
     }else if(method == "GET" && uriencode.empty()){
         StringCQ +="/\n";
-    }else if(method == "GET" && is_prefix(uriencode.c_str(), "/")){
+    }else if(method == "GET" && is_prefix(uriencode, "/")){
         StringCQ += uriencode +"\n";
-    }else if(method == "GET" && !is_prefix(uriencode.c_str(), "/")){
+    }else if(method == "GET" && !is_prefix(uriencode, "/")){
         StringCQ += "/\n" + urlEncodeQuery(canonical_uri) +"\n";
     }else if(method == "POST"){
         StringCQ += uriencode + "\n";

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -144,7 +144,7 @@ std::string get_sorted_header_keys(const struct curl_slist* list)
     return sorted_headers;
 }
 
-std::string get_header_value(const struct curl_slist* list, const std::string &key)
+std::string get_header_value(const struct curl_slist* list, std::string_view key)
 {
     if(!list){
         return "";
@@ -154,7 +154,7 @@ std::string get_header_value(const struct curl_slist* list, const std::string &k
         std::string strkey = list->data;
         size_t pos;
         if(std::string::npos != (pos = strkey.find(':', 0))){
-            if(0 == strcasecmp(trim(strkey.substr(0, pos)).c_str(), key.c_str())){
+            if(CaseInsensitiveStringView(trim(strkey.substr(0, pos))) == key){
                 return trim(strkey.substr(pos+1));
             }
         }
@@ -221,9 +221,9 @@ std::string prepare_url(const char* url)
     size_t bucket_length = token.size();
     size_t uri_length = 0;
 
-    if(is_prefix(url_str.c_str(), "https://")){
+    if(is_prefix(url_str, "https://")){
         uri_length = 8;
-    } else if(is_prefix(url_str.c_str(), "http://")) {
+    } else if(is_prefix(url_str, "http://")) {
         uri_length = 7;
     }
     uri  = url_str.substr(0, uri_length);
@@ -262,17 +262,17 @@ std::optional<std::string> make_md5_from_binary(const char* pstr, size_t length)
     return s3fs_base64(binary.data(), binary.size());
 }
 
-std::string url_to_host(const std::string &url)
+std::string url_to_host(std::string_view url)
 {
-    S3FS_PRN_INFO3("url is %s", url.c_str());
+    S3FS_PRN_INFO3("url is %.*s", static_cast<int>(url.size()), url.data());
 
     static constexpr char HTTP[] = "http://";
     static constexpr char HTTPS[] = "https://";
     std::string hostname;
 
-    if (is_prefix(url.c_str(), HTTP)) {
+    if (is_prefix(url, HTTP)) {
         hostname = url.substr(sizeof(HTTP) - 1);
-    } else if (is_prefix(url.c_str(), HTTPS)) {
+    } else if (is_prefix(url, HTTPS)) {
         hostname = url.substr(sizeof(HTTPS) - 1);
     } else {
         S3FS_PRN_EXIT("url does not begin with http:// or https://");
@@ -321,9 +321,15 @@ const char* getCurlDebugHead(curl_infotype type)
 //
 // compare ETag ignoring quotes and case
 //
-bool etag_equals(const std::string& s1, const std::string& s2)
+bool etag_equals(std::string_view s1, std::string_view s2)
 {
-    return 0 == strcasecmp(peeloff(s1).c_str(), peeloff(s2).c_str());
+    if(2 <= s1.size() && '"' == s1.front() && '"' == s1.back()){
+        s1 = s1.substr(1, s1.size() - 2);
+    }
+    if(2 <= s2.size() && '"' == s2.front() && '"' == s2.back()){
+        s2 = s2.substr(1, s2.size() - 2);
+    }
+    return CaseInsensitiveStringView(s1) == s2;
 }
 
 /*

--- a/src/curl_util.h
+++ b/src/curl_util.h
@@ -25,6 +25,7 @@
 #include <curl/curl.h>
 #include <optional>
 #include <string>
+#include <string_view>
 #include "metaheader.h"
 
 enum class sse_type_t : uint8_t;
@@ -36,18 +37,18 @@ struct curl_slist* curl_slist_sort_insert(struct curl_slist* list, const char* k
 struct curl_slist* curl_slist_remove(struct curl_slist* list, const char* key);
 std::string get_sorted_header_keys(const struct curl_slist* list);
 std::string get_canonical_headers(const struct curl_slist* list, bool only_amz = false);
-std::string get_header_value(const struct curl_slist* list, const std::string &key);
+std::string get_header_value(const struct curl_slist* list, std::string_view key);
 bool MakeUrlResource(const char* realpath, std::string& resourcepath, std::string& url);
 std::string prepare_url(const char* url);
 bool get_object_sse_type(const char* path, sse_type_t& ssetype, std::string& ssevalue);   // implement in s3fs.cpp
 int put_headers(const char* path, const headers_t& meta, bool is_copy, bool use_st_size = true);    // implement in s3fs.cpp
 
 std::optional<std::string> make_md5_from_binary(const char* pstr, size_t length);
-std::string url_to_host(const std::string &url);
+std::string url_to_host(std::string_view url);
 std::string get_bucket_host();
 const char* getCurlDebugHead(curl_infotype type);
 
-bool etag_equals(const std::string& s1, const std::string& s2);
+bool etag_equals(std::string_view s1, std::string_view s2);
 
 #endif // S3FS_CURL_UTIL_H_
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -5694,7 +5694,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
                 length = s3host.length();
             }
             // Check url for http / https protocol std::string
-            if(!is_prefix(s3host.c_str(), "https://") && !is_prefix(s3host.c_str(), "http://")){
+            if(!is_prefix(s3host, "https://") && !is_prefix(s3host, "http://")){
                 S3FS_PRN_EXIT("option url has invalid format, missing http / https protocol");
                 return -1;
             }
@@ -5792,7 +5792,8 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
         // debug level option
         //
         else if(is_prefix(arg, "dbglevel=")){
-            auto strlevel = CaseInsensitiveStringView(strchr(arg, '=') + sizeof(char));
+            const char* pstrlevel = strchr(arg, '=') + sizeof(char);
+            auto strlevel = CaseInsensitiveStringView(pstrlevel);
             if(strlevel == "silent" || strlevel == "critical" || strlevel == "crit"){
                 S3fsLog::SetLogLevel(S3fsLog::Level::CRIT);
             }else if(strlevel == "error" || strlevel == "err"){
@@ -5804,7 +5805,7 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             }else if(strlevel == "dbg" || strlevel == "debug"){
                 S3fsLog::SetLogLevel(S3fsLog::Level::DBG);
             }else{
-                S3FS_PRN_EXIT("option dbglevel has unknown parameter(%s).", strlevel.c_str());
+                S3FS_PRN_EXIT("option dbglevel has unknown parameter(%s).", pstrlevel);
                 return -1;
             }
             return 0;
@@ -5842,14 +5843,15 @@ static int my_fuse_opt_proc(void* data, const char* arg, int key, struct fuse_ar
             S3fsCurl::SetVerbose(true);
             return 0;
         }else if(is_prefix(arg, "curldbg=")){
-            auto strlevel = CaseInsensitiveStringView(strchr(arg, '=') + sizeof(char));
+            const char* pstrlevel = strchr(arg, '=') + sizeof(char);
+            auto strlevel = CaseInsensitiveStringView(pstrlevel);
             if(strlevel == "normal"){
                 S3fsCurl::SetVerbose(true);
             }else if(strlevel == "body"){
                 S3fsCurl::SetVerbose(true);
                 S3fsCurl::SetDumpBody(true);
             }else{
-                S3FS_PRN_EXIT("option curldbg has unknown parameter(%s).", strlevel.c_str());
+                S3FS_PRN_EXIT("option curldbg has unknown parameter(%s).", pstrlevel);
                 return -1;
             }
             return 0;

--- a/src/s3fs_cred.cpp
+++ b/src/s3fs_cred.cpp
@@ -1498,7 +1498,7 @@ bool S3fsCred::CheckForbiddenBucketParams()
         return false;
     }
 
-    if(!pathrequeststyle && is_prefix(s3host.c_str(), "https://") && bucket_name.find_first_of('.') != std::string::npos) {
+    if(!pathrequeststyle && is_prefix(s3host, "https://") && bucket_name.find_first_of('.') != std::string::npos) {
         S3FS_PRN_EXIT("BUCKET %s -- cannot mount bucket with . while using HTTPS without use_path_request_style", bucket_name.c_str());
         return false;
     }

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -159,7 +159,7 @@ static constexpr char encode_general_except_chars[] = ".-_~";    // For general 
 static constexpr char encode_path_except_chars[]    = ".-_~/";   // For fuse(included path) URL encode
 static constexpr char encode_query_except_chars[]   = ".-_~=&%"; // For query params(and encoded string)
 
-static std::string rawUrlEncode(const std::string &s, const char* except_chars)
+static std::string rawUrlEncode(std::string_view s, const char* except_chars)
 {
     std::string result;
     for(unsigned char c : s){
@@ -177,22 +177,22 @@ static std::string rawUrlEncode(const std::string &s, const char* except_chars)
     return result;
 }
 
-std::string urlEncodeGeneral(const std::string &s)
+std::string urlEncodeGeneral(std::string_view s)
 {
     return rawUrlEncode(s, encode_general_except_chars);
 }
 
-std::string urlEncodePath(const std::string &s)
+std::string urlEncodePath(std::string_view s)
 {
     return rawUrlEncode(s, encode_path_except_chars);
 }
 
-std::string urlEncodeQuery(const std::string &s)
+std::string urlEncodeQuery(std::string_view s)
 {
     return rawUrlEncode(s, encode_query_except_chars);
 }
 
-std::string urlDecode(const std::string& s)
+std::string urlDecode(std::string_view s)
 {
     std::string result;
     for(size_t i = 0; i < s.length(); ++i){

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -21,10 +21,10 @@
 #ifndef S3FS_STRING_UTIL_H_
 #define S3FS_STRING_UTIL_H_
 
-#include <cstring>
 #include <ctime>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <strings.h>
 
 #include "types.h"
@@ -42,17 +42,15 @@ inline constexpr char SPACES[] = " \t\r\n";
 //-------------------------------------------------------------------
 class CaseInsensitiveStringView {
 public:
-    explicit CaseInsensitiveStringView(const char *str) : str(str) {}
-    explicit CaseInsensitiveStringView(const std::string &str) : str(str.c_str()) {}
-    bool operator==(const char *other) const { return strcasecmp(str, other) == 0; }
-    bool operator!=(const char *other) const { return !(*this == other); }
-    bool is_prefix(const char *prefix) const { return strncasecmp(str, prefix, strlen(prefix)) == 0; }
-    const char *c_str() const { return str; }
+    explicit CaseInsensitiveStringView(std::string_view str) : str(str) {}
+    bool operator==(std::string_view other) const { return str.size() == other.size() && is_prefix(other); }
+    bool operator!=(std::string_view other) const { return !(*this == other); }
+    // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage): strncasecmp is bounded by the passed size
+    bool is_prefix(std::string_view prefix) const { return prefix.size() <= str.size() && 0 == strncasecmp(str.data(), prefix.data(), prefix.size()); }
 private:
-    const char *str;
+    std::string_view str;
 };
-// TODO: constexpr with C++17
-static inline bool is_prefix(const char *str, const char *prefix) { return strncmp(str, prefix, strlen(prefix)) == 0; }
+static constexpr bool is_prefix(std::string_view str, std::string_view prefix) { return str.substr(0, prefix.size()) == prefix; }
 static constexpr const char* SAFESTRPTR(const char *strptr) { return strptr ? strptr : ""; }
 
 //-------------------------------------------------------------------
@@ -110,10 +108,10 @@ std::optional<time_t> convert_unixtime_from_option_arg(const char* argv);
 //
 // For encoding
 //
-std::string urlEncodeGeneral(const std::string &s);
-std::string urlEncodePath(const std::string &s);
-std::string urlEncodeQuery(const std::string &s);
-std::string urlDecode(const std::string& s);
+std::string urlEncodeGeneral(std::string_view s);
+std::string urlEncodePath(std::string_view s);
+std::string urlEncodeQuery(std::string_view s);
+std::string urlDecode(std::string_view s);
 
 bool takeout_str_dquart(std::string& str);
 std::optional<std::string> get_keyword_value(const std::string& target, const char* keyword);


### PR DESCRIPTION
Convert the string utilities that only inspect their input to take std::string_view: the url encoders and decoder, etag_equals, get_header_value, url_to_host, and the free is_prefix, which also resolves its constexpr-with-C++17 TODO.  Rebase
CaseInsensitiveStringView onto std::string_view, collapsing its two constructors into one, dropping the unused c_str accessor, and bounding the comparisons by length instead of NUL termination.  etag_equals now strips the quotes as views instead of building two peeled string copies per comparison.

Callers keep passing std::string and C strings through the implicit conversion; the redundant c_str() calls at converted call sites are removed (readability-redundant-string-cstr enforces this).  Functions whose bodies need NUL terminated data stay on const char*: the wtf8 core scans multi byte sequences relying on the terminator, and everything feeding libcurl, syscalls or strtoll is unchanged.