### PR TITLE
Do not share the readdir listing cache with incompatible listings

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -109,6 +109,14 @@ class StatCache
         bool AddStat(const std::string& key, const struct stat& stbuf, const headers_t& meta, objtype_t type, bool notruncate = false);
         bool AddStat(const std::string& key, const struct stat& stbuf, objtype_t type, bool notruncate = false);
         bool AddNegativeStat(const std::string& key);
+
+        // [NOTE]
+        // The cached S3ObjList must always be the complete one-level
+        // listing(delimiter=/) of the directory, as stored by
+        // s3fs_readdir.  Never store truncated or recursive(no
+        // delimiter) listings, because every caller of GetS3ObjList
+        // assumes this shape.
+        //
         bool AddS3ObjList(std::string key, const S3ObjList& list);
 
         // Update meta stats

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1347,27 +1347,28 @@ static int s3fs_unlink(const char* _path)
 
 static int directory_empty(const char* path)
 {
-    int       result = 0;
     S3ObjList head;
 
     // check s3objlist in cache
+    //
+    // [NOTE]
+    // The cached list is always the complete one-level listing stored
+    // by s3fs_readdir, so it can answer whether the directory is empty.
+    // On a cache miss, only a truncated listing(max-keys=2) is requested
+    // here.  It must not be stored in the cache, because s3fs_readdir
+    // would serve it as if it were the complete listing.
+    //
     if(!StatCache::getStatCacheData()->GetS3ObjList(path, head)){
+        int result;
         if((result = list_bucket(path, head, "/", true)) != 0){
             S3FS_PRN_ERR("list_bucket returns error.");
             return result;
         }
-        if(!head.IsEmpty()){
-            if(!StatCache::getStatCacheData()->AddS3ObjList(path, head)){
-                S3FS_PRN_WARN("failed to add s3objlist for %s, but continue...", path);
-            }
-            result = -ENOTEMPTY;
-        }
-    }else{
-        if(!head.IsEmpty()){
-            result = -ENOTEMPTY;
-        }
     }
-    return result;
+    if(!head.IsEmpty()){
+        return -ENOTEMPTY;
+    }
+    return 0;
 }
 
 static int s3fs_rmdir(const char* _path)
@@ -1848,15 +1849,16 @@ static int rename_directory(const char* from, const char* to)
     // No delimiter is specified, the result(head) is all object keys.
     // (CommonPrefixes is empty, but all object is listed in Key.)
     //
