### PR TITLE
Update outdated fuse-t timestamp granularity assumptions in tests

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -558,6 +558,10 @@ function test_external_modification {
     # This extends the expiration date of the target file(1 sec by
     # stat_cache_interval_expire option).
     # Therefore, on MacOS, you need to add an additional 1 sec.
+    # (Verified on macos/fuse-t: with use_cache and only a 1 second
+    # wait, about 1 in 3 runs still read stale data, while 2 seconds
+    # is reliable.  This is a caching effect, not NFS timestamp
+    # granularity.)
     #
     sleep 1
     wait_ostype 1 "Darwin"
@@ -1080,11 +1084,6 @@ function test_extended_attributes {
     # over write value
     set_xattr key1 value1 "${TEST_TEXT_FILE}"
     get_xattr key1 "${TEST_TEXT_FILE}" | grep -q '^value1$'
-
-    # [NOTE]
-    # macOS still caches extended attributes even when told not to.
-    # Thus we need to wait one second here.
-    wait_ostype 1 "Darwin"
 
     # append value
     set_xattr key2 value2 "${TEST_TEXT_FILE}"

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -437,12 +437,12 @@ function s3fs_args() {
 # $1:    sleep seconds
 # $2:    OS type(ex. 'Darwin', unset(means all os type))
 #
-# [NOTE] macos fuse-t
-# macos fuse-t mounts over NFS, and the mtime/ctime/atime attribute
-# values are in seconds(not m/u/n-sec).
-# Therefore, unlike tests on other OSs, we have to wait at least 1
-# second.
-# This function is called primarily for this purpose.
+# [NOTE]
+# Sleeps to let timing-sensitive state settle, optionally only on
+# one OS type.
+# This previously waited out fuse-t's NFS timestamp granularity on
+# macos, but fuse-t(1.2.7 and later) passes nanosecond timestamps
+# through, so timestamp resolution is no longer a reason to wait.
 #
 function wait_ostype() {
     if [ -z "$2" ] || uname | grep -q "$2"; then


### PR DESCRIPTION
fuse-t 1.2.7 passes nanosecond timestamps through its NFS bridge, so the wait_ostype comment claiming second-granularity attribute values no longer holds; verified by round-tripping a nanosecond mtime through a live mount.

Remove the Darwin wait in test_extended_attributes: the xattr sequence passed 62 consecutive runs without it.

Keep the Darwin wait in test_external_modification: with use_cache and only the base 1 second wait, about 1 in 3 runs still read stale data because post-release getattrs extend stat_cache_interval_expire; 2 seconds was reliable.  Document that this is a caching effect, not timestamp granularity.