### PR TITLE
Restrict the GITHUB_TOKEN to read-only permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+# [NOTE]
+# The jobs only need to read the repository contents, so restrict the
+# GITHUB_TOKEN for all jobs to read-only access.
+#
+permissions:
+  contents: read
+
 #
 # Jobs
 #


### PR DESCRIPTION
No job writes to the repository or the GitHub API.  The repository default is already read-only; declaring it in the workflow makes the least privilege explicit and independent of repository settings.