### PR TITLE
Fix directory sub-type poisoning by readdir listings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ doc/man/s3fs.1
 default_commit_hash
 src/s3fs
 src/test_auth
+src/test_cache_node
 src/test_curl_util
 src/test_page_list
 src/test_s3objlist

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -73,6 +73,7 @@ s3fs_LDADD = $(DEPS_LIBS)
 
 noinst_PROGRAMS = \
     test_auth \
+    test_cache_node \
     test_curl_util \
     test_page_list \
     test_s3objlist \
@@ -99,6 +100,16 @@ test_curl_util_SOURCES = \
 
 test_curl_util_LDADD = $(DEPS_LIBS)
 
+test_cache_node_SOURCES = \
+    cache_node.cpp \
+    filetimes.cpp \
+    metaheader.cpp \
+    s3fs_global.cpp \
+    s3fs_logger.cpp \
+    s3objlist.cpp \
+    string_util.cpp \
+    test_cache_node.cpp
+
 test_page_list_SOURCES = \
     fdcache_page.cpp \
     s3fs_global.cpp \
@@ -112,6 +123,7 @@ test_string_util_SOURCES = string_util.cpp test_string_util.cpp s3fs_logger.cpp
 
 TESTS = \
     test_auth \
+    test_cache_node \
     test_curl_util \
     test_page_list \
     test_s3objlist \
@@ -119,7 +131,7 @@ TESTS = \
 
 clang-tidy:
 	clang-tidy -extra-arg-before=-xc++ -extra-arg=-std=@CPP_VERSION@ -header-filter= \
-		*.h $(s3fs_SOURCES) test_auth.cpp test_curl_util.cpp test_page_list.cpp test_s3objlist.cpp test_string_util.cpp \
+		*.h $(s3fs_SOURCES) test_auth.cpp test_cache_node.cpp test_curl_util.cpp test_page_list.cpp test_s3objlist.cpp test_string_util.cpp \
 		-- $(DEPS_CFLAGS) $(CPPFLAGS)
 
 #

--- a/src/cache_node.cpp
+++ b/src/cache_node.cpp
@@ -1114,9 +1114,22 @@ bool DirStatCache::AddHasLock(const std::string& strpath, const struct stat* pst
                 // The type(other than negative type) of object found is different
                 return false;
             }
