### PR TITLE
Skip test_concurrent_directory_updates on macOS

### DIFF
--- a/test/integration-test-main.sh
+++ b/test/integration-test-main.sh
@@ -3300,7 +3300,15 @@ function add_all_tests {
     add_tests test_copy_file
     add_tests test_write_after_seek_ahead
     add_tests test_overwrite_existing_file_range
-    add_tests test_concurrent_directory_updates
+    # [NOTE]
+    # A macOS NFS client kernel bug can permanently wedge processes racing
+    # open/unlink/recreate of the same names, hanging the job until the CI
+    # timeout.  FUSE-T mounts are NFS, so this test cannot run safely there.
+    # https://github.com/macos-fuse-t/fuse-t/issues/112
+    #
+    if ! uname | grep -q Darwin; then
+        add_tests test_concurrent_directory_updates
+    fi
     add_tests test_concurrent_reads
     add_tests test_concurrent_writes
     add_tests test_open_second_fd


### PR DESCRIPTION
A macOS NFS client kernel bug can permanently wedge processes that race open/unlink/recreate of the same names.  FUSE-T mounts are NFS, so the test intermittently hangs the macos-14 CI job until its 20 minute timeout: the racing syscalls are never delivered to s3fs while the rest of the mount stays serviceable.  The FUSE-T maintainer confirms the bug reproduces on a native NFS mount with the same script and that Apple has known about it for years:

https://github.com/macos-fuse-t/fuse-t/issues/112

Linux continues to run the test.