### PR TITLE
Accept binary SSE-C keys starting with a NUL byte

### DIFF
--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -250,7 +250,12 @@ std::string prepare_url(const char* url)
 
 std::optional<std::string> make_md5_from_binary(const char* pstr, size_t length)
 {
-    if(!pstr || '\0' == pstr[0]){
+    // [NOTE]
+    // The input is a length-delimited binary buffer(ex. a raw SSE-C key)
+    // which may legally start with a NUL byte, so do not test it as a
+    // C string.
+    //
+    if(!pstr || 0 == length){
         S3FS_PRN_ERR("Parameter is wrong.");
         return std::nullopt;
     }

--- a/src/test_curl_util.cpp
+++ b/src/test_curl_util.cpp
@@ -150,10 +150,28 @@ void test_slist_remove()
     curl_slist_free_all(list);
 }
 
+void test_make_md5_from_binary()
+{
+    // A binary key is length-delimited and may contain or even start
+    // with a NUL byte(a random SSE-C key does so with probability 1/256).
+    char binary_key[32];
+    for(size_t i = 0; i < sizeof(binary_key); ++i){
+        binary_key[i] = static_cast<char>(i);
+    }
+    auto md5 = make_md5_from_binary(binary_key, sizeof(binary_key));
+    ASSERT_TRUE(md5.has_value());
+    ASSERT_STREQUALS("tP/LI3N87DFaSk0aoqYgzg==", md5.value_or("").c_str());
+
+    // A null or empty key is invalid.
+    ASSERT_FALSE(make_md5_from_binary(nullptr, sizeof(binary_key)).has_value());
+    ASSERT_FALSE(make_md5_from_binary(binary_key, 0).has_value());
+}
+
 int main(int argc, const char *argv[])
 {
     test_sort_insert();
     test_slist_remove();
+    test_make_md5_from_binary();
     return 0;
 }
 


### PR DESCRIPTION
make_md5_from_binary tested its length-delimited binary input with a C string emptiness check, so a raw SSE-C key whose first byte happens to be 0x00 -- one in 256 random keys -- was rejected with "Could not make MD5 from SSE-C keys" at startup.  Check the length instead, and add a unit test using a key that starts with a NUL byte.