### PR TITLE
Create a regular file in the truncate fallback path

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3032,9 +3032,13 @@ static int s3fs_truncate(const char* _path, off_t size, struct fuse_file_info* i
             return -EIO;
         }
 
+        mode_t filemask = umask(0);      // macos does not have getumask()
+        umask(filemask);
+
         std::string strnow       = s3fs_str_realtime();
         meta["Content-Type"]     = "application/octet-stream"; // Static
-        meta["x-amz-meta-mode"]  = std::to_string(S_IFLNK | S_IRWXU | S_IRWXG | S_IRWXO);
+        meta["x-amz-meta-mode"]  = std::to_string(S_IFREG | (~filemask & (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)));
+        meta["x-amz-meta-atime"] = strnow;
         meta["x-amz-meta-ctime"] = strnow;
         meta["x-amz-meta-mtime"] = strnow;
         meta["x-amz-meta-uid"]   = std::to_string(pcxt->uid);


### PR DESCRIPTION
The -ENOENT branch of s3fs_truncate stamped the newly created object with x-amz-meta-mode = S_IFLNK|0777, copy-pasted from the symlink creation code, and set no x-amz-meta-atime.  Once the stat cache entry expired, the object created by this path appeared as a broken world-writable symlink instead of a file.  Use S_IFREG with the process umask applied to 0666, matching regular file creation, and set atime like the other creation paths.

The branch is only reachable when the object disappears between the preceding access check and the attribute lookup(for example another client deleting it), so there is no deterministic regression test.