### PR TITLE
Discard HTTP error response bodies when downloading an object

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -530,13 +530,24 @@ size_t S3fsCurl::DownloadWriteCallback(void* ptr, size_t size, size_t nmemb, voi
     if(1 > (size * nmemb)){
         return 0;
     }
-    if(-1 == pCurl->partdata.fd || 0 >= pCurl->partdata.size){
-        return 0;
-    }
 
     // Buffer initial bytes in case it is an XML error response.
     if(pCurl->bodydata.size() < GET_OBJECT_RESPONSE_LIMIT){
         pCurl->bodydata.append(static_cast<const char*>(ptr), std::min(size * nmemb, GET_OBJECT_RESPONSE_LIMIT - pCurl->bodydata.size()));
+    }
+
+    // An error response body is not object data and is usually longer than the
+    // requested range.  Writing it to the cache file would both corrupt the file
+    // and, since a short return makes libcurl fail with CURLE_WRITE_ERROR, hide
+    // the HTTP status behind a write error that RequestPerform then retries.
+    // Discard it here so the caller sees the response code, e.g. 404 -> ENOENT.
+    long responseCode = 0;
+    if(CURLE_OK == curl_easy_getinfo(pCurl->hCurl, CURLINFO_RESPONSE_CODE, &responseCode) && 300 <= responseCode){
+        return size * nmemb;
+    }
+
+    if(-1 == pCurl->partdata.fd || 0 >= pCurl->partdata.size){
+        return 0;
     }
 
     // write size


### PR DESCRIPTION
DownloadWriteCallback writes at most partdata.size bytes and returns that count.  An error response body is not object data and is usually longer than the requested range, so the callback returns short and libcurl fails the transfer with CURLE_WRITE_ERROR.  RequestPerform treats that as a transient failure and retries it, sleeping 2 seconds each time, then gives up with -EIO.  The HTTP status never reaches the code which would have mapped it, so reading a file whose object has been removed takes 6 seconds per GET and reports EIO instead of ENOENT.

Discard the body in the callback when the response code indicates an error.  The transfer then completes normally and the caller sees the status, e.g. 404 -> ENOENT.  This also stops the error body from being written into the cache file when the requested range is larger than the body, and does the same for the redirect bodies that arrive because CURLOPT_FOLLOWLOCATION is enabled.

Reading a file whose object was deleted behind s3fs's back drops from 12045ms to 8ms.  test_concurrent_directory_updates hits this whenever a concurrent rm removes a file another process has open: 20 iterations of that test drop from 38.3s to 2.1s.