### PR TITLE
Move logging macro bodies into out-of-line functions

### DIFF
--- a/src/s3fs_logger.cpp
+++ b/src/s3fs_logger.cpp
@@ -284,16 +284,33 @@ void S3fsLog::Printf(FILE* fp, const char* fmt, ...)
     }
 }
 
+// Format a printf-style message into a heap buffer.
+//
+// [NOTE]
+// The caller owns the va_list (va_start/va_end); this helper only copies
+// it for the sizing pass and consumes the original for the format pass.
+//
+static std::unique_ptr<char[]> s3fs_vformat(const char* fmt, va_list va)
+{
+    va_list va2;
+    va_copy(va2, va);
+    int len = vsnprintf(nullptr, 0, fmt, va2);
+    va_end(va2);
+    len = std::max(len, 0);
+
+    auto message = std::make_unique<char[]>(static_cast<size_t>(len) + 1);
+    vsnprintf(message.get(), static_cast<size_t>(len) + 1, fmt, va);
+    return message;
+}
+
 void s3fs_low_logprn(S3fsLog::Level level, const char* file, const char *func, int line, const char *fmt, ...)
 {
+    // [NOTE]
+    // The level guard lives in the S3FS_LOW_LOGPRN macro so the log
+    // arguments are not evaluated when the level is disabled.
     va_list va;
     va_start(va, fmt);
-    size_t len = vsnprintf(nullptr, 0, fmt, va) + 1;
-    va_end(va);
-
-    auto message = std::make_unique<char[]>(len);
-    va_start(va, fmt);
-    vsnprintf(message.get(), len, fmt, va);
+    auto message = s3fs_vformat(fmt, va);
     va_end(va);
 
     if(foreground || S3fsLog::IsSetLogFile()){
@@ -306,20 +323,87 @@ void s3fs_low_logprn(S3fsLog::Level level, const char* file, const char *func, i
 
 void s3fs_low_logprn2(S3fsLog::Level level, int nest, const char* file, const char *func, int line, const char *fmt, ...)
 {
+    // [NOTE]
+    // The level guard lives in the S3FS_LOW_LOGPRN2 macro so the log
+    // arguments are not evaluated when the level is disabled.
     va_list va;
     va_start(va, fmt);
-    size_t len = vsnprintf(nullptr, 0, fmt, va) + 1;
-    va_end(va);
-
-    auto message = std::make_unique<char[]>(len);
-    va_start(va, fmt);
-    vsnprintf(message.get(), len, fmt, va);
+    auto message = s3fs_vformat(fmt, va);
     va_end(va);
 
     if(foreground || S3fsLog::IsSetLogFile()){
         S3fsLog::Printf(S3fsLog::GetOutputLogFile(), "%s%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(level), S3fsLog::GetS3fsLogNest(nest), file, func, line, message.get());
     }else{
         syslog(S3fsLog::GetSyslogLevel(level), "%s%s%s", instance_name.c_str(), S3fsLog::GetS3fsLogNest(nest), message.get());
+    }
+}
+
+void s3fs_low_curldbg(const char* fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+    auto message = s3fs_vformat(fmt, va);
+    va_end(va);
+
+    if(foreground || S3fsLog::IsSetLogFile()){
+        S3fsLog::Printf(S3fsLog::GetOutputLogFile(), "%s[CURL DBG] %s\n", S3fsLog::GetCurrentTime().c_str(), message.get());
+    }else{
+        syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::CRIT), "%s%s", instance_name.c_str(), message.get());
+    }
+}
+
+void s3fs_low_logprn_exit(const char* fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+    auto message = s3fs_vformat(fmt, va);
+    va_end(va);
+
+    S3fsLog::Printf(S3fsLog::GetErrorLogFile(), "s3fs: %s\n", message.get());
+    if(!(foreground || S3fsLog::IsSetLogFile())){
+        syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::CRIT), "%ss3fs: %s", instance_name.c_str(), message.get());
+    }
+}
+
+void s3fs_low_init_info(const char* file, const char *func, int line, const char *fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+    auto message = s3fs_vformat(fmt, va);
+    va_end(va);
+
+    if(foreground || S3fsLog::IsSetLogFile()){
+        S3fsLog::Printf(S3fsLog::GetOutputLogFile(), "%s%s%s%s:%s(%d): %s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(S3fsLog::Level::INFO), S3fsLog::GetS3fsLogNest(0), file, func, line, message.get());
+    }else{
+        syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::INFO), "%s%s%s", instance_name.c_str(), S3fsLog::GetS3fsLogNest(0), message.get());
+    }
+}
+
+void s3fs_low_launch_info(const char* fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+    auto message = s3fs_vformat(fmt, va);
+    va_end(va);
+
+    if(foreground || S3fsLog::IsSetLogFile()){
+        S3fsLog::Printf(S3fsLog::GetOutputLogFile(), "%s%s%s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(S3fsLog::Level::INFO), message.get());
+    }else{
+        syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::INFO), "%s%s", instance_name.c_str(), message.get());
+    }
+}
+
+void s3fs_low_cache(FILE* fp, const char* fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+    auto message = s3fs_vformat(fmt, va);
+    va_end(va);
+
+    if(foreground || S3fsLog::IsSetLogFile()){
+        S3fsLog::Printf(fp, "%s\n", message.get());
+    }else{
+        syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::INFO), "%s: %s", instance_name.c_str(), message.get());
     }
 }
 