-            // Already has strpath child, so set stat and meta.
-            if(!iter->second->UpdateHasLock(pstat, pmeta, true) || !iter->second->UpdateHasLock(is_notruncate) || !iter->second->UpdateHasLock()){
-                return false;
+            if(IS_DIR_OBJ(type) && type != iter->second->GetTypeHasLock()){
+                // [NOTE]
+                // Both are directories but the sub-type changed(ex. a legacy
+                // "dir" object was replaced by a "dir/" object).  Re-enter
+                // the child node itself: its own-path branch updates the
+                // type and all data depending on it, and sets stat and meta
+                // in the same way as below.
+                //
+                if(!iter->second->AddHasLock(strpath, pstat, pmeta, type, is_notruncate)){
+                    return false;
+                }
+            }else{
+                // Already has strpath child, so set stat and meta.
+                if(!iter->second->UpdateHasLock(pstat, pmeta, true) || !iter->second->UpdateHasLock(is_notruncate) || !iter->second->UpdateHasLock()){
+                    return false;
+                }
             }
             if(has_s3obj && !s3obj.HasName(strLeafName)){
                 ClearS3ObjListHasLock();        // always true

--- a/src/s3objlist.cpp
+++ b/src/s3objlist.cpp
@@ -34,9 +34,10 @@
 // If name is terminated by "_$folder$", it is forced dir type.
 // If is_dir is true, the name ends with "/", or the name ends with "_$folder$",
 // it will be determined to be a directory.
-// If it is determined to be a directory, one of the directory types in objtype_t
-// will be set to type. If it is not a directory(file, symbolic link), type will
-// be set to objtype_t::UNKNOWN.
+// If it is determined to be a directory, the type is set from the evidence in
+// the name: "_$folder$" gives objtype_t::DIR_FOLDER_SUFFIX, everything else
+// gives objtype_t::DIR_NORMAL. If it is not a directory(file, symbolic link),
+// type will be set to objtype_t::UNKNOWN.
 //
 bool S3ObjList::insert(const char* name, const char* etag, bool is_dir, off_t size, const char* last_modified)
 {
@@ -64,7 +65,18 @@ bool S3ObjList::insert(const char* name, const char* etag, bool is_dir, off_t si
         if(is_dir || IS_DIR_OBJ(type)){
             newname += "/";
             if(!IS_DIR_OBJ(type)){
-                type = objtype_t::DIR_NOT_TERMINATE_SLASH;
+                // [NOTE]
+                // A name without a slash and with is_dir=true comes from a
+                // CommonPrefixes element, whose trailing slash was cut when
+                // the name was extracted.  It carries no evidence of a
+                // legacy "dir" object(a Contents key without a slash would),
+                // so do not type it as DIR_NOT_TERMINATE_SLASH: readdir
+                // forwards this type to the stat cache once a HEAD request
+                // for "dir/" succeeds, and a wrong sub-type makes every
+                // later metadata update replace the directory object(and
+                // delete the "dir" key) instead of copying it.
+                //
+                type = objtype_t::DIR_NORMAL;
             }
         }
     }

--- a/src/test_cache_node.cpp
+++ b/src/test_cache_node.cpp
@@ -1,0 +1,168 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2026 Andrew Gaul <andrew@gaul.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <sys/stat.h>
+
+#include <memory>
+#include <string>
+
+#include "cache_node.h"
+#include "metaheader.h"
+#include "s3objlist.h"
+#include "test_util.h"
+#include "types.h"
+
+static struct stat make_dir_stat()
+{
+    struct stat st = {};
+    st.st_mode  = S_IFDIR | 0755;
+    st.st_nlink = 2;
+    return st;
+}
+
+static struct stat make_file_stat()
+{
+    struct stat st = {};
+    st.st_mode  = S_IFREG | 0644;
+    st.st_nlink = 1;
+    return st;
+}
+
+//
+// A CommonPrefixes entry in a listing proves only that keys exist under
+// "subdir/".  It must not be typed as a legacy no-slash directory
+// object("subdir"), otherwise readdir stamps that wrong sub-type into the
+// stat cache and every later metadata update rebuilds the directory
+// object instead of copying it.
+//
+static void test_common_prefix_type()
+{
+    S3ObjList list;
+    ASSERT_TRUE(list.insert("subdir", nullptr, /*is_dir=*/ true, -1, nullptr));
+
+    s3obj_type_map_t typemap;
+    ASSERT_TRUE(list.GetNameMap(typemap, /*OnlyNormalized=*/ true, /*CutSlash=*/ false));
+    auto iter = typemap.find("subdir/");
+    ASSERT_TRUE(typemap.cend() != iter);
+    ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NORMAL), static_cast<int>(iter->second));
+}
+
+//
+// Directory objects can change their physical representation while the
+// path stays a directory(ex. replacing a legacy "dir" object with "dir/").
+// Re-adding a cached directory with a new sub-type must update the node,
+// otherwise a stale sub-type can never heal.
+//
+static void test_dir_subtype_heal()
+{
+    DirStatCache root("/");
+    struct stat  st   = make_dir_stat();
+    headers_t    meta;
+    meta["Content-Type"]       = "application/x-directory";
+    meta["x-amz-meta-foreign"] = "keepme";
+
+    ASSERT_TRUE(root.Add("/dir/", &st, &meta, objtype_t::DIR_NOT_TERMINATE_SLASH, false));
+    std::shared_ptr<StatCacheNode> node = root.Find("/dir/");
+    ASSERT_TRUE(nullptr != node);
+    ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NOT_TERMINATE_SLASH), static_cast<int>(node->GetType()));
+
+    // Update to the modern "dir/" representation.
+    ASSERT_TRUE(root.Add("/dir/", &st, &meta, objtype_t::DIR_NORMAL, false));
+    node = root.Find("/dir/");
+    ASSERT_TRUE(nullptr != node);
+    ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NORMAL), static_cast<int>(node->GetType()));
+
+    // The stat and meta survive the sub-type update.
+    struct stat getst = {};
+    headers_t   getmeta;
+    ASSERT_TRUE(node->Get(getmeta, getst));
+    ASSERT_TRUE(S_ISDIR(getst.st_mode));
+    ASSERT_TRUE(getmeta.cend() != getmeta.find("x-amz-meta-foreign"));
+
+    // The object was deleted externally and only the path remains.
+    ASSERT_TRUE(root.Add("/dir/", &st, &meta, objtype_t::DIR_NOT_EXIST_OBJECT, false));
+    node = root.Find("/dir/");
+    ASSERT_TRUE(nullptr != node);
+    ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NOT_EXIST_OBJECT), static_cast<int>(node->GetType()));
+
+    // Re-adding with the same sub-type keeps the node untouched.
+    ASSERT_TRUE(root.Add("/dir/", &st, &meta, objtype_t::DIR_NOT_EXIST_OBJECT, false));
+    node = root.Find("/dir/");
+    ASSERT_TRUE(nullptr != node);
+    ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NOT_EXIST_OBJECT), static_cast<int>(node->GetType()));
+}
+
+//
+// The same heal must work for a directory nested below the top level,
+// where the parent recursion ends in the direct-child branch.
+//
+static void test_nested_dir_subtype_heal()
+{
+    DirStatCache root("/");
+    struct stat  st = make_dir_stat();
+
+    ASSERT_TRUE(root.Add("/dir/", &st, nullptr, objtype_t::DIR_NORMAL, false));
+    ASSERT_TRUE(root.Add("/dir/sub/", &st, nullptr, objtype_t::DIR_NOT_TERMINATE_SLASH, false));
+    std::shared_ptr<StatCacheNode> node = root.Find("/dir/sub/");
+    ASSERT_TRUE(nullptr != node);
+    ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NOT_TERMINATE_SLASH), static_cast<int>(node->GetType()));
+
+    ASSERT_TRUE(root.Add("/dir/sub/", &st, nullptr, objtype_t::DIR_NORMAL, false));
+    node = root.Find("/dir/sub/");
+    ASSERT_TRUE(nullptr != node);
+    ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NORMAL), static_cast<int>(node->GetType()));
+}
+
+//
+// Non-directory nodes are not affected by the directory sub-type update.
+//
+static void test_file_type_unchanged()
+{
+    DirStatCache root("/");
+    struct stat  st = make_file_stat();
+
+    ASSERT_TRUE(root.Add("/file", &st, nullptr, objtype_t::FILE, false));
+    std::shared_ptr<StatCacheNode> node = root.Find("/file");
+    ASSERT_TRUE(nullptr != node);
+    ASSERT_EQUALS(static_cast<int>(objtype_t::FILE), static_cast<int>(node->GetType()));
+
+    ASSERT_TRUE(root.Add("/file", &st, nullptr, objtype_t::FILE, false));
+    node = root.Find("/file");
+    ASSERT_TRUE(nullptr != node);
+    ASSERT_EQUALS(static_cast<int>(objtype_t::FILE), static_cast<int>(node->GetType()));
+}
+
+int main(int argc, const char *argv[])
+{
+    test_common_prefix_type();
+    test_dir_subtype_heal();
+    test_nested_dir_subtype_heal();
+    test_file_type_unchanged();
+    return 0;
+}
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -477,6 +477,45 @@ function test_external_no_slash_directory_object {
     fi
 }
 
