### PR TITLE
Fix constexpr linkage and extend constexpr coverage

### DIFF
--- a/src/cache_node.cpp
+++ b/src/cache_node.cpp
@@ -18,11 +18,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <cstring>
 #include <iomanip>
 #include <sstream>
 
 #include "s3fs_logger.h"
 #include "cache_node.h"
+#include "filetimes.h"
 #include "string_util.h"
 
 //===================================================================
@@ -36,32 +38,13 @@ static void SetCurrentTime(struct timespec& ts)
     }
 }
 
-static constexpr int CompareStatCacheTime(const struct timespec& ts1, const struct timespec& ts2)
-{
-    // return -1:  ts1 < ts2
-    //         0:  ts1 == ts2
-    //         1:  ts1 > ts2
-    if(ts1.tv_sec < ts2.tv_sec){
-        return -1;
-    }else if(ts1.tv_sec > ts2.tv_sec){
-        return 1;
-    }else{
-        if(ts1.tv_nsec < ts2.tv_nsec){
-            return -1;
-        }else if(ts1.tv_nsec > ts2.tv_nsec){
-            return 1;
-        }
-    }
-    return 0;
-}
-
 static bool IsExpireStatCacheTime(const struct timespec& ts, time_t expire)
 {
     struct timespec nowts;
     SetCurrentTime(nowts);
     nowts.tv_sec -= expire;
 
-    return (0 < CompareStatCacheTime(nowts, ts));
+    return (0 < compare_timespec(nowts, ts));
 }
 
 //
@@ -175,7 +158,7 @@ bool StatCacheNode::NeedExpireCheckHasLock(const struct timespec& ts)
     // checking is not necessary.
     //
     if(0L < StatCacheNode::DisableCheckingExpire){
-        if(0 >= CompareStatCacheTime(StatCacheNode::DisableExpireDate, ts)){
+        if(0 >= compare_timespec(StatCacheNode::DisableExpireDate, ts)){
             return false;
         }
     }

--- a/src/curl_util.cpp
+++ b/src/curl_util.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <curl/curl.h>
 #include <string>
 
@@ -298,29 +299,6 @@ std::string get_bucket_host()
         return S3fsCred::GetBucket() + "." + url_to_host(s3host);
     }
     return url_to_host(s3host);
-}
-
-const char* getCurlDebugHead(curl_infotype type)
-{
-    const char* unknown = "";
-    const char* dataIn  = "BODY <";
-    const char* dataOut = "BODY >";
-    const char* headIn  = "<";
-    const char* headOut = ">";
-
-    switch(type){
-        case CURLINFO_DATA_IN:
-            return dataIn;
-        case CURLINFO_DATA_OUT:
-            return dataOut;
-        case CURLINFO_HEADER_IN:
-            return headIn;
-        case CURLINFO_HEADER_OUT:
-            return headOut;
-        default:
-            break;
-    }
-    return unknown;
 }
 
 //