-    if(!StatCache::getStatCacheData()->GetS3ObjList(basepath, head)){
-        // get a list of all the objects
-        if(0 != (result = list_bucket(basepath.c_str(), head, nullptr))){
-            S3FS_PRN_ERR("list_bucket returns error.");
-            return result;
-        }
-        if(!StatCache::getStatCacheData()->AddS3ObjList(basepath, head)){
-            S3FS_PRN_WARN("failed to add s3objlist for %s, but continue...", basepath.c_str());
-        }
+    // [NOTE]
+    // The S3ObjList cache is not used here.  It holds the one-level
+    // listing(delimiter=/) stored by s3fs_readdir, which does not
+    // include objects under subdirectories, so a rename based on it
+    // would leave those objects behind.  For the same reason, this
+    // recursive listing must not be stored in the cache.
+    //
+    if(0 != (result = list_bucket(basepath.c_str(), head, nullptr))){
+        S3FS_PRN_ERR("list_bucket returns error.");
+        return result;
     }
     head.GetNameList(headlist);                                             // get name without "/".
 

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -424,6 +424,71 @@ function test_remove_nonempty_directory {
     rm_test_dir
 }
 
+function test_list_directory_after_failed_rmdir {
+    describe "Test listing a non-empty directory after a failed rmdir ..."
+
+    # [NOTE]
+    # The objects are created with s3_cp(not through the mount
+    # point) like a directory written by another client, so that the
+    # children are not in the stat cache.  s3fs_readdir merges stat
+    # cache entries into its result, which would hide an incomplete
+    # listing cache entry.
+    #
+    local DIR_NAME; DIR_NAME="dir_$(basename "${PWD}")_failed_rmdir"
+    local OBJECT_PREFIX; OBJECT_PREFIX=$(basename "${PWD}")/"${DIR_NAME}"
+    s3_cp "${TEST_BUCKET_1}/${OBJECT_PREFIX}/" --header "Content-Type: application/x-directory" < /dev/null
+    echo data1 | s3_cp "${TEST_BUCKET_1}/${OBJECT_PREFIX}/file1"
+    echo data2 | s3_cp "${TEST_BUCKET_1}/${OBJECT_PREFIX}/file2"
+    echo data3 | s3_cp "${TEST_BUCKET_1}/${OBJECT_PREFIX}/file3"
+
+    # rmdir must fail, and must not poison the listing cache with the
+    # truncated(max-keys=2) listing requested for the emptiness check.
+    (
+        set +o pipefail
+        rmdir "${DIR_NAME}" 2>&1 | grep -q "Directory not empty"
+    )
+
+    local FILE_CNT; FILE_CNT=$(find "${DIR_NAME}" -mindepth 1 -maxdepth 1 | wc -l)
+    if [ "${FILE_CNT}" -ne 3 ]; then
+        echo "Expected 3 files in ${DIR_NAME} but got ${FILE_CNT}"
+        return 1
+    fi
+
+    rm -r "${DIR_NAME}"
+}
+
+function test_rename_directory_after_list {
+    describe "Test renaming a directory with a subdirectory after listing it ..."
+
+    # [NOTE]
+    # The objects are created with s3_cp like in
+    # test_list_directory_after_failed_rmdir.
+    #
+    local DIR_NAME; DIR_NAME="dir_$(basename "${PWD}")_rename_after_list"
+    local TO_DIR_NAME; TO_DIR_NAME="${DIR_NAME}_renamed"
+    local OBJECT_PREFIX; OBJECT_PREFIX=$(basename "${PWD}")/"${DIR_NAME}"
+    s3_cp "${TEST_BUCKET_1}/${OBJECT_PREFIX}/" --header "Content-Type: application/x-directory" < /dev/null
+    echo direct | s3_cp "${TEST_BUCKET_1}/${OBJECT_PREFIX}/file1"
+    s3_cp "${TEST_BUCKET_1}/${OBJECT_PREFIX}/subdir/" --header "Content-Type: application/x-directory" < /dev/null
+    echo nested | s3_cp "${TEST_BUCKET_1}/${OBJECT_PREFIX}/subdir/file2"
+
+    # Listing the directory stores the one-level list in the listing
+    # cache; the rename must not consume it as the recursive object
+    # list, otherwise objects under the subdirectory are left behind.
+    ls "${DIR_NAME}" > /dev/null
+
+    mv "${DIR_NAME}" "${TO_DIR_NAME}"
+
+    cmp "${TO_DIR_NAME}/file1" <(echo direct)
+    cmp "${TO_DIR_NAME}/subdir/file2" <(echo nested)
+    if [ -e "${DIR_NAME}" ]; then
+        echo "${DIR_NAME} still exists after mv"
+        return 1
+    fi
+
+    rm -r "${TO_DIR_NAME}"
+}
+
 function test_external_directory_creation {
     describe "Test external directory creation ..."
     local OBJECT_NAME; OBJECT_NAME=$(basename "${PWD}")/directory/"${TEST_TEXT_FILE}"
@@ -3024,6 +3089,8 @@ function add_all_tests {
     add_tests test_chown
     add_tests test_list
     add_tests test_remove_nonempty_directory
+    add_tests test_list_directory_after_failed_rmdir
+    add_tests test_rename_directory_after_list
     add_tests test_external_directory_creation
     add_tests test_external_no_slash_directory_object
     add_tests test_external_modification


### PR DESCRIPTION
The per-directory S3ObjList cache added in 052b0f9 stored three different listing shapes in one slot: s3fs_readdir's complete one-level listing, directory_empty's max-keys=2 first page, and rename_directory's recursive no-delimiter listing.  Consumers cannot tell them apart:

- After rmdir or rename failed on a non-empty directory, s3fs_readdir served the truncated two-key page, so ls showed only the first entry.  This is visible when the children are not in the stat cache, for example on a fresh mount, because readdir merges stat cache entries into its result.
- After ls, rename_directory consumed the one-level listing as if it were the recursive object list, so objects under subdirectories were never renamed and mv failed half way with ENOTEMPTY, leaving the tree split between the old and new names.

Keep s3fs_readdir as the only producer of the cached listing. directory_empty still reads it, because a complete one-level listing answers the emptiness check exactly, but no longer stores its truncated page.  rename_directory always requests a fresh recursive listing and does not store it.

The new integration tests create the objects with s3_cp so that the stat cache cannot mask the listing cache behavior.