### PR TITLE
Fix trailing-slash name handling in S3ObjList HasName and Remove

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ src/s3fs
 src/test_auth
 src/test_curl_util
 src/test_page_list
+src/test_s3objlist
 src/test_string_util
 
 test/chaos-http-proxy-*

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -75,6 +75,7 @@ noinst_PROGRAMS = \
     test_auth \
     test_curl_util \
     test_page_list \
+    test_s3objlist \
     test_string_util
 
 test_auth_SOURCES = \
@@ -105,17 +106,20 @@ test_page_list_SOURCES = \
     string_util.cpp \
     test_page_list.cpp
 
+test_s3objlist_SOURCES = s3objlist.cpp test_s3objlist.cpp
+
 test_string_util_SOURCES = string_util.cpp test_string_util.cpp s3fs_logger.cpp
 
 TESTS = \
     test_auth \
     test_curl_util \
     test_page_list \
+    test_s3objlist \
     test_string_util
 
 clang-tidy:
 	clang-tidy -extra-arg-before=-xc++ -extra-arg=-std=@CPP_VERSION@ -header-filter= \
-		*.h $(s3fs_SOURCES) test_auth.cpp test_curl_util.cpp test_page_list.cpp test_string_util.cpp \
+		*.h $(s3fs_SOURCES) test_auth.cpp test_curl_util.cpp test_page_list.cpp test_s3objlist.cpp test_string_util.cpp \
 		-- $(DEPS_CFLAGS) $(CPPFLAGS)
 
 #

--- a/src/s3objlist.cpp
+++ b/src/s3objlist.cpp
@@ -280,11 +280,15 @@ bool S3ObjList::GetNameMap(s3obj_type_map_t& objmap, bool OnlyNormalized, bool C
 
 bool S3ObjList::HasName(const std::string& strName) const
 {
+    if(strName.empty()){
+        return false;
+    }
+
     std::string strWitoutSlash;
     std::string strWithSlash;
 
     if('/' == strName.back()){
-        strWitoutSlash = strName.substr(strName.size() - 1);
+        strWitoutSlash = strName.substr(0, strName.size() - 1);
         strWithSlash   = strName;
     }else{
         strWitoutSlash = strName;
@@ -298,11 +302,15 @@ bool S3ObjList::HasName(const std::string& strName) const
 
 bool S3ObjList::Remove(const std::string& strName)
 {
+    if(strName.empty()){
+        return false;
+    }
+
     std::string strWitoutSlash;
     std::string strWithSlash;
 
     if('/' == strName.back()){
-        strWitoutSlash = strName.substr(strName.size() - 1);
+        strWitoutSlash = strName.substr(0, strName.size() - 1);
         strWithSlash   = strName;
     }else{
         strWitoutSlash = strName;

--- a/src/test_s3objlist.cpp
+++ b/src/test_s3objlist.cpp
@@ -1,0 +1,78 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "s3objlist.h"
+#include "test_util.h"
+
+void test_hasname()
+{
+    S3ObjList list;
+
+    ASSERT_TRUE(list.insert("file1"));
+    ASSERT_TRUE(list.insert("sub", nullptr, true));
+
+    // names are found with and without a terminating slash
+    ASSERT_TRUE(list.HasName("file1"));
+    ASSERT_TRUE(list.HasName("file1/"));
+    ASSERT_TRUE(list.HasName("sub"));
+    ASSERT_TRUE(list.HasName("sub/"));
+
+    ASSERT_FALSE(list.HasName("missing"));
+    ASSERT_FALSE(list.HasName("missing/"));
+    ASSERT_FALSE(list.HasName("/"));
+    ASSERT_FALSE(list.HasName(""));
+}
+
+void test_remove()
+{
+    S3ObjList list;
+
+    // remove a file by the name with a terminating slash
+    ASSERT_TRUE(list.insert("file1"));
+    ASSERT_TRUE(list.Remove("file1/"));
+    ASSERT_FALSE(list.HasName("file1"));
+
+    // a directory is stored under both "sub/" and the normalized name
+    // "sub", and removing it must erase both
+    ASSERT_TRUE(list.insert("sub", nullptr, true));
+    ASSERT_TRUE(list.Remove("sub/"));
+    ASSERT_FALSE(list.HasName("sub"));
+    ASSERT_FALSE(list.HasName("sub/"));
+
+    ASSERT_FALSE(list.Remove(""));
+    ASSERT_TRUE(list.IsEmpty());
+}
+
+int main(int argc, const char *argv[])
+{
+    test_hasname();
+    test_remove();
+
+    return 0;
+}
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/


### PR DESCRIPTION
Both methods built the slash-less probe with substr(size - 1), which yields the last character "/" instead of the name without its terminating slash.  As a result, a slash-terminated query missed entries stored under the plain name: HasName("x/") did not find a file "x", and Remove("x/") erased the "x/" entry but left the normalized "x" alias behind.  All current callers pass leaf names without a slash, so this was latent.  Also reject empty names, which previously invoked undefined behavior via back().

Add a test_s3objlist unit test program covering the slash-insensitive lookup and removal semantics, which fails on the unfixed code.