### PR TITLE
Stop a truncated listing from standing in for a directory's contents

### DIFF
--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -1352,20 +1352,20 @@ static int directory_empty(const char* path)
 
     // check s3objlist in cache
     if(!StatCache::getStatCacheData()->GetS3ObjList(path, head)){
+        // [NOTE]
+        // Only the presence of a child matters here, so this listing is
+        // deliberately truncated(max-keys=2 and no paging).  It must not be
+        // stored in the shared child listing cache: readdir() reads that cache
+        // as the complete list of a directory's children, so caching this would
+        // make a directory with many entries appear to hold at most two.
+        //
         if((result = list_bucket(path, head, "/", true)) != 0){
             S3FS_PRN_ERR("list_bucket returns error.");
             return result;
         }
-        if(!head.IsEmpty()){
-            if(!StatCache::getStatCacheData()->AddS3ObjList(path, head)){
-                S3FS_PRN_WARN("failed to add s3objlist for %s, but continue...", path);
-            }
-            result = -ENOTEMPTY;
-        }
-    }else{
-        if(!head.IsEmpty()){
-            result = -ENOTEMPTY;
-        }
+    }
+    if(!head.IsEmpty()){
+        result = -ENOTEMPTY;
     }
     return result;
 }
@@ -1848,15 +1848,17 @@ static int rename_directory(const char* from, const char* to)
     // No delimiter is specified, the result(head) is all object keys.
     // (CommonPrefixes is empty, but all object is listed in Key.)
     //
-    if(!StatCache::getStatCacheData()->GetS3ObjList(basepath, head)){
-        // get a list of all the objects
-        if(0 != (result = list_bucket(basepath.c_str(), head, nullptr))){
-            S3FS_PRN_ERR("list_bucket returns error.");
-            return result;
-        }
-        if(!StatCache::getStatCacheData()->AddS3ObjList(basepath, head)){
-            S3FS_PRN_WARN("failed to add s3objlist for %s, but continue...", basepath.c_str());
-        }
+    // [NOTE]
+    // The shared child listing cache holds only the direct children of a
+    // directory, because readdir() fills it with a "/" delimited listing.
+    // That cannot stand in for the recursive listing needed here, and storing
+    // this recursive listing there would in turn make readdir() report nested
+    // paths as if they were direct entries.  So this listing is neither taken
+    // from nor written back to that cache.
+    //
+    if(0 != (result = list_bucket(basepath.c_str(), head, nullptr))){
+        S3FS_PRN_ERR("list_bucket returns error.");
+        return result;
     }
     head.GetNameList(headlist);                                             // get name without "/".
 


### PR DESCRIPTION
directory_empty() only needs to know whether a directory has any child, so it lists with max-keys=2 and stops after the first page.  It then stored that deliberately truncated listing in the child listing cache that readdir() reads as the complete list of a directory's children.  A failed rmdir(2) therefore made the directory appear to hold at most two entries:

    $ mkdir d && for i in $(seq 10); do : > d/f$i; done   # cold cache
    $ rmdir d
    rmdir: failed to remove 'd': Directory not empty
    $ ls d | wc -l
    1

The same cache is consulted by rename_directory(), so renaming such a directory afterwards moved only the two cached objects and left the rest stranded under the old key prefix, while reporting success:

    $ mv d e                    # 11 objects under d/
    $ # 9 objects stranded under d/, 2 moved to e/

Do not cache the truncated listing.  A complete listing that is already cached still answers the question, so it is still read.

rename_directory() also must not use that cache at all: it needs a recursive listing, whereas readdir() fills the cache with a "/" delimited one holding only direct children, and writing its recursive listing back would in turn make readdir() report nested paths as direct entries.  It now always lists directly.

xfstests generic/013 failed 5 of 5 runs before this change and 2 of 5 after, so a further problem remains under parallel fsstress; the generic/quick group goes from 26 failures to 25 with no new ones, and the ALL_TESTS integration matrix passes all 11 legs.