### PR TITLE
Do not retry the bucket check when no retry condition matched

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -4863,16 +4863,19 @@ static int s3fs_check_service()
                     }
                     return EXIT_FAILURE;
 
-                }else if(check_invalid_sse_arg_error(responseBody.c_str(), responseBody.size())){
+                }else if(!forceNoSSE && check_invalid_sse_arg_error(responseBody.c_str(), responseBody.size())){
                     // SSE argument error, so retry it without SSE
                     S3FS_PRN_CRIT("S3 service returned InvalidArgument(x-amz-server-side-encryption), so retry without adding x-amz-server-side-encryption.");
 
                     // Retry without sse parameters
                     forceNoSSE = true;
+                }else{
+                    // No retry condition matched(ex. NoSuchBucket), so do not retry
+                    isLoop = false;
                 }
 
-            }else if(S3fsCurl::S3FSCURL_RESPONSECODE_FATAL_ERROR == responseCode){
-                // Curl error cases(ex, about SSL)
+            }else{
+                // Curl error cases(ex, about SSL), 5xx errors, etc. are not retried
                 isLoop = false;
             }
 

--- a/test/small-integration-test.sh
+++ b/test/small-integration-test.sh
@@ -74,6 +74,71 @@ if ! s3_head "${TEST_BUCKET_1}"; then
     s3_mb "${TEST_BUCKET_1}"
 fi
 
+# Regression test for the bucket check at startup: mounting a bucket
+# that does not exist must fail promptly instead of retrying forever.
+function test_mount_nonexistent_bucket {
+    echo "testing mount of nonexistent bucket"
+
+    local bucket="s3fs-nonexistent-bucket-$$"
+    local mountpoint="nonexistent-bucket-mountpoint"
+    local logfile="nonexistent-bucket-s3fs.log"
+
+    if [ -n "${PUBLIC}" ]; then
+        local AUTH_OPT="-o public_bucket=1"
+    elif [ -n "${S3FS_PROFILE}" ]; then
+        local AUTH_OPT="-o profile=${S3FS_PROFILE}"
+    else
+        local AUTH_OPT="-o passwd_file=${S3FS_CREDENTIALS_FILE}"
+    fi
+
+    mkdir -p "${mountpoint}"
+
+    # shellcheck disable=SC2086
+    CURL_CA_BUNDLE="${S3PROXY_CACERT_FILE}" "${S3FS}" "${bucket}" "${mountpoint}" \
+        -o use_path_request_style \
+        -o url="${S3_URL}" \
+        -o region="${S3_ENDPOINT}" \
+        ${AUTH_OPT} \
+        -o dbglevel="${DBGLEVEL:=info}" \
+        -o retries=3 \
+        -f > "${logfile}" 2>&1 &
+    local pid=$!
+
+    # s3fs must exit on its own; give it 30 seconds before declaring a hang
+    local rc=""
+    for _ in $(seq 300); do
+        if ! kill -0 "${pid}" 2>/dev/null; then
+            rc=0
+            wait "${pid}" || rc=$?
+            break
+        fi
+        sleep 0.1
+    done
+
+    if [ -z "${rc}" ]; then
+        kill -9 "${pid}" 2>/dev/null || true
+        fusermount3 -u "${mountpoint}" 2>/dev/null || umount "${mountpoint}" 2>/dev/null || true
+        cat "${logfile}"
+        echo "s3fs did not exit after mounting nonexistent bucket: ${bucket}"
+        return 1
+    fi
+    if [ "${rc}" -eq 0 ]; then
+        cat "${logfile}"
+        echo "s3fs unexpectedly succeeded mounting nonexistent bucket: ${bucket}"
+        return 1
+    fi
+    if ! grep -q "Bucket or directory not found" "${logfile}"; then
+        cat "${logfile}"
+        echo "s3fs did not report a missing bucket: ${bucket}"
+        return 1
+    fi
+
+    rm -f "${logfile}"
+    rmdir "${mountpoint}"
+}
+
+test_mount_nonexistent_bucket
+
 for flag in "${FLAGS[@]}"; do
     echo "testing s3fs flag: ${flag}"
 


### PR DESCRIPTION
The thread pool refactoring in efc2331 rewrote the s3fs_check_service retry loop as for(bool isLoop = true; ...) where only recognized cases clear isLoop.  Any response matching no branch -- a 404 for a missing bucket or mount prefix, a 400/403 whose error code is not one of the known invalid access codes, or any 5xx response -- re-issued the check request forever: mounting a nonexistent bucket generated ~6,000 requests per second against a local server, never reported "Bucket or directory not found", and did not react to SIGTERM.  The code before the refactoring defaulted to not retrying(do_retry = false).

Restore that default: exit the loop when the response matches no retry condition so the existing error report runs and s3fs fails with EXIT_FAILURE.  Also make the retry without SSE a one-shot so a server repeating InvalidArgument(x-amz-server-side-encryption) cannot recreate the endless loop.  The 5xx cases are already retried with backoff inside RequestPerform before reaching this loop.

Add a regression test mounting a nonexistent bucket, asserting s3fs exits promptly with an error and reports the missing bucket.