--- a/src/curl_util.h
+++ b/src/curl_util.h
@@ -46,7 +46,22 @@ int put_headers(const char* path, const headers_t& meta, bool is_copy, bool use_
 std::optional<std::string> make_md5_from_binary(const char* pstr, size_t length);
 std::string url_to_host(std::string_view url);
 std::string get_bucket_host();
-const char* getCurlDebugHead(curl_infotype type);
+
+constexpr const char* getCurlDebugHead(curl_infotype type)
+{
+    switch(type){
+        case CURLINFO_DATA_IN:
+            return "BODY <";
+        case CURLINFO_DATA_OUT:
+            return "BODY >";
+        case CURLINFO_HEADER_IN:
+            return "<";
+        case CURLINFO_HEADER_OUT:
+            return ">";
+        default:
+            return "";
+    }
+}
 
 bool etag_equals(std::string_view s1, std::string_view s2);
 

--- a/src/fdcache.cpp
+++ b/src/fdcache.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <cerrno>
 #include <climits>  // NOLINT(misc-include-cleaner)
 #include <unistd.h>

--- a/src/filetimes.cpp
+++ b/src/filetimes.cpp
@@ -25,38 +25,12 @@
 //-------------------------------------------------------------------
 // Utility functions
 //-------------------------------------------------------------------
-//
-// result: -1  ts1 <  ts2
-//          0  ts1 == ts2
-//          1  ts1 >  ts2
-//
 bool valid_timespec(const struct timespec& ts)
 {
     if(0 > ts.tv_sec || UTIME_OMIT == ts.tv_nsec || UTIME_NOW == ts.tv_nsec){
         return false;
     }
     return true;
-}
-
-//
-// result: -1  ts1 <  ts2
-//          0  ts1 == ts2
-//          1  ts1 >  ts2
-//
-constexpr int compare_timespec(const struct timespec& ts1, const struct timespec& ts2)
-{
-    if(ts1.tv_sec < ts2.tv_sec){
-        return -1;
-    }else if(ts1.tv_sec > ts2.tv_sec){
-        return 1;
-    }else{
-        if(ts1.tv_nsec < ts2.tv_nsec){
-            return -1;
-        }else if(ts1.tv_nsec > ts2.tv_nsec){
-            return 1;
-        }
-    }
-    return 0;
 }
 
 //

--- a/src/filetimes.h
+++ b/src/filetimes.h
@@ -38,7 +38,31 @@ enum class stat_time_type : uint8_t {
 // Utility Functions for timespecs
 //-------------------------------------------------------------------
 bool valid_timespec(const struct timespec& ts);
-constexpr int compare_timespec(const struct timespec& ts1, const struct timespec& ts2);
+
+//
+// result: -1  ts1 <  ts2
+//          0  ts1 == ts2
+//          1  ts1 >  ts2
+//
+// [NOTE]
+// This must be defined in the header since constexpr implies inline.
+//
+constexpr int compare_timespec(const struct timespec& ts1, const struct timespec& ts2)
+{
+    if(ts1.tv_sec < ts2.tv_sec){
+        return -1;
+    }else if(ts1.tv_sec > ts2.tv_sec){
+        return 1;
+    }else{
+        if(ts1.tv_nsec < ts2.tv_nsec){
+            return -1;
+        }else if(ts1.tv_nsec > ts2.tv_nsec){
+            return 1;
+        }
+    }
+    return 0;
+}
+
 int compare_timespec(const struct stat& st, stat_time_type type, const struct timespec& ts);
 void set_timespec_to_stat(struct stat& st, stat_time_type type, const struct timespec& ts);
 struct timespec* set_stat_to_timespec(const struct stat& st, stat_time_type type, struct timespec& ts);

--- a/src/s3fs.h
+++ b/src/s3fs.h
@@ -34,7 +34,7 @@
 #include <fuse.h>  // NOLINT(misc-include-cleaner)
 
 // FUSE_FILL_DIR_DEFAULTS requirse FUSE 3.17
-static constexpr fuse_fill_dir_flags S3FS_FUSE_FILL_DIR_DEFAULTS = static_cast<fuse_fill_dir_flags>(0);  // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
+inline constexpr fuse_fill_dir_flags S3FS_FUSE_FILL_DIR_DEFAULTS = static_cast<fuse_fill_dir_flags>(0);  // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
 
 #define S3FS_FUSE_EXIT() \
         do{ \

--- a/src/s3fs_cred.cpp
+++ b/src/s3fs_cred.cpp
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <cstring>
 #include <cerrno>
 #include <unistd.h>
 #include <pwd.h>

--- a/src/s3fs_util.cpp
+++ b/src/s3fs_util.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <unistd.h>
 #include <cerrno>
 #include <grp.h>

--- a/src/s3fs_xml.h
+++ b/src/s3fs_xml.h
@@ -33,9 +33,9 @@
 
 // S3 responses never use DTDs — block external entity loading.
 #ifdef XML_PARSE_NO_XXE
-static constexpr int S3FS_XML_PARSE_FLAGS = XML_PARSE_NO_XXE;
+inline constexpr int S3FS_XML_PARSE_FLAGS = XML_PARSE_NO_XXE;
 #else
-static constexpr int S3FS_XML_PARSE_FLAGS = XML_PARSE_NONET;
+inline constexpr int S3FS_XML_PARSE_FLAGS = XML_PARSE_NONET;
 #endif
 
 class S3ObjList;

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <algorithm>
+#include <array>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -34,6 +35,8 @@
 
 #include "s3fs_logger.h"
 #include "string_util.h"
+
+using namespace std::string_view_literals;
 
 //-------------------------------------------------------------------
 // Functions
@@ -679,16 +682,15 @@ const char* mask_sensitive_string_with_flag(const char* sensitive, bool nomask)
 
 std::string mask_sensitive_header(const char* pheader, size_t length)
 {
-    static const char* SensitiveHeaders[] = {
-        "authorization:",                                   // do not change this position(see. isAuthHeader)
-        "x-amz-security-token:",
-        "x-amz-credential:",
-        "x-amz-signature:",
-        "x-amz-server-side-encryption-customer-key-md5:",
-        "x-amz-server-side-encryption-aws-kms-key-id:",
-        "x-amz-copy-source-server-side-encryption-customer-key:",
-        "x-amz-copy-source-server-side-encryption-customer-key-md5:",
-        nullptr
+    static constexpr std::array SensitiveHeaders = {
+        "authorization:"sv,                                 // do not change this position(see. isAuthHeader)
+        "x-amz-security-token:"sv,
+        "x-amz-credential:"sv,
+        "x-amz-signature:"sv,
+        "x-amz-server-side-encryption-customer-key-md5:"sv,
+        "x-amz-server-side-encryption-aws-kms-key-id:"sv,
+        "x-amz-copy-source-server-side-encryption-customer-key:"sv,
+        "x-amz-copy-source-server-side-encryption-customer-key-md5:"sv
     };
 
     if(!pheader || length == 0){
@@ -697,11 +699,8 @@ std::string mask_sensitive_header(const char* pheader, size_t length)
     std::string strHeader(pheader, length);
 
     bool isAuthHeader = true;
-    for(const auto* one_sensitive: SensitiveHeaders){
-        if(one_sensitive == nullptr){
-            break;
-        }
-        if(0 == strncasecmp(strHeader.c_str(), one_sensitive, strlen(one_sensitive))){
+    for(const auto& one_sensitive: SensitiveHeaders){
+        if(CaseInsensitiveStringView(strHeader).is_prefix(one_sensitive)){
             if(isAuthHeader){
                 // mask the element in Authorization header
                 static const std::regex aws4_check(R"(\s*AWS4-HMAC-SHA256\s+)", std::regex::icase);
@@ -717,11 +716,11 @@ std::string mask_sensitive_header(const char* pheader, size_t length)
                     strHeader = std::regex_replace(strHeader, std::regex(R"((\s*AWS\s+)(.+))", std::regex::icase), "$1[SENSITIVE]");
                 }else{
                     // wrong format
-                    strHeader.resize(strlen(one_sensitive));
+                    strHeader.resize(one_sensitive.size());
                     strHeader += " [SENSITIVE(wrong format)]";
                 }
             }else{
-                strHeader.resize(strlen(one_sensitive));
+                strHeader.resize(one_sensitive.size());
                 strHeader += " [SENSITIVE]";
             }
             break;

--- a/src/string_util.cpp
+++ b/src/string_util.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <algorithm>
+#include <array>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -679,7 +680,7 @@ const char* mask_sensitive_string_with_flag(const char* sensitive, bool nomask)
 
 std::string mask_sensitive_header(const char* pheader, size_t length)
 {
-    static const char* SensitiveHeaders[] = {
+    static constexpr std::array<std::string_view, 8> SensitiveHeaders = {
         "authorization:",                                   // do not change this position(see. isAuthHeader)
         "x-amz-security-token:",
         "x-amz-credential:",
@@ -687,8 +688,7 @@ std::string mask_sensitive_header(const char* pheader, size_t length)
         "x-amz-server-side-encryption-customer-key-md5:",
         "x-amz-server-side-encryption-aws-kms-key-id:",
         "x-amz-copy-source-server-side-encryption-customer-key:",
-        "x-amz-copy-source-server-side-encryption-customer-key-md5:",
-        nullptr
+        "x-amz-copy-source-server-side-encryption-customer-key-md5:"
     };
 
     if(!pheader || length == 0){
@@ -697,11 +697,8 @@ std::string mask_sensitive_header(const char* pheader, size_t length)
     std::string strHeader(pheader, length);
 
     bool isAuthHeader = true;
-    for(const auto* one_sensitive: SensitiveHeaders){
-        if(one_sensitive == nullptr){
-            break;
-        }
-        if(0 == strncasecmp(strHeader.c_str(), one_sensitive, strlen(one_sensitive))){
+    for(const auto& one_sensitive: SensitiveHeaders){
+        if(CaseInsensitiveStringView(strHeader).is_prefix(one_sensitive)){
             if(isAuthHeader){
                 // mask the element in Authorization header
                 static const std::regex aws4_check(R"(\s*AWS4-HMAC-SHA256\s+)", std::regex::icase);
@@ -717,11 +714,11 @@ std::string mask_sensitive_header(const char* pheader, size_t length)
                     strHeader = std::regex_replace(strHeader, std::regex(R"((\s*AWS\s+)(.+))", std::regex::icase), "$1[SENSITIVE]");
                 }else{
                     // wrong format
-                    strHeader.resize(strlen(one_sensitive));
+                    strHeader.resize(one_sensitive.size());
                     strHeader += " [SENSITIVE(wrong format)]";
                 }
             }else{
-                strHeader.resize(strlen(one_sensitive));
+                strHeader.resize(one_sensitive.size());
                 strHeader += " [SENSITIVE]";
             }
             break;

--- a/src/string_util.h
+++ b/src/string_util.h
@@ -50,8 +50,8 @@ public:
 private:
     std::string_view str;
 };
-static constexpr bool is_prefix(std::string_view str, std::string_view prefix) { return str.substr(0, prefix.size()) == prefix; }
-static constexpr const char* SAFESTRPTR(const char *strptr) { return strptr ? strptr : ""; }
+constexpr bool is_prefix(std::string_view str, std::string_view prefix) { return str.substr(0, prefix.size()) == prefix; }
+constexpr const char* SAFESTRPTR(const char *strptr) { return strptr ? strptr : ""; }
 
 //-------------------------------------------------------------------
 // Macros(WTF8)

--- a/src/test_util.h
+++ b/src/test_util.h
@@ -23,6 +23,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <string>
 

--- a/src/types.h
+++ b/src/types.h
@@ -22,8 +22,9 @@
 #define S3FS_TYPES_H_
 
 #include <cstdint>
-#include <cstring>
+#include <strings.h>
 #include <string>
+#include <string_view>
 #include <map>
 #include <list>
 #include <utility>
@@ -91,23 +92,23 @@ constexpr const char* str(acl_t value)
     abort();
 }
 
-inline acl_t to_acl(const char *acl)
+constexpr acl_t to_acl(std::string_view acl)
 {
-    if(0 == strcmp(acl, "private")){
+    if(acl == "private"){
         return acl_t::PRIVATE;
-    }else if(0 == strcmp(acl, "public-read")){
+    }else if(acl == "public-read"){
         return acl_t::PUBLIC_READ;
-    }else if(0 == strcmp(acl, "public-read-write")){
+    }else if(acl == "public-read-write"){
         return acl_t::PUBLIC_READ_WRITE;
-    }else if(0 == strcmp(acl, "aws-exec-read")){
+    }else if(acl == "aws-exec-read"){
         return acl_t::AWS_EXEC_READ;
-    }else if(0 == strcmp(acl, "authenticated-read")){
+    }else if(acl == "authenticated-read"){
         return acl_t::AUTHENTICATED_READ;
-    }else if(0 == strcmp(acl, "bucket-owner-read")){
+    }else if(acl == "bucket-owner-read"){
         return acl_t::BUCKET_OWNER_READ;
-    }else if(0 == strcmp(acl, "bucket-owner-full-control")){
+    }else if(acl == "bucket-owner-full-control"){
         return acl_t::BUCKET_OWNER_FULL_CONTROL;
-    }else if(0 == strcmp(acl, "log-delivery-write")){
+    }else if(acl == "log-delivery-write"){
         return acl_t::LOG_DELIVERY_WRITE;
     }else{
         return acl_t::UNKNOWN;


### PR DESCRIPTION
compare_timespec(timespec, timespec) was declared constexpr in filetimes.h but defined in filetimes.cpp.  constexpr implies inline, so any translation unit other than filetimes.cpp that called this overload would fail to link.  It only linked because the sole external caller in fdcache_entity.cpp resolves to the non-constexpr (struct stat&, stat_time_type, ...) overload instead.  Move the definition into the header.  This also allows removing CompareStatCacheTime from cache_node.cpp, which was a byte-for-byte duplicate.

Also make a few pure leaf functions constexpr:

- to_acl now takes std::string_view and compares with ==, replacing an eight-way strcmp chain, and matches the already-constexpr str(acl_t) beside it.
- getCurlDebugHead moves to the header as a switch returning literals directly, dropping five pointless local variables.
- mask_sensitive_header's SensitiveHeaders becomes a constexpr std::array<std::string_view>, dropping the nullptr sentinel, the sentinel break, and three strlen calls.  The authorization: entry must remain first; see isAuthHeader.

Finally, switch namespace-scope constexpr in headers from static to inline.  static gives internal linkage, so each translation unit got its own copy at a distinct address.