### PR TITLE
Set the SSE-C headers in the meta of newly created objects

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -2814,6 +2814,42 @@ bool S3fsCurl::AddSseRequestHead(sse_type_t ssetype, std::string ssevalue, bool 
 }
 
 //
+// Set the SSE headers that a HEAD response would carry into meta
+//
+// This is the counterpart of AddSseRequestHead() for the meta which is
+// built locally for a newly created object and then cached in place of
+// a HEAD response.  The object is stored with the current SSE setting,
+// so the meta must describe it the same way the server would, without
+// the SSE-C key itself which a response never echoes.  New objects are
+// encrypted with the latest SSE-C key(position 0).
+//
+bool S3fsCurl::AddSseResponseHead(headers_t& meta)
+{
+    switch(S3fsCurl::GetSseType()){
+        case sse_type_t::SSE_DISABLE:
+            return true;
+        case sse_type_t::SSE_S3:
+            meta["x-amz-server-side-encryption"] = "AES256";
+            return true;
+        case sse_type_t::SSE_C:
+            if(auto md5 = S3fsCurl::GetSseKeyMd5(0)){
+                meta["x-amz-server-side-encryption-customer-algorithm"] = "AES256";
+                meta["x-amz-server-side-encryption-customer-key-md5"]   = *md5;
+                return true;
+            }
+            S3FS_PRN_ERR("Failed to insert SSE-C header.");
+            return false;
+        case sse_type_t::SSE_KMS:
+            meta["x-amz-server-side-encryption"]                = "aws:kms";
+            meta["x-amz-server-side-encryption-aws-kms-key-id"] = S3fsCurl::GetSseKmsId();
+            return true;
+    }
+    S3FS_PRN_ERR("sse type is unknown(%d).", static_cast<int>(S3fsCurl::ssetype));
+
+    return false;
+}
+
+//
 // tpath :      target path for head request
 // ssekey_pos : SIZE_MAX means "not" SSE-C type
 //              0 - X means SSE-C type and position for SSE-C key(0 is latest key)

--- a/src/curl.h
+++ b/src/curl.h
@@ -290,6 +290,7 @@ class S3fsCurl
         static bool IsSetSseKmsId() { return !S3fsCurl::ssekmsid.empty(); }
         static const char* GetSseKmsId() { return S3fsCurl::ssekmsid.c_str(); }
         static bool GetSseKey(std::string& md5, std::string& ssekey);
+        static bool AddSseResponseHead(headers_t& meta);
         static std::optional<std::string> GetSseKeyMd5(size_t pos);
         static size_t GetSseKeyCount();
         static bool SetContentMd5(bool flag);

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1183,6 +1183,15 @@ static int s3fs_create(const char* _path, mode_t mode, struct fuse_file_info* fi
         meta["x-amz-meta-xattr"] = *xattrvalue;
     }
 
+    // [NOTE]
+    // This meta is cached and used in place of a HEAD response, so it
+    // must carry the SSE headers describing how the object is stored.
+    //
+    if(!S3fsCurl::AddSseResponseHead(meta)){
+        S3FS_PRN_ERR("failed to set the SSE headers in the meta of %s", strpath.c_str());
+        return -EIO;
+    }
+
     // Set stat structure
     struct stat stbuf = {};
     if(!convert_header_to_stat(strpath, meta, stbuf, false)){
@@ -1502,6 +1511,15 @@ static int s3fs_symlink(const char* _from, const char* _to)
     headers["x-amz-meta-mtime"] = strnow;
     headers["x-amz-meta-uid"]   = std::to_string(pcxt->uid);
     headers["x-amz-meta-gid"]   = std::to_string(pcxt->gid);
+
+    // [NOTE]
+    // These headers are cached and used in place of a HEAD response, so
+    // they must describe how the object is stored.
+    //
+    if(!S3fsCurl::AddSseResponseHead(headers)){
+        S3FS_PRN_ERR("failed to set the SSE headers in the meta of %s", strTo.c_str());
+        return -EIO;
+    }
 
     // [NOTE]
     // Symbolic links do not set xattrs.


### PR DESCRIPTION
When SSE-C is used, reading an object requires presenting its key, including when the object is the source of a copy request. put_headers() and the multipart copy functions resolve that key from the key md5 in their meta, which normally comes from a HEAD response echoing it.  But the meta built locally for a newly created file, directory, or symbolic link carried no SSE-C headers, and it is stored in the stat cache and the entity org meta, where it stands in for a HEAD response.  Until those entries expired, any meta updating copy on a fresh object, such as utimens or chmod, sent no copy source SSE-C headers and failed with 400 InvalidRequest against AWS and other enforcing servers, and get_object_sse_type() reported the object as unencrypted.

Seed the algorithm and the md5 of the current key, which new uploads are encrypted with, into the locally built meta at the creation sites.  With use_sse=custom against s3proxy, test_pjdfstest_utimensat now passes; the remaining failures are a separate multipart copy part bug and test harness limitations.