### PR TITLE
Remove stdbuf from the integration tests

### DIFF
--- a/test/integration-test-common.sh
+++ b/test/integration-test-common.sh
@@ -120,16 +120,6 @@ if [ ! -d "${TEST_BUCKET_MOUNT_POINT_1}" ]; then
     mkdir -p "${TEST_BUCKET_MOUNT_POINT_1}"
 fi
 
-# [NOTE]
-# For the Github Actions macos-14 Runner,
-# Set variables for when stdbuf is used and when it is not.
-#
-if [ -n "${STDBUF_BIN}" ]; then
-    STDBUF_COMMAND_LINE=("${STDBUF_BIN}" -oL -eL)
-else
-    STDBUF_COMMAND_LINE=()
-fi
-
 # This function execute the function parameters $1 times
 # before giving up, with 0.1 second delays.
 function retry {
@@ -193,7 +183,7 @@ function start_s3proxy {
             S3PROXY_CACERT_FILE=""
         fi
 
-        "${STDBUF_COMMAND_LINE[@]}" java -jar "${S3PROXY_BINARY}" --properties "${S3PROXY_CONFIG}" &
+        java -jar "${S3PROXY_BINARY}" --properties "${S3PROXY_CONFIG}" &
         S3PROXY_PID=$!
 
         # wait for S3Proxy to start
@@ -209,7 +199,7 @@ function start_s3proxy {
             chmod +x "${CHAOS_HTTP_PROXY_BINARY}"
         fi
 
-        "${STDBUF_COMMAND_LINE[@]}" java -jar "${CHAOS_HTTP_PROXY_BINARY}" --properties chaos-http-proxy.conf &
+        java -jar "${CHAOS_HTTP_PROXY_BINARY}" --properties chaos-http-proxy.conf &
         CHAOS_HTTP_PROXY_PID=$!
 
         # wait for Chaos HTTP Proxy to start
@@ -337,7 +327,6 @@ function start_s3fs {
     (
         set -x
         CURL_CA_BUNDLE="${S3PROXY_CACERT_FILE}" \
-        "${STDBUF_COMMAND_LINE[@]}" \
             ${VALGRIND_EXEC} \
             ${S3FS} \
             ${TEST_BUCKET_1} \
@@ -361,7 +350,7 @@ function start_s3fs {
             -f \
             "${@}" &
         echo $! >&3
-    ) 3>pid | "${STDBUF_COMMAND_LINE[@]}" awk "{print \"s3fs: \" \$0}" &
+    ) 3>pid | awk '{print "s3fs: " $0; fflush()}' &
     # Poll for the pid file rather than sleeping a fixed second.
     for _ in $(seq 50); do
         [ -s pid ] && break

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -51,31 +51,18 @@ BIG_FILE_LENGTH=$((BIG_FILE_BLOCK_SIZE * BIG_FILE_COUNT))
 export LC_ALL=en_US.UTF-8
 
 # [NOTE]
-# stdbuf, truncate and sed installed on macos do not work as
+# truncate and sed installed on macos do not work as
 # expected(not compatible with Linux).
 # Therefore, macos installs a brew package such as coreutils
-# and uses gnu commands(gstdbuf, gtruncate, gsed).
+# and uses gnu commands(gtruncate, gsed).
 # Set your PATH appropriately so that you can find these commands.
 #
 if [ "$(uname)" = "Darwin" ]; then
     export STAT_BIN="gstat"
-    # [NOTE][TODO]
-    # In macos-14(and maybe later), currently coreutils' gstdbuf doesn't
-    # work with the Github Actions Runner.
-    # This is because libstdbuf.so is arm64, when arm64e is required.
-    # To resolve this case, we'll avoid making calls to stdbuf. This can
-    # result in mixed log output, but there is currently no workaround.
-    #
-    if lipo -archs /opt/homebrew/Cellar/coreutils/9.8/libexec/coreutils/libstdbuf.so 2>/dev/null | grep -q 'arm64e'; then
-        export STDBUF_BIN="gstdbuf"
-    else
-        export STDBUF_BIN=""
-    fi
     export TRUNCATE_BIN="gtruncate"
     export SHA256SUM_BIN="gsha256sum"
 else
     export STAT_BIN="stat"
-    export STDBUF_BIN="stdbuf"
     export TRUNCATE_BIN="truncate"
     export SHA256SUM_BIN="sha256sum"
 fi


### PR DESCRIPTION
Make the awk filter that prefixes s3fs log output flush each line via fflush() instead. stdbuf only affects libc stdio buffering via LD_PRELOAD, so two of its three uses never had an effect: s3fs emits each log line with raw write(2) (S3fsLog::Printf) and the JVM writes System.out through FileOutputStream. The only command that actually buffered was awk itself, which fflush() addresses directly. fflush() is supported by gawk, mawk, busybox awk, and BSD awk, and was standardized in POSIX.1-2024.

This also removes the macos-14 workaround for coreutils' gstdbuf lacking an arm64e slice.