### PR TITLE
Add [[nodiscard]] to error-returning functions

### DIFF
--- a/src/curl.h
+++ b/src/curl.h
@@ -249,11 +249,11 @@ class S3fsCurl
         }
         std::string CalcSignatureV2(const std::string& method, const std::string& strMD5, const std::string& content_type, const std::string& date, const std::string& resource, const std::string& secret_access_key, const std::string& access_token);
         std::string CalcSignature(const std::string& method, const std::string& canonical_uri, const std::string& query_string, const std::string& strdate, const std::string& payload_hash, const std::string& date8601, const std::string& secret_access_key, const std::string& access_token);
-        int MultipartUploadContentPartSetup(const char* tpath, int part_num, const std::string& upload_id);
-        int MultipartUploadCopyPartSetup(const char* from, const char* to, int part_num, const std::string& upload_id, const headers_t& meta);
+        [[nodiscard]] int MultipartUploadContentPartSetup(const char* tpath, int part_num, const std::string& upload_id);
+        [[nodiscard]] int MultipartUploadCopyPartSetup(const char* from, const char* to, int part_num, const std::string& upload_id, const headers_t& meta);
         bool MultipartUploadContentPartComplete();
         bool MultipartUploadCopyPartComplete();
-        int MapPutErrorResponse(int result) const;
+        [[nodiscard]] int MapPutErrorResponse(int result) const;
 
     public:
         // class methods
@@ -329,24 +329,24 @@ class S3fsCurl
         std::optional<std::string> GetIAMRoleFromMetaData(const char* cred_url, const char* iam_v2_token);
         std::optional<long> GetResponseCode(bool from_curl_handle = true) const;
         std::optional<std::string> GetCurlErrorString() const;
-        int RequestPerform(bool dontAddAuthHeaders=false);
-        int DeleteRequest(const char* tpath);
-        int GetIAMv2ApiToken(const char* token_url, int token_ttl, const char* token_ttl_hdr, std::string& response);
-        int HeadRequest(const char* tpath, headers_t& meta);
-        int PutHeadRequest(const char* tpath, const headers_t& meta, bool is_copy);
-        int PutRequest(const char* tpath, headers_t& meta, int fd);
-        int PreGetObjectRequest(const char* tpath, int fd, off_t start, off_t size, sse_type_t ssetype, const std::string& ssevalue);
-        int GetObjectRequest(const char* tpath, int fd, off_t start, off_t size, sse_type_t ssetype, const std::string& ssevalue);
-        int CheckBucket(const char* check_path, bool compat_dir, bool force_no_sse);
-        int ListBucketRequest(const char* tpath, const char* query);
-        int PreMultipartUploadRequest(const char* tpath, const headers_t& meta, std::string& upload_id);
-        int MultipartUploadPartSetup(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy);
-        int MultipartUploadComplete(const char* tpath, const std::string& upload_id, const etaglist_t& parts);
+        [[nodiscard]] int RequestPerform(bool dontAddAuthHeaders=false);
+        [[nodiscard]] int DeleteRequest(const char* tpath);
+        [[nodiscard]] int GetIAMv2ApiToken(const char* token_url, int token_ttl, const char* token_ttl_hdr, std::string& response);
+        [[nodiscard]] int HeadRequest(const char* tpath, headers_t& meta);
+        [[nodiscard]] int PutHeadRequest(const char* tpath, const headers_t& meta, bool is_copy);
+        [[nodiscard]] int PutRequest(const char* tpath, headers_t& meta, int fd);
+        [[nodiscard]] int PreGetObjectRequest(const char* tpath, int fd, off_t start, off_t size, sse_type_t ssetype, const std::string& ssevalue);
+        [[nodiscard]] int GetObjectRequest(const char* tpath, int fd, off_t start, off_t size, sse_type_t ssetype, const std::string& ssevalue);
+        [[nodiscard]] int CheckBucket(const char* check_path, bool compat_dir, bool force_no_sse);
+        [[nodiscard]] int ListBucketRequest(const char* tpath, const char* query);
+        [[nodiscard]] int PreMultipartUploadRequest(const char* tpath, const headers_t& meta, std::string& upload_id);
+        [[nodiscard]] int MultipartUploadPartSetup(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy);
+        [[nodiscard]] int MultipartUploadComplete(const char* tpath, const std::string& upload_id, const etaglist_t& parts);
         bool MultipartUploadPartComplete();
