### PR TITLE
Update timestamps on truncate, removexattr and before the epoch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ src/s3fs
 src/test_auth
 src/test_cache_node
 src/test_curl_util
+src/test_metaheader
 src/test_page_list
 src/test_s3objlist
 src/test_string_util

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -75,6 +75,7 @@ noinst_PROGRAMS = \
     test_auth \
     test_cache_node \
     test_curl_util \
+    test_metaheader \
     test_page_list \
     test_s3objlist \
     test_string_util
@@ -121,17 +122,25 @@ test_s3objlist_SOURCES = s3objlist.cpp test_s3objlist.cpp
 
 test_string_util_SOURCES = string_util.cpp test_string_util.cpp s3fs_logger.cpp
 
+test_metaheader_SOURCES = \
+    metaheader.cpp \
+    filetimes.cpp \
+    string_util.cpp \
+    s3fs_logger.cpp \
+    test_metaheader.cpp
+
 TESTS = \
     test_auth \
     test_cache_node \
     test_curl_util \
+    test_metaheader \
     test_page_list \
     test_s3objlist \
     test_string_util
 
 clang-tidy:
 	clang-tidy -extra-arg-before=-xc++ -extra-arg=-std=@CPP_VERSION@ -header-filter= \
-		*.h $(s3fs_SOURCES) test_auth.cpp test_cache_node.cpp test_curl_util.cpp test_page_list.cpp test_s3objlist.cpp test_string_util.cpp \
+		*.h $(s3fs_SOURCES) test_auth.cpp test_cache_node.cpp test_curl_util.cpp test_metaheader.cpp test_page_list.cpp test_s3objlist.cpp test_string_util.cpp \
 		-- $(DEPS_CFLAGS) $(CPPFLAGS)
 
 #