--- a/src/s3fs_logger.h
+++ b/src/s3fs_logger.h
@@ -142,6 +142,16 @@ class S3fsLog
 //-------------------------------------------------------------------
 // Debug macros
 //-------------------------------------------------------------------
+// [NOTE]
+// All formatting, branching and output logic lives in the functions
+// below, so it is emitted once instead of being inlined at every call
+// site. The level-guarded macros keep a cheap inline IsS3fsLogLevel()
+// check at the call site so the log arguments are not evaluated when
+// the level is disabled; the out-of-line function is called only when
+// the check passes. The macros also capture __FILE__/__func__/__LINE__,
+// which a plain function cannot obtain on its own before C++20's
+// std::source_location.
+//
 void s3fs_low_logprn(S3fsLog::Level level, const char* file, const char *func, int line, const char *fmt, ...) __attribute__ ((format (printf, 5, 6)));
 #define S3FS_LOW_LOGPRN(level, fmt, ...) \
         do{ \
@@ -158,58 +168,21 @@ void s3fs_low_logprn2(S3fsLog::Level level, int nest, const char* file, const ch
             } \
         }while(0)
 
-#define S3FS_LOW_CURLDBG(fmt, ...) \
-        do{ \
-            if(foreground || S3fsLog::IsSetLogFile()){ \
-                S3fsLog::Printf(S3fsLog::GetOutputLogFile(), "%s[CURL DBG] " fmt "%s\n", S3fsLog::GetCurrentTime().c_str(), __VA_ARGS__); \
-            }else{ \
-                syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::CRIT), "%s" fmt "%s", instance_name.c_str(), __VA_ARGS__); \
-            } \
-        }while(0)
+void s3fs_low_curldbg(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
-#define S3FS_LOW_LOGPRN_EXIT(fmt, ...) \
-        do{ \
-            if(foreground || S3fsLog::IsSetLogFile()){ \
-                S3fsLog::Printf(S3fsLog::GetErrorLogFile(), "s3fs: " fmt "%s\n", __VA_ARGS__); \
-            }else{ \
-                S3fsLog::Printf(S3fsLog::GetErrorLogFile(), "s3fs: " fmt "%s\n", __VA_ARGS__); \
-                syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::CRIT), "%ss3fs: " fmt "%s", instance_name.c_str(), __VA_ARGS__); \
-            } \
-        }while(0)
+void s3fs_low_logprn_exit(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
-// Special macro for init message
+// Special function for init message
+void s3fs_low_init_info(const char* file, const char *func, int line, const char *fmt, ...) __attribute__ ((format (printf, 4, 5)));
 #define S3FS_PRN_INIT_INFO(fmt, ...) \
-        do{ \
-            if(foreground || S3fsLog::IsSetLogFile()){ \
-                S3fsLog::Printf(S3fsLog::GetOutputLogFile(), "%s%s%s%s:%s(%d): " fmt "%s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(S3fsLog::Level::INFO), S3fsLog::GetS3fsLogNest(0), __FILE__, __func__, __LINE__, __VA_ARGS__, ""); \
-            }else{ \
-                syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::INFO), "%s%s" fmt "%s", instance_name.c_str(), S3fsLog::GetS3fsLogNest(0), __VA_ARGS__, ""); \
-            } \
-        }while(0)
+        s3fs_low_init_info(__FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
 
-#define S3FS_PRN_LAUNCH_INFO(fmt, ...) \
-        do{ \
-            if(foreground || S3fsLog::IsSetLogFile()){ \
-                S3fsLog::Printf(S3fsLog::GetOutputLogFile(), "%s%s" fmt "%s\n", S3fsLog::GetCurrentTime().c_str(), S3fsLog::GetLevelString(S3fsLog::Level::INFO), __VA_ARGS__, ""); \
-            }else{ \
-                syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::INFO), "%s" fmt "%s", instance_name.c_str(), __VA_ARGS__, ""); \
-            } \
-        }while(0)
+void s3fs_low_launch_info(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
-// Special macro for checking cache files
-#define S3FS_LOW_CACHE(fp, fmt, ...) \
-        do{ \
-            if(foreground || S3fsLog::IsSetLogFile()){ \
-                S3fsLog::Printf(fp, fmt "%s\n", __VA_ARGS__); \
-            }else{ \
-                syslog(S3fsLog::GetSyslogLevel(S3fsLog::Level::INFO), "%s: " fmt "%s", instance_name.c_str(), __VA_ARGS__); \
-            } \
-        }while(0)
+// Special function for checking cache files
+void s3fs_low_cache(FILE* fp, const char* fmt, ...) __attribute__ ((format (printf, 2, 3)));
 
-// [NOTE]
-// small trick for VA_ARGS
-//
-#define S3FS_PRN_EXIT(fmt, ...)   S3FS_LOW_LOGPRN_EXIT(fmt, ##__VA_ARGS__, "")
+#define S3FS_PRN_EXIT(fmt, ...)   s3fs_low_logprn_exit(fmt, ##__VA_ARGS__)
 #define S3FS_PRN_CRIT(fmt, ...)   S3FS_LOW_LOGPRN(S3fsLog::Level::CRIT, fmt, ##__VA_ARGS__)
 #define S3FS_PRN_ERR(fmt, ...)    S3FS_LOW_LOGPRN(S3fsLog::Level::ERR,  fmt, ##__VA_ARGS__)
 #define S3FS_PRN_WARN(fmt, ...)   S3FS_LOW_LOGPRN(S3fsLog::Level::WARN, fmt, ##__VA_ARGS__)
@@ -218,8 +191,9 @@ void s3fs_low_logprn2(S3fsLog::Level level, int nest, const char* file, const ch
 #define S3FS_PRN_INFO1(fmt, ...)  S3FS_LOW_LOGPRN2(S3fsLog::Level::INFO, 1, fmt, ##__VA_ARGS__)
 #define S3FS_PRN_INFO2(fmt, ...)  S3FS_LOW_LOGPRN2(S3fsLog::Level::INFO, 2, fmt, ##__VA_ARGS__)
 #define S3FS_PRN_INFO3(fmt, ...)  S3FS_LOW_LOGPRN2(S3fsLog::Level::INFO, 3, fmt, ##__VA_ARGS__)
-#define S3FS_PRN_CURL(fmt, ...)   S3FS_LOW_CURLDBG(fmt, ##__VA_ARGS__, "")
-#define S3FS_PRN_CACHE(fp, ...)   S3FS_LOW_CACHE(fp, ##__VA_ARGS__, "")
+#define S3FS_PRN_CURL(fmt, ...)   s3fs_low_curldbg(fmt, ##__VA_ARGS__)
+#define S3FS_PRN_CACHE(fp, ...)   s3fs_low_cache(fp, ##__VA_ARGS__)
+#define S3FS_PRN_LAUNCH_INFO(fmt, ...)  s3fs_low_launch_info(fmt, ##__VA_ARGS__)
 
 // Macros to print log with fuse context
 #define PRINT_FUSE_CTX(level, indent, fmt, ...) do {                    \


### PR DESCRIPTION
The logging macros inlined a level-check guard and, for the exit/curl/ cache/init/launch variants, an entire foreground?Printf:syslog branch at every one of ~1100 call sites. Move that formatting and branching into out-of-line functions so the code is emitted once.

To avoid evaluating log arguments when a level is disabled, the level-guarded macros (S3FS_LOW_LOGPRN/LOGPRN2) keep a cheap call-site check; IsS3fsLogLevel() is now inline so that check compiles to a few instructions rather than an out-of-line call. The remaining macros exist only to capture __FILE__/__func__/__LINE__, which a function cannot obtain on its own before C++20's std::source_location.

Behavior is unchanged. At -O this shrinks .text by ~22 KB and code+rodata by ~31.5 KB (~3.3%).