-        int MultipartListRequest(std::string& body);
-        int AbortMultipartUpload(const char* tpath, const std::string& upload_id);
-        int MultipartPutHeadRequest(const std::string& from, const std::string& to, int part_number, const std::string& upload_id, const headers_t& meta);
-        int MultipartUploadPartRequest(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy);
+        [[nodiscard]] int MultipartListRequest(std::string& body);
+        [[nodiscard]] int AbortMultipartUpload(const char* tpath, const std::string& upload_id);
+        [[nodiscard]] int MultipartPutHeadRequest(const std::string& from, const std::string& to, int part_number, const std::string& upload_id, const headers_t& meta);
+        [[nodiscard]] int MultipartUploadPartRequest(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy);
 
         // methods(variables)
         const std::string& GetPath() const { return path; }

--- a/src/curl_util.h
+++ b/src/curl_util.h
@@ -41,7 +41,7 @@ std::string get_header_value(const struct curl_slist* list, std::string_view key
 bool MakeUrlResource(const char* realpath, std::string& resourcepath, std::string& url);
 std::string prepare_url(const char* url);
 bool get_object_sse_type(const char* path, sse_type_t& ssetype, std::string& ssevalue);   // implement in s3fs.cpp
-int put_headers(const char* path, const headers_t& meta, bool is_copy, bool use_st_size = true);    // implement in s3fs.cpp
+[[nodiscard]] int put_headers(const char* path, const headers_t& meta, bool is_copy, bool use_st_size = true);    // implement in s3fs.cpp
 
 std::optional<std::string> make_md5_from_binary(const char* pstr, size_t length);
 std::string url_to_host(std::string_view url);

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1056,7 +1056,8 @@ bool FdManager::RawCheckAllCache(FILE* fp, const char* cache_stat_top_dir, const
 
                 continue;
             }
-            cfstat.Release();
+            // Ignore the result since Release logs errors and they do not affect the check.
+            static_cast<void>(cfstat.Release());
 
             // compare cache file size and stats information
             if(st.st_size != pagelist.Size()){

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -1057,7 +1057,8 @@ bool FdManager::RawCheckAllCache(FILE* fp, const char* cache_stat_top_dir, const
 
                 continue;
             }
-            cfstat.Release();
+            // Ignore the result since Release logs errors and they do not affect the check.
+            static_cast<void>(cfstat.Release());
 
             // compare cache file size and stats information
             if(st.st_size != pagelist.Size()){

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -426,10 +426,7 @@ int FdEntity::Open(const headers_t* pmeta, off_t size, const FileTimes& ts_times
                 return -errno;
             }
             // resize page list
-            if(!pagelist.Resize(size, false, true)){      // Areas with increased size are modified
-                S3FS_PRN_ERR("failed to truncate temporary file information(physical_fd=%d).", physical_fd);
-                return -EIO;
-            }
+            pagelist.Resize(size, false, true);           // Areas with increased size are modified
         }
 
         // set untreated area

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -398,10 +398,7 @@ int FdEntity::Open(const headers_t* pmeta, off_t size, const FileTimes& ts_times
                 return -errno;
             }
             // resize page list
-            if(!pagelist.Resize(size, false, true)){      // Areas with increased size are modified
-                S3FS_PRN_ERR("failed to truncate temporary file information(physical_fd=%d).", physical_fd);
-                return -EIO;
-            }
+            pagelist.Resize(size, false, true);           // Areas with increased size are modified
         }
 
         // set untreated area

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -89,7 +89,7 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
         void Clear();
         ino_t GetInode() const REQUIRES(FdEntity::fdent_data_lock);
         int OpenMirrorFile() REQUIRES(FdEntity::fdent_data_lock);
-        int NoCacheLoadAndPost(PseudoFdInfo* pseudo_obj, off_t start = 0, off_t size = 0) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);    // size=0 means loading to end
+        [[nodiscard]] int NoCacheLoadAndPost(PseudoFdInfo* pseudo_obj, off_t start = 0, off_t size = 0) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);    // size=0 means loading to end
         void FreeUploadedRange(off_t start, off_t size) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         PseudoFdInfo* CheckPseudoFdFlags(int fd, bool writable) REQUIRES(FdEntity::fdent_lock);
         bool IsUploading() const REQUIRES(FdEntity::fdent_lock);