+function test_chmod_listed_directory_keeps_metadata {
+    describe "Test chmod after listing copies the directory object ..."
+    local OBJECT_NAME; OBJECT_NAME=$(basename "${PWD}")/"${TEST_DIR}"/
+
+    # Create a "dir/" object externally, carrying metadata from another client.
+    # x-amz-meta-mode 16877 is 0755 with S_IFDIR.
+    s3_cp "${TEST_BUCKET_1}/${OBJECT_NAME}" \
+        --header "Content-Type: application/x-directory" \
+        --header "x-amz-meta-mode: 16877" \
+        --header "x-amz-meta-foreign: keepme" < /dev/null
+    local HEADERS; HEADERS=$(s3_head "${TEST_BUCKET_1}/${OBJECT_NAME}")
+    echo "${HEADERS}" | grep -qi "x-amz-meta-foreign: keepme"
+
+    # List the parent so that readdir fills the stat cache from the listing.
+    # shellcheck disable=SC2010
+    ls | grep -q "${TEST_DIR}"
+
+    # A metadata update on a directory backed by a "dir/" object must copy
+    # the object in place, which keeps metadata set by other clients and
+    # adds no metadata of its own except the changed values.  If the
+    # listing poisoned the cached directory type, s3fs instead deletes the
+    # "dir" key and recreates "dir/" from a full fresh header set.
+    chmod 750 "${TEST_DIR}"
+    get_permissions "${TEST_DIR}" | grep -q 750$
+    HEADERS=$(s3_head "${TEST_BUCKET_1}/${OBJECT_NAME}")
+    # metadata from the other client survives
+    echo "${HEADERS}" | grep -qi "x-amz-meta-foreign: keepme"
+    # 16872 is 0750 with S_IFDIR
+    echo "${HEADERS}" | grep -qi "x-amz-meta-mode: 16872"
+    # recreating the directory object stamps time metadata that chmod on a
+    # copied object never adds
+    if echo "${HEADERS}" | grep -qi "x-amz-meta-mtime"; then
+        echo "chmod recreated the ${OBJECT_NAME} object instead of copying it"
+        return 1
+    fi
+
+    rm_test_dir
+}
+
 function test_external_modification {
     describe "Test external modification to an object ..."
     echo "old" > "${TEST_TEXT_FILE}"
@@ -3140,6 +3179,7 @@ function add_all_tests {
     add_tests test_remove_nonempty_directory
     add_tests test_external_directory_creation
     add_tests test_external_no_slash_directory_object
+    add_tests test_chmod_listed_directory_keeps_metadata
     add_tests test_external_modification
     add_tests test_external_creation
     add_tests test_read_external_object

--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -479,6 +479,31 @@ function test_external_no_slash_directory_object {
 
 function test_chmod_listed_directory_keeps_metadata {
     describe "Test chmod after listing copies the directory object ..."
+
+    # [NOTE]
+    # With nocopyapi the directory object is always recreated instead of
+    # copied, so metadata from other clients cannot be preserved.
+    #
+    if s3fs_args | grep -q nocopyapi; then
+        echo "This test does not run with nocopyapi"
+        return 0
+    fi
+
+    # [NOTE]
+    # macos fuse-t mounts over NFS and hands s3fs permission-only modes(the
+    # S_IFDIR/S_IFREG type bits are stripped), so the copied directory object
+    # carries x-amz-meta-mode 488 rather than 16872 and the assertion below
+    # cannot match.  fuse-t is also run with "noattrcache", so the kernel
+    # issues a getattr before the chmod that reloads the directory type
+    # directly from a HEAD, healing the stat cache regardless of what the
+    # listing stored.  The test therefore cannot probe the poisoned-type
+    # path on macos.
+    #
+    if [ "$(uname)" = "Darwin" ]; then
+        echo "This test does not run on macos"
+        return 0
+    fi
+
     local OBJECT_NAME; OBJECT_NAME=$(basename "${PWD}")/"${TEST_DIR}"/
 
     # Create a "dir/" object externally, carrying metadata from another client.


### PR DESCRIPTION
S3ObjList::insert typed slash-less CommonPrefixes entries as DIR_NOT_TERMINATE_SLASH, asserting a legacy "dir" object that the listing gives no evidence for.  readdir_multi_head forwards this type as a hint and the HEAD worker stores it verbatim into the stat cache exactly when a HEAD request for "dir/" succeeds, i.e. when the truth is DIR_NORMAL.  After any readdir, every chmod/chown/utimens/setxattr on a listed subdirectory then took the replace-directory path: DELETE of the "dir" key (which destroys a coexisting "dir" file object on backends that allow both) plus a full re-PUT of "dir/" from a fresh header set that drops metadata set by other clients, instead of a metadata copy of the existing object.

The wrong sub-type could also never heal: DirStatCache::AddHasLock updates stat and meta for an existing directory child but not the sub-type (isSameObjectTypeHasLock treats all directory sub-types as equal), and directory nodes survive DelStat, so even the truthful AddStat(objtype_t::DIR_NORMAL) issued after rebuilding the directory object was ignored and the next metadata update rebuilt it again.

Type CommonPrefixes entries as DIR_NORMAL (legacy no-slash directory objects appear as Contents keys and keep getting their type from the HEAD worker's header inference), and make DirStatCache::AddHasLock re-enter the child node when both the cached and the added type are directories with different sub-types, so that its own-path branch updates the sub-type and the data depending on it.

Add a cache_node unit test covering the CommonPrefixes type and the sub-type update, and an integration test that chmods a listed externally-created directory and asserts that the "dir/" object is copied, keeping the other client's metadata.