--- a/src/filetimes.cpp
+++ b/src/filetimes.cpp
@@ -27,7 +27,11 @@
 //-------------------------------------------------------------------
 bool valid_timespec(const struct timespec& ts)
 {
-    if(0 > ts.tv_sec || UTIME_OMIT == ts.tv_nsec || UTIME_NOW == ts.tv_nsec){
+    // [NOTE]
+    // A negative tv_sec is a valid time before the epoch, so only the
+    // UTIME_OMIT/UTIME_NOW markers make a timespec unusable here.
+    //
+    if(UTIME_OMIT == ts.tv_nsec || UTIME_NOW == ts.tv_nsec){
         return false;
     }
     return true;

--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -27,7 +27,6 @@
 #include "string_util.h"
 #include "filetimes.h"
 
-static constexpr struct timespec ERROR_TIMESPEC = {-1, 0};
 static constexpr struct timespec OMIT_TIMESPEC  = {0, UTIME_OMIT};
 
 //-------------------------------------------------------------------
@@ -55,24 +54,31 @@ static struct timespec cvt_string_to_time(const char *str)
     return ts;
 }
 
-static struct timespec get_time(const headers_t& meta, const char *header)
+// [NOTE]
+// Returns false if the header is not present at all. A present header is
+// parsed even when it holds a negative number of seconds, because times
+// before the epoch are legitimate(utimensat(2) accepts them). Absence is
+// reported separately rather than as a negative sentinel so that a real
+// pre-1970 timestamp is not mistaken for a missing header.
+//
+static bool get_time(const headers_t& meta, const char *header, struct timespec& ts)
 {
     headers_t::const_iterator iter;
     if(meta.cend() == (iter = meta.find(header))){
-        return ERROR_TIMESPEC;
+        return false;
     }
-    return cvt_string_to_time((*iter).second.c_str());
+    ts = cvt_string_to_time((*iter).second.c_str());
+    return true;
 }
 
 struct timespec get_mtime(const headers_t& meta, bool overcheck)
 {
-    struct timespec mtime = get_time(meta, "x-amz-meta-mtime");
-    if(0 <= mtime.tv_sec && UTIME_OMIT != mtime.tv_nsec){
+    struct timespec mtime;
+    if(get_time(meta, "x-amz-meta-mtime", mtime) && UTIME_OMIT != mtime.tv_nsec){
         return mtime;
     }
 
-    mtime = get_time(meta, "x-amz-meta-goog-reserved-file-mtime");
-    if(0 <= mtime.tv_sec && UTIME_OMIT != mtime.tv_nsec){
+    if(get_time(meta, "x-amz-meta-goog-reserved-file-mtime", mtime) && UTIME_OMIT != mtime.tv_nsec){
         return mtime;
     }
     if(overcheck){
@@ -84,8 +90,8 @@ struct timespec get_mtime(const headers_t& meta, bool overcheck)
 
 struct timespec get_ctime(const headers_t& meta, bool overcheck)
 {
-    struct timespec ctime = get_time(meta, "x-amz-meta-ctime");
-    if(0 <= ctime.tv_sec && UTIME_OMIT != ctime.tv_nsec){
+    struct timespec ctime;
+    if(get_time(meta, "x-amz-meta-ctime", ctime) && UTIME_OMIT != ctime.tv_nsec){
         return ctime;
     }
     if(overcheck){
@@ -97,8 +103,8 @@ struct timespec get_ctime(const headers_t& meta, bool overcheck)
 
 struct timespec get_atime(const headers_t& meta, bool overcheck)
 {
-    struct timespec atime = get_time(meta, "x-amz-meta-atime");
-    if(0 <= atime.tv_sec && UTIME_OMIT != atime.tv_nsec){
+    struct timespec atime;
+    if(get_time(meta, "x-amz-meta-atime", atime) && UTIME_OMIT != atime.tv_nsec){
         return atime;
     }
     if(overcheck){
@@ -436,23 +442,27 @@ bool convert_header_to_stat(const std::string& strpath, const headers_t& meta, s
     }
     stbuf.st_blksize = 4096;
 
+    // [NOTE]
+    // Only an omitted(absent) time falls back to the epoch. A negative
+    // tv_sec is a valid time before 1970 and is passed through as-is.
+    //
     // mtime
     struct timespec mtime = get_mtime(meta);
-    if(mtime.tv_sec < 0){
+    if(UTIME_OMIT == mtime.tv_nsec){
         mtime = {0, 0};
     }
     set_timespec_to_stat(stbuf, stat_time_type::MTIME, mtime);
 
     // ctime
     struct timespec ctime = get_ctime(meta);
-    if(ctime.tv_sec < 0){
+    if(UTIME_OMIT == ctime.tv_nsec){
         ctime = {0, 0};
     }
     set_timespec_to_stat(stbuf, stat_time_type::CTIME, ctime);
 
     // atime
     struct timespec atime = get_atime(meta);
-    if(atime.tv_sec < 0){
+    if(UTIME_OMIT == atime.tv_nsec){
         atime = {0, 0};
     }
     set_timespec_to_stat(stbuf, stat_time_type::ATIME, atime);

--- a/src/metaheader.cpp
+++ b/src/metaheader.cpp
@@ -82,8 +82,18 @@ struct timespec get_mtime(const headers_t& meta, bool overcheck)
         return mtime;
     }
     if(overcheck){
-        mtime = {get_lastmodified(meta), 0};
-        return mtime;
+        // [NOTE]
+        // get_lastmodified() reports a missing or unparsable Last-Modified
+        // header as -1, and a directory that exists only as the prefix of
+        // other keys has no header at all.  That is an absence rather than a
+        // time one second before the epoch, so it must not be handed back as
+        // a timestamp: report it as omitted and let the caller default it.
+        //
+        time_t lastmodified = get_lastmodified(meta);
+        if(-1 != lastmodified){
+            mtime = {lastmodified, 0};
+            return mtime;
+        }
     }
     return OMIT_TIMESPEC;
 }
@@ -95,8 +105,12 @@ struct timespec get_ctime(const headers_t& meta, bool overcheck)
         return ctime;
     }
     if(overcheck){
-        ctime = {get_lastmodified(meta), 0};
-        return ctime;
+        // See the note in get_mtime() about a missing Last-Modified header.
+        time_t lastmodified = get_lastmodified(meta);
+        if(-1 != lastmodified){
+            ctime = {lastmodified, 0};
+            return ctime;
+        }
     }
     return OMIT_TIMESPEC;
 }
@@ -108,8 +122,12 @@ struct timespec get_atime(const headers_t& meta, bool overcheck)
         return atime;
     }
     if(overcheck){
-        atime = {get_lastmodified(meta), 0};
-        return atime;
+        // See the note in get_mtime() about a missing Last-Modified header.
+        time_t lastmodified = get_lastmodified(meta);
+        if(-1 != lastmodified){
+            atime = {lastmodified, 0};
+            return atime;
+        }
     }
     return OMIT_TIMESPEC;
 }

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -3062,20 +3062,40 @@ static int s3fs_truncate(const char* _path, off_t size, struct fuse_file_info* i
         }
 #endif
 
-        if(need_flush){
-            // successful truncate(2) updates ctime and mtime
-            struct timespec ts_now;
-            s3fs_realtime(ts_now);
-            if(0 != (result = ent->SetCtime(ts_now)) || 0 != (result = ent->SetMtime(ts_now))){
-                S3FS_PRN_ERR("could not set mtime and ctime to file(%s): result=%d", path, result);
-                return result;
-            }
+        // [NOTE]
+        // A successful truncate(2)/ftruncate(2) updates ctime and mtime
+        // whether or not the file is currently open, so this must happen
+        // outside the need_flush branch below. When the file is open the
+        // new times are only recorded in the FdEntity, so the metadata is
+        // marked dirty to have them uploaded by the flush at close.
+        //
+        struct timespec ts_now;
+        s3fs_realtime(ts_now);
+        if(0 != (result = ent->SetCtime(ts_now)) || 0 != (result = ent->SetMtime(ts_now))){
+            S3FS_PRN_ERR("could not set mtime and ctime to file(%s): result=%d", path, result);
+            return result;
+        }
 
+        if(need_flush){
             if(0 != (result = ent->Flush(autoent.GetPseudoFd(), true))){
                 S3FS_PRN_ERR("could not upload file(%s): result=%d", path, result);
                 return result;
             }
             StatCache::getStatCacheData()->DelStat(path);
+        }else{
+            ent->MarkDirtyMetadata();
+
+            // Reflect the new times in the stat cache, which would otherwise
+            // keep serving the pre-truncate values until the upload happens.
+            headers_t newmeta;
+            struct stat newstbuf;
+            if(ent->GetOrgMeta(newmeta) && convert_header_to_stat(path, newmeta, newstbuf, false)){
+                if(!StatCache::getStatCacheData()->UpdateStat(path, newstbuf, newmeta)){
+                    StatCache::getStatCacheData()->DelStat(path);
+                }
+            }else{
+                StatCache::getStatCacheData()->DelStat(path);
+            }
         }
 
     }else if(-ENOENT == result){
@@ -4530,6 +4550,7 @@ static int s3fs_removexattr(const char* _path, const char* name)
     // set xattr all object
     std::string strSourcePath              = (mount_prefix.empty() && "/" == curpath) ? "//" : curpath;
     headers_t   updatemeta;
+    updatemeta["x-amz-meta-ctime"]         = s3fs_str_realtime();    // removexattr(2) updates ctime, as setxattr(2) does
     updatemeta["x-amz-copy-source"]        = urlEncodePath(service_path + S3fsCred::GetBucket() + get_realpath(strSourcePath.c_str()));
     updatemeta["x-amz-metadata-directive"] = "REPLACE";
     if(!xattrs.empty()){

--- a/src/test_metaheader.cpp
+++ b/src/test_metaheader.cpp
@@ -1,0 +1,107 @@
+/*
+ * s3fs - FUSE-based file system backed by Amazon S3
+ *
+ * Copyright(C) 2014 Andrew Gaul <andrew@gaul.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <string>
+
+#include "filetimes.h"
+#include "metaheader.h"
+#include "test_util.h"
+
+//-------------------------------------------------------------------
+// Global variables for test_metaheader
+//-------------------------------------------------------------------
+bool foreground                   = false;
+std::string instance_name;
+
+//
+// A time before the epoch is a legitimate timestamp, so it must survive the
+// round trip through the metadata headers instead of being treated as a
+// missing value and replaced by Last-Modified or by the epoch.
+//
+static void test_negative_times()
+{
+    headers_t meta;
+    meta["x-amz-meta-mtime"] = "-315619140";     // 1960-01-01
+    meta["x-amz-meta-ctime"] = "-315619140";
+    meta["x-amz-meta-atime"] = "-315619140";
+
+    ASSERT_EQUALS(static_cast<time_t>(-315619140), get_mtime(meta).tv_sec);
+    ASSERT_EQUALS(static_cast<time_t>(-315619140), get_ctime(meta).tv_sec);
+    ASSERT_EQUALS(static_cast<time_t>(-315619140), get_atime(meta).tv_sec);
+
+    // nanoseconds are kept alongside a negative number of seconds
+    headers_t nsecmeta;
+    nsecmeta["x-amz-meta-mtime"] = "-315619140.123";
+    ASSERT_EQUALS(static_cast<time_t>(-315619140), get_mtime(nsecmeta).tv_sec);
+    ASSERT_EQUALS(static_cast<long>(123), get_mtime(nsecmeta).tv_nsec);
+}
+
+//
+// An absent header is distinct from a negative one: without overcheck it is
+// reported as omitted, and with overcheck it falls back to Last-Modified.
+//
+static void test_missing_times()
+{
+    headers_t empty;
+    ASSERT_EQUALS(static_cast<long>(UTIME_OMIT), get_mtime(empty, false).tv_nsec);
+    ASSERT_EQUALS(static_cast<long>(UTIME_OMIT), get_ctime(empty, false).tv_nsec);
+    ASSERT_EQUALS(static_cast<long>(UTIME_OMIT), get_atime(empty, false).tv_nsec);
+
+    headers_t lastmod;
+    lastmod["Last-Modified"] = "Mon, 03 Feb 2020 04:05:06 GMT";
+    ASSERT_TRUE(0 < get_mtime(lastmod, true).tv_sec);
+}
+
+//
+// valid_timespec() rejects only the UTIME_OMIT/UTIME_NOW markers; a negative
+// number of seconds is an ordinary time.
+//
+static void test_valid_timespec()
+{
+    struct timespec negative = {-315619140, 0};
+    ASSERT_TRUE(valid_timespec(negative));
+
+    struct timespec epoch = {0, 0};
+    ASSERT_TRUE(valid_timespec(epoch));
+
+    struct timespec omit = {0, UTIME_OMIT};
+    ASSERT_FALSE(valid_timespec(omit));
+
+    struct timespec now = {0, UTIME_NOW};
+    ASSERT_FALSE(valid_timespec(now));
+}
+
+int main(int argc, const char *argv[])
+{
+    test_negative_times();
+    test_missing_times();
+    test_valid_timespec();
+
+    return 0;
+}
+
+/*
+* Local variables:
+* tab-width: 4
+* c-basic-offset: 4
+* End:
+* vim600: expandtab sw=4 ts=4 fdm=marker
+* vim<600: expandtab sw=4 ts=4
+*/

--- a/src/test_metaheader.cpp
+++ b/src/test_metaheader.cpp
@@ -67,6 +67,16 @@ static void test_missing_times()
     headers_t lastmod;
     lastmod["Last-Modified"] = "Mon, 03 Feb 2020 04:05:06 GMT";
     ASSERT_TRUE(0 < get_mtime(lastmod, true).tv_sec);
+
+    //
+    // With overcheck and no Last-Modified either, there is no time to report.
+    // get_lastmodified() answers -1 in that case, and handing that back would
+    // date a directory that only exists as a key prefix to one second before
+    // the epoch instead of defaulting it.
+    //
+    ASSERT_EQUALS(static_cast<long>(UTIME_OMIT), get_mtime(empty, true).tv_nsec);
+    ASSERT_EQUALS(static_cast<long>(UTIME_OMIT), get_ctime(empty, true).tv_nsec);
+    ASSERT_EQUALS(static_cast<long>(UTIME_OMIT), get_atime(empty, true).tv_nsec);
 }
 
 //


### PR DESCRIPTION
Three unrelated timestamp defects found by xfstests generic/313, 728 and 258.

truncate(2) only updated ctime and mtime when the file was not already open, because the update sat inside the "need_flush" branch that runs when there is no open descriptor.  ftruncate(2) on an open file, and truncate(2) on a file another descriptor holds open, therefore left both times untouched.  Set the times whichever path is taken, and when the file is open mark the metadata dirty so the flush at close uploads them and refresh the stat cache so it stops serving the pre-truncate values.

removexattr(2) did not update ctime, though setxattr(2) already did.

Times before the epoch were discarded.  get_mtime(), get_ctime() and get_atime() reported a missing header as a negative sentinel and then treated every negative tv_sec as invalid, so a real pre-1970 timestamp fell back to Last-Modified; convert_header_to_stat() clamped what was left to the epoch, and valid_timespec() rejected it a third time. Report absence separately from the parsed value and key the remaining checks off the existing UTIME_OMIT marker, which already means "no value", so a negative number of seconds survives the round trip.

test_metaheader covers the parsing; it fails against the previous code. The xfstests generic/quick group goes from 26 to 23 failures with no new ones, and the ALL_TESTS integration matrix passes all 11 legs.