@@ -99,22 +99,22 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
         int SetFileTimesHasLock(const FileTimes& ts_times) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         bool SetAllStatus(bool is_loaded) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         bool SetAllStatusUnloaded() REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock) { return SetAllStatus(false); }
-        int PreMultipartUploadRequest(PseudoFdInfo* pseudo_obj, const char* tpath = nullptr) REQUIRES(FdEntity::fdent_lock, fdent_data_lock);
-        int NoCachePreMultipartUploadRequest(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
-        int NoCacheMultipartUploadRequest(PseudoFdInfo* pseudo_obj, int tgfd, off_t start, off_t size) REQUIRES(FdEntity::fdent_lock);
-        int NoCacheMultipartUploadComplete(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock);
-        int RowFlushHasLock(int fd, const char* tpath, bool force_sync) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
-        int RowFlushNoMultipart(const PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
-        int RowFlushMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
-        int RowFlushMixMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
-        int RowFlushStreamMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int PreMultipartUploadRequest(PseudoFdInfo* pseudo_obj, const char* tpath = nullptr) REQUIRES(FdEntity::fdent_lock, fdent_data_lock);
+        [[nodiscard]] int NoCachePreMultipartUploadRequest(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int NoCacheMultipartUploadRequest(PseudoFdInfo* pseudo_obj, int tgfd, off_t start, off_t size) REQUIRES(FdEntity::fdent_lock);
+        [[nodiscard]] int NoCacheMultipartUploadComplete(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock);
+        [[nodiscard]] int RowFlushHasLock(int fd, const char* tpath, bool force_sync) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int RowFlushNoMultipart(const PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int RowFlushMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int RowFlushMixMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int RowFlushStreamMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         void AbortStreamUpload(PseudoFdInfo* pseudo_obj, const std::string& strpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         ssize_t WriteNoMultipart(const PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         ssize_t WriteMultipart(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         ssize_t WriteMixMultipart(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         ssize_t WriteStreamUpload(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
 
-        int UploadPendingHasLock(int fd) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int UploadPendingHasLock(int fd) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
 
         bool ReserveDiskSpace(off_t size) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
 
@@ -151,9 +151,9 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
             const std::lock_guard<std::mutex> ro_lock(ro_path_lock);
             return ro_path;
         }
-        int Open(const headers_t* pmeta, off_t size, const FileTimes& ts_times, int flags);
+        [[nodiscard]] int Open(const headers_t* pmeta, off_t size, const FileTimes& ts_times, int flags);
 
-        int LoadAll(int fd, off_t* size = nullptr, bool force_load = false);
+        [[nodiscard]] int LoadAll(int fd, off_t* size = nullptr, bool force_load = false);
         int Dup(int fd) {
             const std::lock_guard<std::mutex> lock(fdent_lock);
             return DupWithLock(fd);
@@ -176,7 +176,7 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
         bool MergeOrgMeta(headers_t& updatemeta);
         bool GetOrgMeta(headers_t& meta) const;
 
-        int UploadPending(int fd) {
+        [[nodiscard]] int UploadPending(int fd) {
             const std::lock_guard<std::mutex> lock(fdent_lock);
             const std::lock_guard<std::mutex> lock_data(fdent_data_lock);
             return UploadPendingHasLock(fd);
@@ -229,15 +229,15 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
         bool SetContentType(const char* path);
         bool GetStatsFromMeta(struct stat& st) const;
 
-        int Load(off_t start, off_t size, bool is_modified_flag = false) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);  // size=0 means loading to end
+        [[nodiscard]] int Load(off_t start, off_t size, bool is_modified_flag = false) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);  // size=0 means loading to end
 
         off_t BytesModified() const;
-        int RowFlush(int fd, const char* tpath, bool force_sync = false) {
+        [[nodiscard]] int RowFlush(int fd, const char* tpath, bool force_sync = false) {
             const std::lock_guard<std::mutex> lock(fdent_lock);
             const std::lock_guard<std::mutex> lock_data(fdent_data_lock);
             return RowFlushHasLock(fd, tpath, force_sync);
         }
-        int Flush(int fd, bool force_sync = false) {
+        [[nodiscard]] int Flush(int fd, bool force_sync = false) {
             return RowFlush(fd, nullptr, force_sync);
         }
 

--- a/src/fdcache_entity.h
+++ b/src/fdcache_entity.h
@@ -88,7 +88,7 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
         void Clear();
         ino_t GetInode() const REQUIRES(FdEntity::fdent_data_lock);
         int OpenMirrorFile() REQUIRES(FdEntity::fdent_data_lock);
-        int NoCacheLoadAndPost(PseudoFdInfo* pseudo_obj, off_t start = 0, off_t size = 0) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);    // size=0 means loading to end
+        [[nodiscard]] int NoCacheLoadAndPost(PseudoFdInfo* pseudo_obj, off_t start = 0, off_t size = 0) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);    // size=0 means loading to end
         PseudoFdInfo* CheckPseudoFdFlags(int fd, bool writable) REQUIRES(FdEntity::fdent_lock);
         bool IsUploading() const REQUIRES(FdEntity::fdent_lock);
         int SetCtimeHasLock(struct timespec time) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
@@ -97,21 +97,21 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
         int SetFileTimesHasLock(const FileTimes& ts_times) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         bool SetAllStatus(bool is_loaded) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         bool SetAllStatusUnloaded() REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock) { return SetAllStatus(false); }
-        int PreMultipartUploadRequest(PseudoFdInfo* pseudo_obj, const char* tpath = nullptr) REQUIRES(FdEntity::fdent_lock, fdent_data_lock);
-        int NoCachePreMultipartUploadRequest(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
-        int NoCacheMultipartUploadRequest(PseudoFdInfo* pseudo_obj, int tgfd, off_t start, off_t size) REQUIRES(FdEntity::fdent_lock);
-        int NoCacheMultipartUploadComplete(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock);
-        int RowFlushHasLock(int fd, const char* tpath, bool force_sync) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
-        int RowFlushNoMultipart(const PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
-        int RowFlushMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
-        int RowFlushMixMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
-        int RowFlushStreamMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int PreMultipartUploadRequest(PseudoFdInfo* pseudo_obj, const char* tpath = nullptr) REQUIRES(FdEntity::fdent_lock, fdent_data_lock);
+        [[nodiscard]] int NoCachePreMultipartUploadRequest(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int NoCacheMultipartUploadRequest(PseudoFdInfo* pseudo_obj, int tgfd, off_t start, off_t size) REQUIRES(FdEntity::fdent_lock);
+        [[nodiscard]] int NoCacheMultipartUploadComplete(PseudoFdInfo* pseudo_obj) REQUIRES(FdEntity::fdent_lock);
+        [[nodiscard]] int RowFlushHasLock(int fd, const char* tpath, bool force_sync) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int RowFlushNoMultipart(const PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int RowFlushMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int RowFlushMixMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int RowFlushStreamMultipart(PseudoFdInfo* pseudo_obj, const char* tpath) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         ssize_t WriteNoMultipart(const PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         ssize_t WriteMultipart(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         ssize_t WriteMixMultipart(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
         ssize_t WriteStreamUpload(PseudoFdInfo* pseudo_obj, const char* bytes, off_t start, size_t size) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
 
-        int UploadPendingHasLock(int fd) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
+        [[nodiscard]] int UploadPendingHasLock(int fd) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
 
         bool ReserveDiskSpace(off_t size) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);
 
@@ -148,9 +148,9 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
             const std::lock_guard<std::mutex> ro_lock(ro_path_lock);
             return ro_path;
         }
-        int Open(const headers_t* pmeta, off_t size, const FileTimes& ts_times, int flags);
+        [[nodiscard]] int Open(const headers_t* pmeta, off_t size, const FileTimes& ts_times, int flags);
 
-        int LoadAll(int fd, off_t* size = nullptr, bool force_load = false);
+        [[nodiscard]] int LoadAll(int fd, off_t* size = nullptr, bool force_load = false);
         int Dup(int fd) {
             const std::lock_guard<std::mutex> lock(fdent_lock);
             return DupWithLock(fd);
@@ -173,7 +173,7 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
         bool MergeOrgMeta(headers_t& updatemeta);
         bool GetOrgMeta(headers_t& meta) const;
 
-        int UploadPending(int fd) {
+        [[nodiscard]] int UploadPending(int fd) {
             const std::lock_guard<std::mutex> lock(fdent_lock);
             const std::lock_guard<std::mutex> lock_data(fdent_data_lock);
             return UploadPendingHasLock(fd);
@@ -226,15 +226,15 @@ class FdEntity : public std::enable_shared_from_this<FdEntity>
         bool SetContentType(const char* path);
         bool GetStatsFromMeta(struct stat& st) const;
 
-        int Load(off_t start, off_t size, bool is_modified_flag = false) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);  // size=0 means loading to end
+        [[nodiscard]] int Load(off_t start, off_t size, bool is_modified_flag = false) REQUIRES(FdEntity::fdent_lock, FdEntity::fdent_data_lock);  // size=0 means loading to end
 
         off_t BytesModified() const;
-        int RowFlush(int fd, const char* tpath, bool force_sync = false) {
+        [[nodiscard]] int RowFlush(int fd, const char* tpath, bool force_sync = false) {
             const std::lock_guard<std::mutex> lock(fdent_lock);
             const std::lock_guard<std::mutex> lock_data(fdent_data_lock);
             return RowFlushHasLock(fd, tpath, force_sync);
         }
-        int Flush(int fd, bool force_sync = false) {
+        [[nodiscard]] int Flush(int fd, bool force_sync = false) {
             return RowFlush(fd, nullptr, force_sync);
         }
 

--- a/src/fdcache_page.cpp
+++ b/src/fdcache_page.cpp
@@ -389,7 +389,7 @@ off_t PageList::Size() const
     return riter->next();
 }
 
-bool PageList::Compress()
+void PageList::Compress()
 {
     fdpage* lastpage = nullptr;
     for(auto iter = pages.begin(); iter != pages.end(); ){
@@ -423,7 +423,6 @@ bool PageList::Compress()
             }
         }
     }
-    return true;
 }
 
 bool PageList::Parse(off_t new_pos)
@@ -443,7 +442,7 @@ bool PageList::Parse(off_t new_pos)
     return false;
 }
 
-bool PageList::Resize(off_t size, bool is_loaded, bool is_modified)
+void PageList::Resize(off_t size, bool is_loaded, bool is_modified)
 {
     off_t total = Size();
 
@@ -481,7 +480,7 @@ bool PageList::Resize(off_t size, bool is_loaded, bool is_modified)
         // nothing to do
     }
     // compress area
-    return Compress();
+    Compress();
 }
 
 bool PageList::IsPageLoaded(off_t start, off_t size) const
@@ -538,7 +537,10 @@ bool PageList::SetPageLoadedStatus(off_t start, off_t size, PageList::page_statu
         }
     }
     // compress area
-    return (is_compress ? Compress() : true);
+    if(is_compress){
+        Compress();
+    }
+    return true;
 }
 
 bool PageList::FindUnloadedPage(off_t start, off_t& resstart, off_t& ressize) const
@@ -649,7 +651,7 @@ size_t PageList::GetUnloadedPages(fdpage_list_t& unloaded_list, off_t start, off
 bool PageList::GetPageListsForMultipartUpload(fdpage_list_t& dlpages, fdpage_list_t& mixuppages, off_t max_partsize)
 {
     // compress before this processing
-    Compress();         // always true
+    Compress();
 
     // make a list by modified flag
     fdpage_list_t modified_pages;
@@ -750,7 +752,7 @@ bool PageList::GetPageListsForMultipartUpload(fdpage_list_t& dlpages, fdpage_lis
 bool PageList::GetNoDataPageLists(fdpage_list_t& nodata_pages, off_t start, size_t size)
 {
     // compress before this processing
-    Compress();         // always true
+    Compress();
 
     // extract areas without data
     fdpage_list_t tmp_pagelist;
@@ -808,7 +810,7 @@ bool PageList::IsModified() const
     return false;
 }
 
-bool PageList::ClearAllModified()
+void PageList::ClearAllModified()
 {
     is_shrink = false;
 
@@ -817,7 +819,7 @@ bool PageList::ClearAllModified()
             iter->modified = false;
         }
     }
-    return Compress();
+    Compress();
 }
 
 bool PageList::Serialize(const CacheFileStat& file, ino_t inode) const

--- a/src/fdcache_page.h
+++ b/src/fdcache_page.h
@@ -107,7 +107,7 @@ class PageList
 
         bool Init(off_t size, bool is_loaded, bool is_modified);
         off_t Size() const;
-        bool Resize(off_t size, bool is_loaded, bool is_modified);
+        void Resize(off_t size, bool is_loaded, bool is_modified);
 
         bool IsPageLoaded(off_t start = 0, off_t size = 0) const;                  // size=0 is checking to end of list
         bool SetPageLoadedStatus(off_t start, off_t size, PageList::page_status pstatus = page_status::LOADED, bool is_compress = true);
@@ -119,9 +119,9 @@ class PageList
 
         off_t BytesModified() const;
         bool IsModified() const;
-        bool ClearAllModified();
+        void ClearAllModified();
 
-        bool Compress();
+        void Compress();
         bool Deserialize(CacheFileStat& file, ino_t inode);
         void Dump() const;
         bool CompareSparseFile(int fd, size_t file_size, fdpage_list_t& err_area_list, fdpage_list_t& warn_area_list) const;

--- a/src/fdcache_stat.cpp
+++ b/src/fdcache_stat.cpp
@@ -174,7 +174,8 @@ CacheFileStat::CacheFileStat(const char* tpath) : fd(-1)
 
 CacheFileStat::~CacheFileStat()
 {
-    Release();
+    // Ignore the result since Release logs errors and the destructor cannot handle them.
+    static_cast<void>(Release());
 }
 
 bool CacheFileStat::SetPath(const char* tpath, bool is_open)

--- a/src/fdcache_stat.h
+++ b/src/fdcache_stat.h
@@ -53,7 +53,7 @@ class CacheFileStat
 
         bool Open();
         bool ReadOnlyOpen();
-        bool Release();
+        [[nodiscard]] bool Release();
         bool SetPath(const char* tpath, bool is_open = true);
         int GetFd() const { return fd; }
         bool OverWriteFile(const std::string& strall) const;

--- a/src/fdcache_untreated.cpp
+++ b/src/fdcache_untreated.cpp
@@ -219,12 +219,11 @@ bool UntreatedParts::RemoveLastUpdatePart()
 //
 // Duplicate the internally untreated_list.
 //
-bool UntreatedParts::Duplicate(untreated_list_t& list) const
+void UntreatedParts::Duplicate(untreated_list_t& list) const
 {
     const std::lock_guard<std::mutex> lock(untreated_list_lock);
 
     list = untreated_list;
-    return true;
 }
 
 void UntreatedParts::Dump() const

--- a/src/fdcache_untreated.h
+++ b/src/fdcache_untreated.h
@@ -60,7 +60,7 @@ class UntreatedParts
         bool ReplaceLastUpdatePart(off_t start, off_t size);
         bool RemoveLastUpdatePart();
 
-        bool Duplicate(untreated_list_t& list) const;
+        void Duplicate(untreated_list_t& list) const;
 
         void Dump() const;
 };

--- a/src/metaheader.h
+++ b/src/metaheader.h
@@ -56,7 +56,7 @@ time_t get_lastmodified(const char* s);
 time_t get_lastmodified(const headers_t& meta);
 bool is_need_check_obj_detail(const headers_t& meta);
 bool merge_headers(headers_t& base, const headers_t& additional, bool add_noexist);
-bool convert_header_to_stat(const std::string& strpath, const headers_t& meta, struct stat& stbuf, bool forcedir = false);
+[[nodiscard]] bool convert_header_to_stat(const std::string& strpath, const headers_t& meta, struct stat& stbuf, bool forcedir = false);
 
 #endif // S3FS_METAHEADER_H_
 

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3627,7 +3627,15 @@ static int readdir_multi_head(const std::string& strpath, const S3ObjList& head,
             if(use_wtf8){
                 bpath = s3fs_wtf8_decode(bpath);
             }
-            syncfiller.Fill(bpath, &st, 0);
+            // [NOTE]
+            // The non-seekable readdir filler only fails when it cannot
+            // allocate memory, so give up on the whole listing.
+            //
+            if(0 != syncfiller.Fill(bpath, &st, 0)){
+                S3FS_PRN_ERR("filler could not add entry(%s), so abort readdir.", bpath.c_str());
+                sched_result = -ENOMEM;
+                break;
+            }
             continue;
         }
 
@@ -3665,7 +3673,10 @@ static int readdir_multi_head(const std::string& strpath, const S3ObjList& head,
     // as a path, so search for objects under that path.(a case of no dir object)
     //
     if(!support_compat_dir){
-        syncfiller.SufficiencyFill(head.GetCommonPrefixes());
+        if(0 != syncfiller.SufficiencyFill(head.GetCommonPrefixes())){
+            S3FS_PRN_ERR("filler could not add entries, so abort readdir.");
+            return -ENOMEM;
+        }
     }
     if(support_compat_dir && !notfound_list.empty()){      // [NOTE] not need to lock to access this here.
         // dummy header
@@ -3693,17 +3704,22 @@ static int readdir_multi_head(const std::string& strpath, const S3ObjList& head,
 
                 // Set stat structure
                 struct stat st;
+                int fill_result;
                 if(!convert_header_to_stat(dirpath, dummy_header, st, true)){       // forcedir=true
                     S3FS_PRN_ERR("failed convert headers to stat[path=%s], so fill empty stat.", dirpath.c_str());
-                    syncfiller.Fill(bpath, nullptr, 0);
+                    fill_result = syncfiller.Fill(bpath, nullptr, 0);
                 }else{
                     // Add stat cache
                     if(!StatCache::getStatCacheData()->AddStat(dirpath, st, dummy_header, objtype_t::DIR_NOT_EXIST_OBJECT, false)){
                         S3FS_PRN_ERR("failed adding stat cache [path=%s], so fill empty stat.", dirpath.c_str());
-                        syncfiller.Fill(bpath, nullptr, 0);
+                        fill_result = syncfiller.Fill(bpath, nullptr, 0);
                     }else{
-                        syncfiller.Fill(bpath, &st, 0);
+                        fill_result = syncfiller.Fill(bpath, &st, 0);
                     }
+                }
+                if(0 != fill_result){
+                    S3FS_PRN_ERR("filler could not add entry(%s), so abort readdir.", bpath.c_str());
+                    return -ENOMEM;
                 }
             }else{
                 S3FS_PRN_WARN("%s object does not have any object under it(errno=%d),", reiter->c_str(), dir_result);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3666,7 +3666,15 @@ static int readdir_multi_head(const std::string& strpath, const S3ObjList& head,
             if(use_wtf8){
                 bpath = s3fs_wtf8_decode(bpath);
             }
-            syncfiller.Fill(bpath, &st, 0);
+            // [NOTE]
+            // The non-seekable readdir filler only fails when it cannot
+            // allocate memory, so give up on the whole listing.
+            //
+            if(0 != syncfiller.Fill(bpath, &st, 0)){
+                S3FS_PRN_ERR("filler could not add entry(%s), so abort readdir.", bpath.c_str());
+                sched_result = -ENOMEM;
+                break;
+            }
             continue;
         }
 
@@ -3704,7 +3712,10 @@ static int readdir_multi_head(const std::string& strpath, const S3ObjList& head,
     // as a path, so search for objects under that path.(a case of no dir object)
     //
     if(!support_compat_dir){
-        syncfiller.SufficiencyFill(head.GetCommonPrefixes());
+        if(0 != syncfiller.SufficiencyFill(head.GetCommonPrefixes())){
+            S3FS_PRN_ERR("filler could not add entries, so abort readdir.");
+            return -ENOMEM;
+        }
     }
     if(support_compat_dir && !notfound_list.empty()){      // [NOTE] not need to lock to access this here.
         // dummy header
@@ -3732,17 +3743,22 @@ static int readdir_multi_head(const std::string& strpath, const S3ObjList& head,
 
                 // Set stat structure
                 struct stat st;
+                int fill_result;
                 if(!convert_header_to_stat(dirpath, dummy_header, st, true)){       // forcedir=true
                     S3FS_PRN_ERR("failed convert headers to stat[path=%s], so fill empty stat.", dirpath.c_str());
-                    syncfiller.Fill(bpath, nullptr, 0);
+                    fill_result = syncfiller.Fill(bpath, nullptr, 0);
                 }else{
                     // Add stat cache
                     if(!StatCache::getStatCacheData()->AddStat(dirpath, st, dummy_header, objtype_t::DIR_NOT_EXIST_OBJECT, false)){
                         S3FS_PRN_ERR("failed adding stat cache [path=%s], so fill empty stat.", dirpath.c_str());
-                        syncfiller.Fill(bpath, nullptr, 0);
+                        fill_result = syncfiller.Fill(bpath, nullptr, 0);
                     }else{
-                        syncfiller.Fill(bpath, &st, 0);
+                        fill_result = syncfiller.Fill(bpath, &st, 0);
                     }
+                }
+                if(0 != fill_result){
+                    S3FS_PRN_ERR("filler could not add entry(%s), so abort readdir.", bpath.c_str());
+                    return -ENOMEM;
                 }
             }else{
                 S3FS_PRN_WARN("%s object does not have any object under it(errno=%d),", reiter->c_str(), dir_result);

--- a/src/s3fs_threadreqs.cpp
+++ b/src/s3fs_threadreqs.cpp
@@ -91,7 +91,12 @@ void* multi_head_req_threadworker(S3fsCurl& s3fscurl, void* arg)
                 struct stat stbuf;
                 if(convert_header_to_stat(pthparam->path, *(s3fscurl.GetResponseHeaders()), stbuf, false)){
                     // fill stat
-                    pthparam->psyncfiller->Fill(bpath, &stbuf, 0);
+                    if(0 != pthparam->psyncfiller->Fill(bpath, &stbuf, 0)){
+                        S3FS_PRN_ERR("filler could not add entry(%s)", pthparam->path.c_str());
+                        if(0 == result){
+                            result = -ENOMEM;
+                        }
+                    }
 
                     // objet type
                     objtype_t ObjType = pthparam->objtype;
@@ -123,7 +128,12 @@ void* multi_head_req_threadworker(S3fsCurl& s3fscurl, void* arg)
                     }
                 }else{
                     S3FS_PRN_INFO2("Could not convert headers to stat[path=%s]", pthparam->path.c_str());
-                    pthparam->psyncfiller->Fill(bpath, nullptr, 0);
+                    if(0 != pthparam->psyncfiller->Fill(bpath, nullptr, 0)){
+                        S3FS_PRN_ERR("filler could not add entry(%s)", pthparam->path.c_str());
+                        if(0 == result){
+                            result = -ENOMEM;
+                        }
+                    }
                 }
                 break;
 

--- a/src/s3fs_util.h
+++ b/src/s3fs_util.h
@@ -41,14 +41,14 @@ std::string get_realpath(const char *path);
 
 void init_sysconf_vars();
 std::string get_username(uid_t uid);
-int is_uid_include_group(uid_t uid, gid_t gid);
+[[nodiscard]] int is_uid_include_group(uid_t uid, gid_t gid);
 
 std::string mydirname(std::string path);
 std::string mybasename(std::string path);
 
-int mkdirp(const std::string& path, mode_t mode);
+[[nodiscard]] int mkdirp(const std::string& path, mode_t mode);
 std::string get_exist_directory_path(const std::string& path);
-bool check_exist_dir_permission(const char* dirpath);
+[[nodiscard]] bool check_exist_dir_permission(const char* dirpath);
 bool delete_files_in_dir(const char* dir, bool is_remove_own);
 
 void print_launch_message(int argc, char** argv);

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -78,7 +78,7 @@ const char* s3fs_strptime(const char* s, const char* f, struct tm* tm);
 // Convert string to off_t.  Returns false on bad input.
 // Replacement for C++11 std::stoll.
 //
-bool s3fs_strtoofft(off_t* value, const char* str, int base = 0);
+[[nodiscard]] bool s3fs_strtoofft(off_t* value, const char* str, int base = 0);
 //
 // This function returns 0 if a value that cannot be converted is specified.
 // Only call if 0 is considered an error and the operation can continue.

--- a/src/syncfiller.h
+++ b/src/syncfiller.h
@@ -51,8 +51,8 @@ class SyncFiller
         SyncFiller& operator=(const SyncFiller&) = delete;
         SyncFiller& operator=(SyncFiller&&) = delete;
 
-        int Fill(const std::string& name, const struct stat *stbuf, off_t off);
-        int SufficiencyFill(const std::vector<std::string>& pathlist);
+        [[nodiscard]] int Fill(const std::string& name, const struct stat *stbuf, off_t off);
+        [[nodiscard]] int SufficiencyFill(const std::vector<std::string>& pathlist);
 };
 
 #endif // SYNCFILLER_H_


### PR DESCRIPTION
Annotate the S3fsCurl request methods, the FdEntity flush/upload/load chain, SyncFiller, CacheFileStat::Release, and utility error returns so that the compiler rejects silently ignored errors, and address the discards this surfaced:

* Handle SyncFiller::Fill and SufficiencyFill results in readdir; the non-seekable filler only fails when it cannot allocate memory, so abort the listing with -ENOMEM instead of silently truncating it
* Convert PageList::Compress, Resize, ClearAllModified and UntreatedParts::Duplicate to void since they always returned true, and remove a dead error branch in FdEntity::Open
* Make the intentional Release discards explicit in ~CacheFileStat and FdManager::RawCheckAllCache

merge_headers and the char* forms of s3fs_wtf8_encode/decode are left unannotated because their bool means "modified something", not an error, and callers legitimately ignore it.