### PR TITLE
Remove GNU sed from the Alpine CI packages

### DIFF
--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -374,7 +374,6 @@ elif [ "${CONTAINER_FULLNAME}" = "alpine:3.24" ]; then
         openssl
         perl-test-harness-utils
         procps
-        sed
     )
 
 else

--- a/.github/workflows/linux-ci-helper.sh
+++ b/.github/workflows/linux-ci-helper.sh
@@ -377,7 +377,6 @@ elif [ "${CONTAINER_FULLNAME}" = "alpine:3.24" ]; then
         openssl
         perl-test-harness-utils
         procps
-        sed
     )
 
 else

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -51,10 +51,10 @@ BIG_FILE_LENGTH=$((BIG_FILE_BLOCK_SIZE * BIG_FILE_COUNT))
 export LC_ALL=en_US.UTF-8
 
 # [NOTE]
-# stdbuf, truncate and sed installed on macos do not work as
+# stdbuf and truncate installed on macos do not work as
 # expected(not compatible with Linux).
 # Therefore, macos installs a brew package such as coreutils
-# and uses gnu commands(gstdbuf, gtruncate, gsed).
+# and uses gnu commands(gstdbuf, gtruncate).
 # Set your PATH appropriately so that you can find these commands.
 #
 if [ "$(uname)" = "Darwin" ]; then

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -51,10 +51,10 @@ BIG_FILE_LENGTH=$((BIG_FILE_BLOCK_SIZE * BIG_FILE_COUNT))
 export LC_ALL=en_US.UTF-8
 
 # [NOTE]
-# truncate and sed installed on macos do not work as
+# truncate installed on macos does not work as
 # expected(not compatible with Linux).
 # Therefore, macos installs a brew package such as coreutils
-# and uses gnu commands(gtruncate, gsed).
+# and uses gnu commands(gtruncate).
 # Set your PATH appropriately so that you can find these commands.
 #
 if [ "$(uname)" = "Darwin" ]; then


### PR DESCRIPTION
Nothing needs it: busybox sed handles every sed invocation in the build and the test suite, including the case-insensitive s///i flag used to parse Content-Type headers.  Verified by building s3fs and running the unit tests in an alpine:3.24 container with only busybox sed installed.  Also drop the stale claim that the macos job uses gsed; brew never installed gnu-sed and nothing references it.