### PR TITLE
Upload the result of truncate(2) on a file which is not open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ test/s3proxy-*
 test/write_multiblock
 test/mknod_test
 test/truncate_read_file
+test/path_truncate
 test/cr_filename
 test/unlink_open_file
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -2956,6 +2956,7 @@ static int s3fs_truncate(const char* _path, off_t size, struct fuse_file_info* i
 
     WTF8_ENCODE(path)
     int          result;
+    struct stat  stbuf;
     headers_t    meta;
     AutoFdEntity autoent;
     FdEntity*    ent = nullptr;
@@ -2972,36 +2973,44 @@ static int s3fs_truncate(const char* _path, off_t size, struct fuse_file_info* i
     }
 
     // Get file information
-    if(0 == (result = get_object_attribute(path, nullptr, &meta))){
+    if(0 == (result = get_object_attribute(path, &stbuf, &meta))){
         // File exists
 
         // [NOTE]
-        // If the file exists, the file has already been opened by FUSE before
-        // truncate is called. Then the call below will change the file size.
-        // (When an already open file is changed the file size, FUSE will not
-        // reopen it.)
-        // The Flush is called before this file is closed, so there is no need
-        // to do it here.
+        // If the file is open, changing the size of the temporary FdEntity
+        // below is sufficient, because the file is flushed before it is
+        // closed.
+        // If no file descriptor is open(truncate(2) was called on a closed
+        // file), the temporary FdEntity is released without flushing when
+        // this function returns, so the resized file must be uploaded here.
         //
         // [NOTICE]
         // FdManager::Open() ignores changes that reduce the file size for the
         // file you are editing. However, if user opens only once, edit it,
         // and then shrink the file, it should be done.
-        // When this function is called, the file is already open by FUSE or
-        // some other operation. Therefore, if the number of open files is 1,
-        // no edits other than that fd will be made, and the files will be
-        // shrunk using ignore_modify flag even while editing.
+        // Therefore, if the number of open files is 1 or less, no edits
+        // other than that fd will be made, and the files will be shrunk
+        // using ignore_modify flag even while editing.
         // See the comments when merging this code for FUSE2 limitations.
         // (In FUSE3, it will be possible to handle it reliably using fuse_file_info.)
         //
+        int  open_fd_count = FdManager::GetOpenFdCount(path);
         bool ignore_modify;
-        if(1 < FdManager::GetOpenFdCount(path)){
+        if(1 < open_fd_count){
             ignore_modify = false;
         }else{
             ignore_modify = true;
         }
 
-        FileTimes ts_times;     // Default: all time values are set UTIME_OMIT
+        // [NOTE]
+        // The current file times are set like s3fs_open, so that a newly
+        // created FdEntity marks the retained area as unloaded(lazily
+        // downloaded) instead of modified. Otherwise the flush below would
+        // upload zeros for the retained area.
+        //
+        FileTimes ts_times;
+        ts_times.SetAll(stbuf);
+
         int error = 0;
         if(nullptr == (ent = autoent.Open(path, &meta, size, ts_times, O_RDWR, false, true, ignore_modify, &error))){
             if(0 == error){
@@ -3011,19 +3020,33 @@ static int s3fs_truncate(const char* _path, off_t size, struct fuse_file_info* i
             return error;
         }
 
+        bool need_flush = (0 == open_fd_count);
+
 #ifdef __APPLE__
         // [NOTE]
         // Only for macos, this truncate calls to "size=0" do not reflect size.
         // The cause is unknown now, but it can be avoided by flushing the file.
         //
         if(0 == size){
+            need_flush = true;
+        }
+#endif
+
+        if(need_flush){
+            // successful truncate(2) updates ctime and mtime
+            struct timespec ts_now;
+            s3fs_realtime(ts_now);
+            if(0 != (result = ent->SetCtime(ts_now)) || 0 != (result = ent->SetMtime(ts_now))){
+                S3FS_PRN_ERR("could not set mtime and ctime to file(%s): result=%d", path, result);
+                return result;
+            }
+
             if(0 != (result = ent->Flush(autoent.GetPseudoFd(), true))){
                 S3FS_PRN_ERR("could not upload file(%s): result=%d", path, result);
                 return result;
             }
             StatCache::getStatCacheData()->DelStat(path);
         }
-#endif
 
     }else if(-ENOENT == result){
         // Creates a sized temporary file only if it doesn't exist(-ENOENT).

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -34,6 +34,7 @@ noinst_PROGRAMS = \
     write_multiblock \
     mknod_test \
     truncate_read_file \
+    path_truncate \
     cr_filename \
     unlink_open_file
 
@@ -41,6 +42,7 @@ junk_data_SOURCES          = junk_data.cc
 write_multiblock_SOURCES   = write_multiblock.cc
 mknod_test_SOURCES         = mknod_test.cc
 truncate_read_file_SOURCES = truncate_read_file.cc
+path_truncate_SOURCES      = path_truncate.cc
 cr_filename_SOURCES        = cr_filename.cc
 unlink_open_file_SOURCES   = unlink_open_file.cc
 
@@ -50,6 +52,7 @@ clang-tidy:
     $(write_multiblock_SOURCES) \
     $(mknod_test_SOURCES) \
     $(truncate_read_file_SOURCES) \
+    $(path_truncate_SOURCES) \
     $(cr_filename_SOURCES) \
     $(unlink_open_file_SOURCES) \
     -- $(DEPS_CFLAGS) $(CPPFLAGS)

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -154,6 +154,27 @@ function test_truncate_shrink_read_file {
     rm_test_file
 }
 
+function test_truncate_closed_file {
+    describe "Testing truncate(2) on a file which is not open ..."
+
+    # [NOTE]
+    # path_truncate calls truncate(2) with a path, unlike the truncate
+    # command which opens the file and calls ftruncate(2). The file is
+    # not open, so s3fs must upload the resized file by itself.
+    #
+    printf '0123456789' > "${TEST_TEXT_FILE}"
+
+    ../../path_truncate "${TEST_TEXT_FILE}" 4
+    check_file_size "${TEST_TEXT_FILE}" 4
+    cmp "${TEST_TEXT_FILE}" <(printf '0123')
+
+    ../../path_truncate "${TEST_TEXT_FILE}" 8
+    check_file_size "${TEST_TEXT_FILE}" 8
+    cmp "${TEST_TEXT_FILE}" <(printf '0123\0\0\0\0')
+
+    rm_test_file
+}
+
 function test_unlink_open_file {
     describe "Testing operations on a file which is unlinked while open ..."
 
@@ -3013,6 +3034,7 @@ function add_all_tests {
     add_tests test_truncate_shrink_file
     add_tests test_truncate_grow_file
     add_tests test_truncate_shrink_read_file
+    add_tests test_truncate_closed_file
     add_tests test_unlink_open_file
     add_tests test_mv_file
     add_tests test_mv_to_exist_file

--- a/test/path_truncate.cc
+++ b/test/path_truncate.cc
@@ -1,0 +1,57 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <unistd.h>
+
+// [NOTE]
+// This program calls truncate(2) with a path, unlike the truncate
+// command which opens the file and calls ftruncate(2). The filesystem
+// receives the request without a file handle, and no file descriptor
+// is open for the file.
+//
+int main(int argc, const char *argv[])
+{
+    if(argc != 3){
+        fprintf(stderr, "[ERROR] Wrong parameters\n");
+        fprintf(stdout, "[Usage] path_truncate <file path> <truncate size(bytes)>\n");
+        exit(EXIT_FAILURE);
+    }
+
+    const char* filepath = argv[1];
+    auto        size     = static_cast<off_t>(strtoull(argv[2], nullptr, 10));
+
+    if(0 != truncate(filepath, size)){
+        fprintf(stderr, "[ERROR] Could not truncate file(%s) to %lld byte.\n", filepath, static_cast<long long>(size));
+        exit(EXIT_FAILURE);
+    }
+
+    exit(EXIT_SUCCESS);
+}
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/


### PR DESCRIPTION
s3fs_truncate resized a temporary FdEntity and relied on FUSE flushing the file when it is closed.  That holds for ftruncate(2) and for truncating an open file, but truncate(2) on a file which nothing has open created a temporary entity that was released without flushing, so the new size was silently discarded and the object never changed.  This went unnoticed because the truncate command opens the file and calls ftruncate(2); only a direct truncate(2) call triggers it.

When no file descriptor was open before the call, flush the resized file and remove the stat cache entry, like the -ENOENT branch.  Two details make the uploaded content correct:

- Open the temporary entity with the object's current times(like s3fs_open) so that the retained area is marked unloaded and the flush downloads it, instead of uploading zeros for it.
- Set ctime and mtime like the O_TRUNC flush in s3fs_open, since a successful truncate(2) updates both.

The macos-only flush for size 0 is folded into the same flush path.

Add a path_truncate test helper which calls truncate(2) with a path, and an integration test using it that checks both shrinking and growing a closed file.