### PR TITLE
Keep the first error in the multipart upload part worker

### DIFF
--- a/src/s3fs_threadreqs.cpp
+++ b/src/s3fs_threadreqs.cpp
@@ -371,7 +371,10 @@ void* multipart_upload_part_req_threadworker(S3fsCurl& s3fscurl, void* arg)
     // Set result for exiting
     {
         const std::lock_guard<std::mutex> lock(*(pthparam->pthparam_lock));
-        *(pthparam->presult) = result;
+        if(0 == *(pthparam->presult) && 0 != result){
+            // keep first error
+            *(pthparam->presult) = result;
+        }
     }
 
     return reinterpret_cast<void*>(result);


### PR DESCRIPTION
multipart_upload_part_req_threadworker stored its result into the shared batch result unconditionally, unlike the other thread workers which keep the first error.  A failed part followed by a successful one reset the shared result to zero, so the caller skipped the abort branch and attempted to complete the multipart upload with an empty part ETag, leaking the upload when the completion failed.  The overwrite could also erase the -ECANCELED flag that PseudoFdInfo::CancelAllThreads sets to stop the remaining workers. The worker's own early-exit check already assumes the shared result latches the first error.