### PR TITLE
Do not strand a queued instruction when the worker handle reset fails

### DIFF
--- a/src/threadpoolman.cpp
+++ b/src/threadpoolman.cpp
@@ -145,8 +145,17 @@ void ThreadPoolMan::Worker(ThreadPoolMan* psingleton, std::promise<int> promise)
 
         // reset curl handle
         if(!s3fscurl.CreateCurlHandle(true)){
-            S3FS_PRN_ERR("Failed to re-create curl handle.");
-            break;
+            // [NOTE]
+            // The acquired semaphore token corresponds to one queued
+            // instruction, which must not be left stranded: the request
+            // function below creates its own curl handle(and reports the
+            // error through its own result plumbing if that fails too),
+            // and the waiting semaphore is released after running it.
+            // Breaking out here instead would leave the instruction
+            // queued with no token, block its waiter forever and
+            // terminate this worker thread.
+            //
+            S3FS_PRN_ERR("Failed to re-create curl handle, but continue to run the instruction.");
         }
 
         // get instruction


### PR DESCRIPTION
When CreateCurlHandle failed, the thread pool worker broke out of its loop after having consumed the semaphore token that corresponds to one queued instruction.  The instruction stayed queued with no token, its waiter -- readdir and multipart drain loops, AwaitInstruct -- blocked on the unreleased semaphore forever, and the worker thread died, shrinking the pool permanently.

The request functions create their own curl handle and report a failure through their result plumbing, so run the instruction anyway: it either succeeds with the handle it creates itself or fails cleanly, and the waiting semaphore is always released.