### PR TITLE
Send SSE-C headers from the test helpers under use_sse=custom

### DIFF
--- a/test/small-integration-test.sh
+++ b/test/small-integration-test.sh
@@ -58,8 +58,8 @@ if [ -n "${ALL_TESTS}" ]; then
         sigv2
         sigv4
         "singlepart_copy_limit=10 -o multipart_copy_size=10"  # limit sizes to exercise multipart copy code paths
-        #use_sse  # TODO: S3Proxy does not support SSE
-        #use_sse=custom:/tmp/ssekey  # TODO: S3Proxy does not support SSE
+        #use_sse  # TODO: needs an S3Proxy release with SSE support
+        #use_sse=custom:/tmp/ssekey  # TODO: needs an S3Proxy release with SSE support
         "use_cache=${CACHE_DIR} -o ensure_diskfree=${ENSURE_DISKFREE_SIZE} -o fake_diskfree=${FAKE_FREE_DISK_SIZE} -o streamupload"
         hard_remove  # exercise null-path file handle operations
     )
@@ -142,6 +142,18 @@ test_mount_nonexistent_bucket
 
 for flag in "${FLAGS[@]}"; do
     echo "testing s3fs flag: ${flag}"
+
+    # When testing use_sse=custom, tell the raw request helpers the key
+    # file, so that they can read what the mount encrypts.
+    case "${flag}" in
+        *use_sse=custom:*)
+            S3FS_SSE_CUSTOM_KEYFILE="${flag#*use_sse=custom:}"
+            export S3FS_SSE_CUSTOM_KEYFILE="${S3FS_SSE_CUSTOM_KEYFILE%% *}"
+            ;;
+        *)
+            unset S3FS_SSE_CUSTOM_KEYFILE
+            ;;
+    esac
 
     # shellcheck disable=SC2086
     start_s3fs -o ${flag}

--- a/test/test-utils.sh
+++ b/test/test-utils.sh
@@ -356,11 +356,32 @@ function get_disk_avail_size() {
     echo "${DISK_AVAIL_SIZE}"
 }
 
+# When s3fs runs with use_sse=custom, objects written through the mount
+# are encrypted, and reading or replacing them from outside of s3fs
+# needs the same key.  While S3FS_SSE_CUSTOM_KEYFILE is exported, the
+# object helpers below send the SSE-C headers for the first key in that
+# file, which is the key that s3fs encrypts new objects with.
+function set_sse_curl_args() {
+    SSE_CURL_ARGS=()
+    if [ -n "${S3FS_SSE_CUSTOM_KEYFILE:-}" ]; then
+        local KEY KEY_MD5
+        KEY=$(head -n 1 "${S3FS_SSE_CUSTOM_KEYFILE}")
+        KEY_MD5=$(echo "${KEY}" | openssl base64 -d | openssl md5 -binary | base64)
+        SSE_CURL_ARGS=(
+            --header "x-amz-server-side-encryption-customer-algorithm: AES256"
+            --header "x-amz-server-side-encryption-customer-key: ${KEY}"
+            --header "x-amz-server-side-encryption-customer-key-md5: ${KEY_MD5}"
+        )
+    fi
+}
+
 function s3_head() {
     local S3_PATH=$1
     shift
+    set_sse_curl_args
     curl --aws-sigv4 "aws:amz:$S3_ENDPOINT:s3" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
         --cacert "$S3PROXY_CACERT_FILE" --fail --silent \
+        "${SSE_CURL_ARGS[@]}" \
         "$@" \
         --head "$S3_URL/$S3_PATH"
 }
@@ -390,10 +411,12 @@ function s3_cp() {
             Content-Type:*) CONTENT_TYPE_HEADER=(); break ;;
         esac
     done
+    set_sse_curl_args
     curl --aws-sigv4 "aws:amz:$S3_ENDPOINT:s3" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
         --cacert "$S3PROXY_CACERT_FILE" --fail --silent \
         --header "Content-Length: $(wc -c < "$TEMPNAME")" \
         "${CONTENT_TYPE_HEADER[@]}" \
+        "${SSE_CURL_ARGS[@]}" \
         "$@" \
         --request PUT --data-binary "@$TEMPNAME" "$S3_URL/$S3_PATH"
     rm -f "$TEMPNAME"


### PR DESCRIPTION
The s3_head and s3_cp helpers make raw signed requests, but sent no SSE-C headers, so heading an object that the mount encrypted failed with 400 in test_create_empty_file, test_mv_file,
test_multipart_copy, test_content_type, and
test_chmod_listed_directory_keeps_metadata, and the files those failed tests left behind broke test_list.

While S3FS_SSE_CUSTOM_KEYFILE is exported, the helpers now send the SSE-C headers for the first key in that file, which is the key s3fs encrypts new objects with.  s3_cp sends them too, so every object in an SSE-C lane is encrypted with the same key whether it was written through the mount or by a helper, and either side can read the other's.  The flag loop exports the key file parsed from the flag.

Also reword the TODO on the disabled SSE combos: S3Proxy now supports SSE on a branch, but the pinned release the harness downloads does not yet.