### PR TITLE
Send SSE-C copy source headers on multipart copy parts

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -3470,7 +3470,7 @@ int S3fsCurl::PreMultipartUploadRequest(const char* tpath, const headers_t& meta
     return 0;
 }
 
-int S3fsCurl::MultipartUploadPartSetup(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy)
+int S3fsCurl::MultipartUploadPartSetup(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy, const std::string& srcssekeymd5)
 {
     // duplicate upload_fd
     if(!tpath || start < 0 || size <= 0 || !petag || (!is_copy && -1 == upload_fd)){
@@ -3506,6 +3506,12 @@ int S3fsCurl::MultipartUploadPartSetup(const char* tpath, int upload_fd, off_t s
         std::ostringstream strrange;
         strrange << "bytes=" << start << "-" << (start + size - 1);
         meta["x-amz-copy-source-range"] = strrange.str();
+
+        // MultipartUploadCopyPartSetup maps this to the copy source
+        // SSE-C headers, without which the source cannot be read.
+        if(!srcssekeymd5.empty()){
+            meta["x-amz-server-side-encryption-customer-key-md5"] = srcssekeymd5;
+        }
 
         partdata.set_etag(petag);                               // [NOTE] be careful, the value is set directly
 
@@ -3942,7 +3948,7 @@ int S3fsCurl::MultipartPutHeadRequest(const std::string& from, const std::string
     return 0;
 }
 
-int S3fsCurl::MultipartUploadPartRequest(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy)
+int S3fsCurl::MultipartUploadPartRequest(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy, const std::string& srcssekeymd5)
 {
     S3FS_PRN_INFO3("Multipart Upload Part [tpath=%s][upload_fd=%d][start=%lld][size=%lld][part_num=%d][upload_id=%s][is_copy=%s]", SAFESTRPTR(tpath), upload_fd, static_cast<long long int>(start), static_cast<long long int>(size), part_num, upload_id.c_str(), (is_copy ? "true" : "false"));
 
@@ -3950,7 +3956,7 @@ int S3fsCurl::MultipartUploadPartRequest(const char* tpath, int upload_fd, off_t
     // Setup
     //
     int   result;
-    if(0 != (result = MultipartUploadPartSetup(tpath, upload_fd, start, size, part_num, upload_id, petag, is_copy))){
+    if(0 != (result = MultipartUploadPartSetup(tpath, upload_fd, start, size, part_num, upload_id, petag, is_copy, srcssekeymd5))){
         S3FS_PRN_ERR("Failed pre-setup for Multipart Upload Part [tpath=%s][upload_fd=%d][start=%lld][size=%lld][part_num=%d][upload_id=%s][is_copy=%s]", SAFESTRPTR(tpath), upload_fd, static_cast<long long int>(start), static_cast<long long int>(size), part_num, upload_id.c_str(), (is_copy ? "true" : "false"));
         return result;
     }

--- a/src/curl.h
+++ b/src/curl.h
@@ -340,13 +340,13 @@ class S3fsCurl
         [[nodiscard]] int CheckBucket(const char* check_path, bool compat_dir, bool force_no_sse);
         [[nodiscard]] int ListBucketRequest(const char* tpath, const char* query);
         [[nodiscard]] int PreMultipartUploadRequest(const char* tpath, const headers_t& meta, std::string& upload_id);
-        [[nodiscard]] int MultipartUploadPartSetup(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy);
+        [[nodiscard]] int MultipartUploadPartSetup(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy, const std::string& srcssekeymd5);
         [[nodiscard]] int MultipartUploadComplete(const char* tpath, const std::string& upload_id, const etaglist_t& parts);
         bool MultipartUploadPartComplete();
         [[nodiscard]] int MultipartListRequest(std::string& body);
         [[nodiscard]] int AbortMultipartUpload(const char* tpath, const std::string& upload_id);
         [[nodiscard]] int MultipartPutHeadRequest(const std::string& from, const std::string& to, int part_number, const std::string& upload_id, const headers_t& meta);
-        [[nodiscard]] int MultipartUploadPartRequest(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy);
+        [[nodiscard]] int MultipartUploadPartRequest(const char* tpath, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy, const std::string& srcssekeymd5);
 
         // methods(variables)
         const std::string& GetPath() const { return path; }

--- a/src/fdcache_entity.cpp
+++ b/src/fdcache_entity.cpp
@@ -1221,7 +1221,7 @@ int FdEntity::NoCacheMultipartUploadRequest(PseudoFdInfo* pseudo_obj, int tgfd, 
 
     // request to thread
     int result;
-    if(0 != (result = await_multipart_upload_part_request(path, tgfd, start, size, petag->part_num, *upload_id, petag, false))){
+    if(0 != (result = await_multipart_upload_part_request(path, tgfd, start, size, petag->part_num, *upload_id, petag, false, ""))){
         S3FS_PRN_ERR("Failed No Cache Multipart Upload Part Request by error(%d) [path=%s][upload_id=%s][fd=%d][start=%lld][size=%lld]", result, path.c_str(), upload_id->c_str(), tgfd, static_cast<long long int>(start), static_cast<long long int>(size));
         return result;
     }
@@ -1942,10 +1942,18 @@ int FdEntity::RowFlushStreamMultipart(PseudoFdInfo* pseudo_obj, const char* tpat
             }
         }
 
+        // The md5 of the SSE-C key that encrypted the source object,
+        // which each copy part presents to read it.
+        std::string srcssekeymd5;
+        auto        ssekeyiter = orgmeta.find("x-amz-server-side-encryption-customer-key-md5");
+        if(orgmeta.cend() != ssekeyiter){
+            srcssekeymd5 = ssekeyiter->second;
+        }
+
         //
         // Upload multipart and copy parts and wait exiting them
         //
-        if(!pseudo_obj->ParallelMultipartUploadAll(strpath.c_str(), to_upload_list, to_copy_list, result)){
+        if(!pseudo_obj->ParallelMultipartUploadAll(strpath.c_str(), to_upload_list, to_copy_list, srcssekeymd5, result)){
             S3FS_PRN_ERR("Failed to upload multipart parts.");
             AbortStreamUpload(pseudo_obj, strpath);     // abort upload and rebuild untreated list
             return -EIO;

--- a/src/fdcache_fdinfo.cpp
+++ b/src/fdcache_fdinfo.cpp
@@ -334,7 +334,7 @@ bool PseudoFdInfo::InsertUploadPart(off_t start, off_t size, int part_num, bool 
     return true;
 }
 
-bool PseudoFdInfo::ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy)
+bool PseudoFdInfo::ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy, const std::string& srcssekeymd5)
 {
     //S3FS_PRN_DBG("[path=%s][mplist(%zu)]", SAFESTRPTR(path), mplist.size());
 
@@ -365,7 +365,7 @@ bool PseudoFdInfo::ParallelMultipartUpload(const char* path, const mp_part_list_
 
         // setup instruction and request on another thread
         int result;
-        if(0 != (result = multipart_upload_part_request(strpath, tmp_upload_fd, iter->start, iter->size, iter->part_num, tmp_upload_id, petag, is_copy, &uploaded_sem, &upload_list_lock, &last_result))){
+        if(0 != (result = multipart_upload_part_request(strpath, tmp_upload_fd, iter->start, iter->size, iter->part_num, tmp_upload_id, petag, is_copy, srcssekeymd5, &uploaded_sem, &upload_list_lock, &last_result))){
             S3FS_PRN_ERR("failed setup instruction for Multipart Upload Part Request by error(%d) [path=%s][start=%lld][size=%lld][part_num=%d][is_copy=%s]", result, strpath.c_str(), static_cast<long long int>(iter->start), static_cast<long long int>(iter->size), iter->part_num, (is_copy ? "true" : "false"));
             return false;
         }
@@ -376,7 +376,7 @@ bool PseudoFdInfo::ParallelMultipartUpload(const char* path, const mp_part_list_
     return true;
 }
 
-bool PseudoFdInfo::ParallelMultipartUploadAll(const char* path, const mp_part_list_t& to_upload_list, const mp_part_list_t& copy_list, int& result)
+bool PseudoFdInfo::ParallelMultipartUploadAll(const char* path, const mp_part_list_t& to_upload_list, const mp_part_list_t& copy_list, const std::string& srcssekeymd5, int& result)
 {
     S3FS_PRN_DBG("[path=%s][to_upload_list(%zu)][copy_list(%zu)]", SAFESTRPTR(path), to_upload_list.size(), copy_list.size());
 
@@ -385,7 +385,7 @@ bool PseudoFdInfo::ParallelMultipartUploadAll(const char* path, const mp_part_li
     if(!OpenUploadFd()){
         return false;
     }
-    if(!ParallelMultipartUpload(path, to_upload_list, false) || !ParallelMultipartUpload(path, copy_list, true)){
+    if(!ParallelMultipartUpload(path, to_upload_list, false, "") || !ParallelMultipartUpload(path, copy_list, true, srcssekeymd5)){
         S3FS_PRN_ERR("Failed setup instruction for uploading(path=%s, to_upload_list=%zu, copy_list=%zu).", SAFESTRPTR(path), to_upload_list.size(), copy_list.size());
         return false;
     }
@@ -521,7 +521,7 @@ ssize_t PseudoFdInfo::UploadBoundaryLastUntreatedArea(const char* path, const he
     //
     // Upload Multipart parts
     //
-    if(!ParallelMultipartUpload(path, to_upload_list, false)){
+    if(!ParallelMultipartUpload(path, to_upload_list, false, "")){
         S3FS_PRN_ERR("Failed to upload multipart parts.");
         return -EIO;
     }

--- a/src/fdcache_fdinfo.h
+++ b/src/fdcache_fdinfo.h
@@ -60,7 +60,7 @@ class PseudoFdInfo
         void RowInitialUploadInfo(const std::string& id, bool is_cancel_mp);
         void IncreaseInstructionCount();
         bool GetUploadInfo(std::string& id, int& fd) const;
-        bool ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy);
+        bool ParallelMultipartUpload(const char* path, const mp_part_list_t& mplist, bool is_copy, const std::string& srcssekeymd5);
         bool InsertUploadPart(off_t start, off_t size, int part_num, bool is_copy, etagpair** ppetag);
         void CancelAllThreads();
         bool ExtractUploadPartsFromUntreatedArea(off_t untreated_start, off_t untreated_size, mp_part_list_t& to_upload_list, filepart_list_t& cancel_upload_list, off_t max_mp_size);
@@ -91,7 +91,7 @@ class PseudoFdInfo
         bool AppendUploadPart(off_t start, off_t size, bool is_copy = false, etagpair** ppetag = nullptr);
         off_t GetNextUploadPos() const;
 
-        bool ParallelMultipartUploadAll(const char* path, const mp_part_list_t& to_upload_list, const mp_part_list_t& copy_list, int& result);
+        bool ParallelMultipartUploadAll(const char* path, const mp_part_list_t& to_upload_list, const mp_part_list_t& copy_list, const std::string& srcssekeymd5, int& result);
         int PreMultipartUploadRequest(const std::string& strpath, const headers_t& meta);
 
         int WaitAllThreadsExit();

--- a/src/s3fs_threadreqs.cpp
+++ b/src/s3fs_threadreqs.cpp
@@ -374,7 +374,7 @@ void* multipart_upload_part_req_threadworker(S3fsCurl& s3fscurl, void* arg)
     // Request
     //
     int result;
-    if(0 != (result = s3fscurl.MultipartUploadPartRequest(pthparam->path.c_str(), pthparam->upload_fd, pthparam->start, pthparam->size, pthparam->part_num, pthparam->upload_id, pthparam->petag, pthparam->is_copy))){
+    if(0 != (result = s3fscurl.MultipartUploadPartRequest(pthparam->path.c_str(), pthparam->upload_fd, pthparam->start, pthparam->size, pthparam->part_num, pthparam->upload_id, pthparam->petag, pthparam->is_copy, pthparam->srcssekeymd5))){
         S3FS_PRN_ERR("Failed Multipart Upload Part Worker with error(%d) [path=%s][upload_id=%s][upload_fd=%d][start=%lld][size=%lld][is_copy=%s][part_num=%d]", result, pthparam->path.c_str(), pthparam->upload_id.c_str(), pthparam->upload_fd, static_cast<long long int>(pthparam->start), static_cast<long long int>(pthparam->size), (pthparam->is_copy ? "true" : "false"), pthparam->part_num);
     }
 
@@ -937,7 +937,7 @@ int pre_multipart_upload_request(const std::string& path, const headers_t& meta,
 //
 // Calls S3fsCurl::MultipartUploadPartRequest via multipart_upload_part_req_threadworker
 //
-int multipart_upload_part_request(const std::string& path, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy, Semaphore* psem, std::mutex* pthparam_lock, int* req_result)
+int multipart_upload_part_request(const std::string& path, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy, const std::string& srcssekeymd5, Semaphore* psem, std::mutex* pthparam_lock, int* req_result)
 {
     // parameter for thread worker (freed in multipart_upload_part_req_threadworker)
     auto thargs            = std::make_unique<multipart_upload_part_req_thparam>();
@@ -947,6 +947,7 @@ int multipart_upload_part_request(const std::string& path, int upload_fd, off_t 
     thargs->start          = start;
     thargs->size           = size;
     thargs->is_copy        = is_copy;
+    thargs->srcssekeymd5   = srcssekeymd5;
     thargs->part_num       = part_num;
     thargs->pthparam_lock  = pthparam_lock;
     thargs->petag          = petag;
@@ -971,7 +972,7 @@ int multipart_upload_part_request(const std::string& path, int upload_fd, off_t 
 //
 // Calls and Await S3fsCurl::MultipartUploadPartRequest via multipart_upload_part_req_threadworker
 //
-int await_multipart_upload_part_request(const std::string& path, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy)
+int await_multipart_upload_part_request(const std::string& path, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy, const std::string& srcssekeymd5)
 {
     std::mutex thparam_lock;
     int        req_result = 0;
@@ -984,6 +985,7 @@ int await_multipart_upload_part_request(const std::string& path, int upload_fd, 
     thargs->start          = start;
     thargs->size           = size;
     thargs->is_copy        = is_copy;
+    thargs->srcssekeymd5   = srcssekeymd5;
     thargs->part_num       = part_num;
     thargs->pthparam_lock  = &thparam_lock;
     thargs->petag          = petag;
@@ -1055,7 +1057,7 @@ int multipart_upload_request(const std::string& path, const headers_t& meta, int
         S3FS_PRN_INFO3("Multipart Upload Part [path=%s][start=%lld][size=%lld][part_num=%d]", path.c_str(), static_cast<long long int>(start), static_cast<long long int>(chunk), (req_count + 1));
 
         // setup instruction and request on another thread
-        if(0 != (result = multipart_upload_part_request(path, upload_fd, start, chunk, (req_count + 1), upload_id, petag, false, &upload_sem, &result_lock, &last_result))){
+        if(0 != (result = multipart_upload_part_request(path, upload_fd, start, chunk, (req_count + 1), upload_id, petag, false, "", &upload_sem, &result_lock, &last_result))){
             S3FS_PRN_ERR("failed setup instruction for Multipart Upload Part Request by error(%d) [path=%s][start=%lld][size=%lld][part_num=%d]", result, path.c_str(), static_cast<long long int>(start), static_cast<long long int>(chunk), (req_count + 1));
 
             // [NOTE]
@@ -1099,7 +1101,7 @@ int multipart_upload_request(const std::string& path, const headers_t& meta, int
 //      abort_multipart_upload_request()
 //      complete_multipart_upload_request()
 //
-int mix_multipart_upload_request(const std::string& path, headers_t& meta, int upload_fd, const fdpage_list_t& mixuppages)
+int mix_multipart_upload_request(const std::string& path, const headers_t& meta, int upload_fd, const fdpage_list_t& mixuppages)
 {
     S3FS_PRN_INFO3("Mix Multipart Upload Request [path=%s][upload_fd=%d]", path.c_str(), upload_fd);
 
@@ -1117,12 +1119,14 @@ int mix_multipart_upload_request(const std::string& path, headers_t& meta, int u
         return result;
     }
 
-    // Prepare headers for Multipart Upload Copy
-    std::string srcresource;
-    std::string srcurl;
-    MakeUrlResource(get_realpath(path.c_str()).c_str(), srcresource, srcurl);
-    meta["Content-Type"]      = S3fsCurl::LookupMimeType(path);
-    meta["x-amz-copy-source"] = srcresource;
+    // The md5 of the SSE-C key that encrypted the source object, which
+    // each copy part presents to read it.  The other copy headers are
+    // made by S3fsCurl::MultipartUploadPartSetup.
+    std::string srcssekeymd5;
+    auto        ssekeyiter = meta.find("x-amz-server-side-encryption-customer-key-md5");
+    if(meta.cend() != ssekeyiter){
+        srcssekeymd5 = ssekeyiter->second;
+    }
 
     Semaphore  upload_sem(0);
     std::mutex result_lock;         // protects last_result
@@ -1143,7 +1147,7 @@ int mix_multipart_upload_request(const std::string& path, headers_t& meta, int u
             S3FS_PRN_INFO3("Mix Multipart Upload Content Part [path=%s][start=%lld][size=%lld][part_num=%d]", path.c_str(), static_cast<long long int>(iter->offset), static_cast<long long int>(iter->bytes), (req_count + 1));
 
             // setup instruction and request on another thread
-            if(0 != (result = multipart_upload_part_request(path, upload_fd, iter->offset, iter->bytes, (req_count + 1), upload_id, petag, false, &upload_sem, &result_lock, &last_result))){
+            if(0 != (result = multipart_upload_part_request(path, upload_fd, iter->offset, iter->bytes, (req_count + 1), upload_id, petag, false, "", &upload_sem, &result_lock, &last_result))){
                 S3FS_PRN_ERR("Failed setup instruction for Mix Multipart Upload Content Part Request by error(%d) [path=%s][start=%lld][size=%lld][part_num=%d]", result, path.c_str(), static_cast<long long int>(iter->offset), static_cast<long long int>(iter->bytes), (req_count + 1));
                 // [NOTE]
                 // Hold onto result until all request finish.
@@ -1173,11 +1177,6 @@ int mix_multipart_upload_request(const std::string& path, headers_t& meta, int u
                     }
                 }
 
-                // Set headers for Multipart Upload Copy
-                std::ostringstream strrange;
-                strrange << "bytes=" << (iter->offset + processed_bytes) << "-" << (iter->offset + processed_bytes + request_bytes - 1);
-                meta["x-amz-copy-source-range"] = strrange.str();
-
                 // add new etagpair to etaglist_t list
                 list.emplace_back(nullptr, (req_count + 1));
                 etagpair* petag = &list.back();
@@ -1185,7 +1184,7 @@ int mix_multipart_upload_request(const std::string& path, headers_t& meta, int u
                 S3FS_PRN_INFO3("Mix Multipart Upload Copy Part [path=%s][start=%lld][size=%lld][part_num=%d]", path.c_str(), static_cast<long long int>(iter->offset + processed_bytes), static_cast<long long int>(request_bytes), (req_count + 1));
 
                 // setup instruction and request on another thread
-                if(0 != (result = multipart_upload_part_request(path, upload_fd, (iter->offset + processed_bytes), request_bytes, (req_count + 1), upload_id, petag, true, &upload_sem, &result_lock, &last_result))){
+                if(0 != (result = multipart_upload_part_request(path, upload_fd, (iter->offset + processed_bytes), request_bytes, (req_count + 1), upload_id, petag, true, srcssekeymd5, &upload_sem, &result_lock, &last_result))){
                     S3FS_PRN_ERR("Failed setup instruction for Mix Multipart Upload Copy Part Request by error(%d) [path=%s][start=%lld][size=%lld][part_num=%d]", result, path.c_str(), static_cast<long long int>(iter->offset + processed_bytes), static_cast<long long int>(request_bytes), (req_count + 1));
                     // [NOTE]
                     // This loop breaks because result is not 0.

--- a/src/s3fs_threadreqs.h
+++ b/src/s3fs_threadreqs.h
@@ -134,6 +134,7 @@ struct multipart_upload_part_req_thparam
 {
     std::string   path;
     std::string   upload_id;
+    std::string   srcssekeymd5;
     int           upload_fd      = -1;
     off_t         start          = 0;
     off_t         size           = 0;
@@ -238,10 +239,10 @@ int put_request(const std::string& strpath, const headers_t& meta, int fd, bool 
 int list_bucket_request(const std::string& strpath, const std::string& query, std::string& responseBody);
 int check_service_request(const std::string& strpath, bool forceNoSSE, bool support_compat_dir, long& responseCode, std::string& responseBody);
 int pre_multipart_upload_request(const std::string& path, const headers_t& meta, std::string& upload_id);
-int multipart_upload_part_request(const std::string& path, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy, Semaphore* psem, std::mutex* pthparam_lock, int* req_result);
-int await_multipart_upload_part_request(const std::string& path, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy);
+int multipart_upload_part_request(const std::string& path, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy, const std::string& srcssekeymd5, Semaphore* psem, std::mutex* pthparam_lock, int* req_result);
+int await_multipart_upload_part_request(const std::string& path, int upload_fd, off_t start, off_t size, int part_num, const std::string& upload_id, etagpair* petag, bool is_copy, const std::string& srcssekeymd5);
 int multipart_upload_request(const std::string& path, const headers_t& meta, int upload_fd);
-int mix_multipart_upload_request(const std::string& path, headers_t& meta, int upload_fd, const fdpage_list_t& mixuppages);
+int mix_multipart_upload_request(const std::string& path, const headers_t& meta, int upload_fd, const fdpage_list_t& mixuppages);
 int complete_multipart_upload_request(const std::string& path, const std::string& upload_id, const etaglist_t& parts);
 int abort_multipart_upload_request(const std::string& path, const std::string& upload_id);
 int multipart_put_head_request(const std::string& strfrom, const std::string& strto, off_t size, const headers_t& meta);


### PR DESCRIPTION
The mix multipart upload and the stream upload build their copy parts through S3fsCurl::MultipartUploadPartSetup, whose synthetic meta carries only x-amz-copy-source and the range.
MultipartUploadCopyPartSetup adds the copy source SSE-C headers only when that meta carries the source key md5, so every UploadPartCopy went out with the destination triple but no source key, and AWS and other enforcing servers reject reading the source with 400 InvalidRequest.  Regular put_headers copies do not have this problem because their meta comes from a HEAD response, which echoes the key md5.

Thread the source key md5 from the entity's metadata down to the part setup, and drop the copy headers mix_multipart_upload_request still wrote into its meta copy: they have been dead since the thread pool refactor moved request building into the workers, which is how the key went missing.

With use_sse=custom against s3proxy, the integration suite improves from 79 to 86 of 93 with plain flushes and passes all multipart mix and stream upload copy tests with -o streamupload; the remaining failures are unrelated to part copies.