### PR TITLE
Keep the Authorization header when retrying IAM credential requests

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1625,7 +1625,7 @@ std::optional<std::string> S3fsCurl::GetCurlErrorString() const
 //
 // Reset all options for retrying
 //
-bool S3fsCurl::RemakeHandle()
+bool S3fsCurl::RemakeHandle(bool keepAuthHeader)
 {
     S3FS_PRN_INFO3("Retry request. [type=%d][url=%s][path=%s]", static_cast<int>(type), url.c_str(), path.c_str());
 
@@ -1647,7 +1647,15 @@ bool S3fsCurl::RemakeHandle()
     }
 
     // reinitialize internal data
-    requestHeaders = curl_slist_remove(requestHeaders, "Authorization");
+    if(!keepAuthHeader){
+        // [NOTE]
+        // The Authorization header is remade by insertAuthHeaders before
+        // each attempt.  When the request runs with dontAddAuthHeaders
+        // (ex. the IBM IAM credential request, which sets Authorization
+        // manually), nothing would re-add it, so it must be kept.
+        //
+        requestHeaders = curl_slist_remove(requestHeaders, "Authorization");
+    }
     responseHeaders.clear();
     bodydata.clear();
     headdata.clear();
@@ -2243,7 +2251,7 @@ int S3fsCurl::RequestPerform(bool dontAddAuthHeaders /*=false*/)
         if(S3FSCURL_PERFORM_RESULT_NOTSET == result){
             S3FS_PRN_INFO("Communication error(%d time): Retry up to the limit.", retrycnt);
 
-            if(!RemakeHandle()){
+            if(!RemakeHandle(dontAddAuthHeaders)){
                 S3FS_PRN_INFO("Failed to reset handle and internal data for retrying.");
                 result = -EIO;
                 break;

--- a/src/curl.h
+++ b/src/curl.h
@@ -235,7 +235,7 @@ class S3fsCurl
 
         // methods
         bool ResetHandle() REQUIRES(S3fsCurl::curl_handles_lock);
-        bool RemakeHandle();
+        bool RemakeHandle(bool keepAuthHeader);
         void WaitBeforeRetry();
         bool ClearInternalData();
         bool insertV4Headers(const std::string& access_key_id, const std::string& secret_access_key, const std::string& access_token);


### PR DESCRIPTION
RemakeHandle removed the Authorization header before every retry, assuming insertAuthHeaders regenerates it on the next attempt.  The IBM IAM credential request runs RequestPerform with dontAddAuthHeaders=true and sets "Authorization: Basic ..." manually, so after the first transient failure(ex. HTTP 500 or a timeout) every retry was sent unauthenticated and refreshing the access token could never succeed.  Pass dontAddAuthHeaders down to RemakeHandle and keep the header when nothing would re-add it.

Verified against a mock IAM token endpoint returning 500 once: before this change the retry carried no Authorization header, afterwards both requests carry it.