### PR TITLE
Remove IBM-specific knowledge from the curl transport layer

### DIFF
--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -1915,7 +1915,13 @@ bool S3fsCurl::RemakeHandle(bool keepAuthHeader)
             if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback)){
                 return false;
             }
-            if(S3fsCurl::ps3fscred->IsIBMIAMAuth()){
+            // [NOTE]
+            // Some credential endpoints(ex. IBM IAM) require the request to
+            // be a POST carrying a body.  GetIAMCredentials sets the options
+            // below itself, so this branch only matters when RemakeHandle
+            // restores postdata for a retry.
+            //
+            if(postdata){
                 if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_POST, true)){
                     return false;
                 }
@@ -2628,7 +2634,12 @@ int S3fsCurl::GetIAMv2ApiToken(const char* token_url, int token_ttl, const char*
 // Get AccessKeyId/SecretAccessKey/AccessToken/Expiration by IAM role,
 // and Set these value to class variable.
 //
-std::optional<std::string> S3fsCurl::GetIAMCredentials(const char* cred_url, const char* iam_v2_token, const char* ibm_secret_access_key)
+// [NOTE]
+// post_body and authorization are for credential endpoints which require a
+// POST request with credentials of their own(ex. the IBM IAM token endpoint).
+// Both are optional and this method does not interpret their contents.
+//
+std::optional<std::string> S3fsCurl::GetIAMCredentials(const char* cred_url, const char* iam_v2_token, const char* post_body, const char* authorization)
 {
     if(!cred_url){
         S3FS_PRN_ERR("url is null.");
@@ -2645,22 +2656,25 @@ std::optional<std::string> S3fsCurl::GetIAMCredentials(const char* cred_url, con
     requestHeaders  = nullptr;
     responseHeaders.clear();
     bodydata.clear();
+
+    // [NOTE]
+    // postdata points into this buffer, so it must live until RequestPerform
+    // (including its retries) returns.
+    //
     std::string postContent;
 
-    if(ibm_secret_access_key){
-        // make contents
-        postContent += "grant_type=urn:ibm:params:oauth:grant-type:apikey";
-        postContent += "&response_type=cloud_iam";
-        postContent += "&apikey=";
-        postContent += ibm_secret_access_key;
+    if(authorization){
+        requestHeaders = curl_slist_sort_insert(requestHeaders, "Authorization", authorization);
+    }
+
+    if(post_body){
+        postContent = post_body;
 
         // set postdata
         postdata             = reinterpret_cast<const unsigned char*>(postContent.c_str());
         b_postdata           = postdata;
         postdata_remaining   = postContent.size(); // without null
         b_postdata_remaining = postdata_remaining;
-
-        requestHeaders = curl_slist_sort_insert(requestHeaders, "Authorization", "Basic Yng6Yng=");
 
         if(CURLE_OK != curl_easy_setopt(hCurl, CURLOPT_POST, true)){              // POST
             return std::nullopt;

--- a/src/curl.h
+++ b/src/curl.h
@@ -326,7 +326,7 @@ class S3fsCurl
         bool DestroyCurlHandle(bool clear_internal_data = true);
         bool DestroyCurlHandleHasLock(bool clear_internal_data = true) REQUIRES(S3fsCurl::curl_handles_lock);
 
-        std::optional<std::string> GetIAMCredentials(const char* cred_url, const char* iam_v2_token, const char* ibm_secret_access_key);
+        std::optional<std::string> GetIAMCredentials(const char* cred_url, const char* iam_v2_token, const char* post_body, const char* authorization);
         std::optional<std::string> GetIAMRoleFromMetaData(const char* cred_url, const char* iam_v2_token);
         std::optional<long> GetResponseCode(bool from_curl_handle = true) const;
         std::optional<std::string> GetCurlErrorString() const;

--- a/src/s3fs_cred.cpp
+++ b/src/s3fs_cred.cpp
@@ -422,7 +422,8 @@ bool S3fsCred::LoadIAMCredentials()
 {
     std::string url;
     std::string striamtoken;
-    std::string stribmsecret;
+    std::string strpostbody;
+    std::string strauthorization;
     std::string cred;
 
     // get parameters(check iam role)
@@ -433,11 +434,16 @@ bool S3fsCred::LoadIAMCredentials()
         striamtoken = GetIAMv2APIToken();
     }
     if(IsIBMIAMAuth()){
-        stribmsecret = AWSSecretAccessKey;
+        // The IBM IAM token endpoint is an OAuth endpoint: it takes the
+        // secret access key as an apikey in a POST body, authenticated as
+        // the well-known "bx:bx" public client.
+        //
+        strpostbody      = "grant_type=urn:ibm:params:oauth:grant-type:apikey&response_type=cloud_iam&apikey="s + AWSSecretAccessKey;
+        strauthorization = "Basic Yng6Yng=";
     }
 
     // Get IAM Credentials
-    if(0 == get_iamcred_request(url, striamtoken, stribmsecret, cred)){
+    if(0 == get_iamcred_request(url, striamtoken, strpostbody, strauthorization, cred)){
         S3FS_PRN_DBG("Succeed to set IAM credentials");
     }else{
         S3FS_PRN_ERR("Something error occurred, could not set IAM credentials.");

--- a/src/s3fs_threadreqs.cpp
+++ b/src/s3fs_threadreqs.cpp
@@ -1563,13 +1563,13 @@ int get_iamrole_request(const std::string& strurl, const std::string& striamtoke
 //
 // Directly calls S3fsCurl::GetIAMCredentials
 //
-int get_iamcred_request(const std::string& strurl, const std::string& striamtoken, const std::string& stribmsecret, std::string& cred)
+int get_iamcred_request(const std::string& strurl, const std::string& striamtoken, const std::string& strpostbody, const std::string& strauthorization, std::string& cred)
 {
-    S3FS_PRN_INFO3("Get IAM Credentials Request directly [url=%s][iam token=%s][ibm secret access key=%s]", strurl.c_str(), mask_sensitive_string(striamtoken.c_str()), mask_sensitive_string(stribmsecret.c_str()));
+    S3FS_PRN_INFO3("Get IAM Credentials Request directly [url=%s][iam token=%s][post body=%s]", strurl.c_str(), mask_sensitive_string(striamtoken.c_str()), mask_sensitive_string(strpostbody.c_str()));
 
     S3fsCurl s3fscurl;
     int      result = 0;
-    if(auto iamcred = s3fscurl.GetIAMCredentials(strurl.c_str(), (striamtoken.empty() ? nullptr : striamtoken.c_str()), (stribmsecret.empty() ? nullptr : stribmsecret.c_str()))){
+    if(auto iamcred = s3fscurl.GetIAMCredentials(strurl.c_str(), (striamtoken.empty() ? nullptr : striamtoken.c_str()), (strpostbody.empty() ? nullptr : strpostbody.c_str()), (strauthorization.empty() ? nullptr : strauthorization.c_str()))){
         cred = std::move(*iamcred);
     }else{
         S3FS_PRN_ERR("Something error occurred during getting IAM Credentials.");

--- a/src/s3fs_threadreqs.h
+++ b/src/s3fs_threadreqs.h
@@ -254,7 +254,7 @@ int get_object_request(const std::string& path, int fd, off_t start, off_t size)
 //-------------------------------------------------------------------
 int get_iamv2api_token_request(const std::string& strurl, int tokenttl, const std::string& strttlhdr, std::string& token);
 int get_iamrole_request(const std::string& strurl, const std::string& striamtoken, std::string& token);
-int get_iamcred_request(const std::string& strurl, const std::string& striamtoken, const std::string& stribmsecret, std::string& cred);
+int get_iamcred_request(const std::string& strurl, const std::string& striamtoken, const std::string& strpostbody, const std::string& strauthorization, std::string& cred);
 
 #endif // S3FS_THREADREQS_H_
 


### PR DESCRIPTION
S3fsCurl reached into S3fsCred to ask whether IBM IAM authentication was in use, and built the IBM OAuth token request itself.  Neither belongs in the transport layer.

GetIAMCredentials now takes an opaque post body and Authorization header instead of an IBM apikey; S3fsCred::LoadIAMCredentials builds both.  The IAMCRED case of ResetHandle keys off postdata rather than IsIBMIAMAuth -- the block is a copy of the unconditional COMPLETEMULTIPOST case and only takes effect on the RemakeHandle retry path, where postdata has just been restored from b_postdata.  GetIAMCredentials sets the same four options itself on the initial pass.

No functional change.