### PR TITLE
Prevent expiration of Directory StatCaches with no_truncate child nodes

### DIFF
--- a/src/cache_node.cpp
+++ b/src/cache_node.cpp
@@ -200,7 +200,7 @@ bool StatCacheNode::ResumeExpireCheck()
 //-------------------------------------------------------------------
 // Methods
 //-------------------------------------------------------------------
-StatCacheNode::StatCacheNode(const char* path, objtype_t type) : cache_type(type), fullpath(path ? path: "")
+StatCacheNode::StatCacheNode(const char* path, const std::shared_ptr<StatCacheNode>& parentdir, objtype_t type) : cache_type(type), fullpath(path ? path: ""), parent(parentdir)
 {
     if(IS_DIR_OBJ(cache_type)){
         // directory type must end with '/'.
@@ -222,6 +222,19 @@ StatCacheNode::StatCacheNode(const char* path, objtype_t type) : cache_type(type
 
 StatCacheNode::~StatCacheNode()
 {
+    if(notruncate){
+        // [NOTE]
+        // No locking is performed when calling GetParentHasLock()
+        // within the destructor.
+        // Similarly, the call to pParent->DecrementNoTruncateChildHasLock()
+        // here does not involve locking. This is because the destructor for
+        // the StatCacheNode class (and its derived classes) is invoked with
+        // pParent already locked.
+        //
+        if(auto pParent = GetParentHasLock()){
+            pParent->DecrementNoTruncateChildHasLock();
+        }
+    }
     StatCacheNode::DecrementCacheCount(objtype_t::UNKNOWN);
 }
 
@@ -412,7 +425,18 @@ bool StatCacheNode::UpdateHasLock(const struct stat* pstat, bool clear_meta)
 
 bool StatCacheNode::UpdateHasLock(bool is_notruncate)
 {
-    notruncate = is_notruncate;
+    if(notruncate != is_notruncate){
+        if(is_notruncate){
+            if(auto pParent = GetParentHasLock()){
+                pParent->IncrementNoTruncateChildHasLock();
+            }
+        }else{
+            if(auto pParent = GetParentHasLock()){
+                pParent->DecrementNoTruncateChildHasLock();
+            }
+        }
+        notruncate = is_notruncate;
+    }
     return true;
 }
 
@@ -659,6 +683,16 @@ bool StatCacheNode::GetNoTruncateHasLock() const
     return notruncate;
 }
 
+void StatCacheNode::IncrementNoTruncateChildHasLock()
+{
+    // nothing to do for this base class
+}
+
+void StatCacheNode::DecrementNoTruncateChildHasLock()
+{
+    // nothing to do for this base class
+}
+
 unsigned long StatCacheNode::IncrementHitCount()
 {
     std::lock_guard<std::mutex> lock(StatCacheNode::cache_lock);
@@ -720,6 +754,11 @@ bool StatCacheNode::GetS3ObjList(S3ObjList& list)
     ++hit_count;
 
     return true;
+}
+
+std::shared_ptr<StatCacheNode> StatCacheNode::GetParentHasLock() const
+{
+    return parent.lock();
 }
 
 bool StatCacheNode::IsExpireStatCacheTimeHasLock() const
@@ -841,7 +880,7 @@ void StatCacheNode::Dump(bool detail)
 //
 // Methods
 //
-FileStatCache::FileStatCache(const char* path) : StatCacheNode(path, objtype_t::FILE)
+FileStatCache::FileStatCache(const char* path, const std::shared_ptr<StatCacheNode>& parentdir) : StatCacheNode(path, parentdir, objtype_t::FILE)
 {
     StatCacheNode::IncrementCacheCount(objtype_t::FILE);
 }
@@ -857,7 +896,7 @@ FileStatCache::~FileStatCache()
 //
 // Methods
 //
-DirStatCache::DirStatCache(const char* path, objtype_t type) : StatCacheNode(path, type), dir_cache_type(type)
+DirStatCache::DirStatCache(const char* path, const std::shared_ptr<StatCacheNode>& parentdir, objtype_t type) : StatCacheNode(path, parentdir, type), dir_cache_type(type)
 {
     std::lock_guard<std::mutex> dircachelock(dir_cache_lock);
     SetCurrentTime(last_check_date);
@@ -938,7 +977,11 @@ bool DirStatCache::RemoveChildHasLock(const std::string& strpath)
                 children.erase(iter);
             }else{
                 // if it is a directory type, first clear the data.
-                if(!iter->second->UpdateHasLock(nullptr, nullptr, true) || !iter->second->UpdateHasLock(false) || !iter->second->UpdateHasLock()){
+                if(iter->second->isRemovableHasLock()){
+                    if(!iter->second->UpdateHasLock(nullptr, nullptr, true) || !iter->second->UpdateHasLock(false) || !iter->second->UpdateHasLock()){
+                        result = false;
+                    }
+                }else{
                     result = false;
                 }
             }
@@ -947,6 +990,7 @@ bool DirStatCache::RemoveChildHasLock(const std::string& strpath)
             result = false;
         }
     }
+
     return result;
 }
 
@@ -963,7 +1007,7 @@ bool DirStatCache::RemoveChildInS3ObjListHasLock(const std::string& strChildLeaf
 
 bool DirStatCache::isRemovableHasLock() const
 {
-    if(HasStatHasLock() || HasMetaHasLock()){
+    if(0 < notruncate_cnt){
         return false;
     }
 
@@ -971,6 +1015,7 @@ bool DirStatCache::isRemovableHasLock() const
     if(HasExistedChildHasLock()){
         return false;
     }
+
     return true;
 }
 
@@ -1123,7 +1168,7 @@ bool DirStatCache::AddHasLock(const std::string& strpath, const struct stat* pst
         if(hasNestedChildren){
             // First add directory child, and add an under child
             std::string subdir     = GetPathHasLock() + strLeafName + "/";  // terminate with "/". (if not terminated, it will added automatically.)
-            auto        pstatcache = std::make_shared<DirStatCache>(subdir.c_str());
+            auto        pstatcache = std::make_shared<DirStatCache>(subdir.c_str(), shared_from_this());
 
             if(!pstatcache->AddHasLock(strpath, pstat, pmeta, type, is_notruncate)){
                 return false;
@@ -1136,11 +1181,11 @@ bool DirStatCache::AddHasLock(const std::string& strpath, const struct stat* pst
             // create and add as a direct child
             std::shared_ptr<StatCacheNode> pstatcache;
             if(IS_DIR_OBJ(type)){
-                pstatcache = std::make_shared<DirStatCache>(strpath.c_str(), type);
+                pstatcache = std::make_shared<DirStatCache>(strpath.c_str(), shared_from_this(), type);
             }else if(objtype_t::FILE == type){
-                pstatcache = std::make_shared<FileStatCache>(strpath.c_str());
+                pstatcache = std::make_shared<FileStatCache>(strpath.c_str(), shared_from_this());
             }else if(objtype_t::SYMLINK == type){
-                pstatcache = std::make_shared<SymlinkStatCache>(strpath.c_str());
+                pstatcache = std::make_shared<SymlinkStatCache>(strpath.c_str(), shared_from_this());
             }else if(objtype_t::NEGATIVE == type){
                 if(!StatCacheNode::IsEnabledNegativeCache()){
                     // Negative cache is invalid.
@@ -1148,7 +1193,7 @@ bool DirStatCache::AddHasLock(const std::string& strpath, const struct stat* pst
                     //
                     return true;
                 }
-                pstatcache = std::make_shared<NegativeStatCache>(strpath.c_str());
+                pstatcache = std::make_shared<NegativeStatCache>(strpath.c_str(), shared_from_this());
             }else{  // objtype_t::UNKNOWN
                 // [NOTE]
                 // If the type of object is UNKNOWN,  it has not been determined
@@ -1158,22 +1203,22 @@ bool DirStatCache::AddHasLock(const std::string& strpath, const struct stat* pst
                 //
                 if(pstat){
                     if(S_ISREG(pstat->st_mode)){
-                        pstatcache = std::make_shared<FileStatCache>(strpath.c_str());
+                        pstatcache = std::make_shared<FileStatCache>(strpath.c_str(), shared_from_this());
                     }else if(S_ISLNK(pstat->st_mode)){
-                        pstatcache = std::make_shared<SymlinkStatCache>(strpath.c_str());
+                        pstatcache = std::make_shared<SymlinkStatCache>(strpath.c_str(), shared_from_this());
                     }else if(S_ISDIR(pstat->st_mode)){
-                        pstatcache = std::make_shared<DirStatCache>(strpath.c_str(), objtype_t::DIR_NOT_TERMINATE_SLASH);   // objtype_t::DIR_NOT_TERMINATE_SLASH
+                        pstatcache = std::make_shared<DirStatCache>(strpath.c_str(), shared_from_this(), objtype_t::DIR_NOT_TERMINATE_SLASH);   // objtype_t::DIR_NOT_TERMINATE_SLASH
                     }else{
                         S3FS_PRN_ERR("The object type of path(%s) is unspecified(objtype_t::UNKNOWN) and cannot be determined.", strpath.c_str());
                         return false;
                     }
                 }else if(pmeta){
                     if(is_reg_fmt(*pmeta)){
-                        pstatcache = std::make_shared<FileStatCache>(strpath.c_str());
+                        pstatcache = std::make_shared<FileStatCache>(strpath.c_str(), shared_from_this());
                     }else if(is_symlink_fmt(*pmeta)){
-                        pstatcache = std::make_shared<SymlinkStatCache>(strpath.c_str());
+                        pstatcache = std::make_shared<SymlinkStatCache>(strpath.c_str(), shared_from_this());
                     }else if(is_dir_fmt(*pmeta)){
-                        pstatcache = std::make_shared<DirStatCache>(strpath.c_str(), objtype_t::DIR_NOT_TERMINATE_SLASH);   // objtype_t::DIR_NOT_TERMINATE_SLASH
+                        pstatcache = std::make_shared<DirStatCache>(strpath.c_str(), shared_from_this(), objtype_t::DIR_NOT_TERMINATE_SLASH);   // objtype_t::DIR_NOT_TERMINATE_SLASH
                     }else{
                         S3FS_PRN_ERR("The object type of path(%s) is unspecified(objtype_t::UNKNOWN) and cannot be determined.", strpath.c_str());
                         return false;
@@ -1246,8 +1291,17 @@ bool DirStatCache::AddS3ObjListHasLock(const std::string& strpath, const S3ObjLi
         auto iter = children.find(strLeafName);
         if(iter == children.end()){
             // Not found child
+            //
+            // [TODO]
+            // This occurs when an object along the path has not yet been cached,
+            // specifically when attempting to configure a subdirectory without
+            // having the cache for the parent directory.
+            // To maintain the S3Object cache, you should create a placeholder
+            // object for the intermediate path.
+            //
             return false;
         }
+
         if(!iter->second->isDirectoryHasLock()){
             // Found child is not directory cache
             return false;
@@ -1263,6 +1317,18 @@ bool DirStatCache::AddS3ObjListHasLock(const std::string& strpath, const S3ObjLi
         return false;
      }
     return true;
+}
+
+void DirStatCache::IncrementNoTruncateChildHasLock()
+{
+    ++notruncate_cnt;
+}
+
+void DirStatCache::DecrementNoTruncateChildHasLock()
+{
+    if(0 < notruncate_cnt){
+        --notruncate_cnt;
+    }
 }
 
 s3obj_type_map_t::size_type DirStatCache::GetChildMapHasLock(s3obj_type_map_t& childmap) const
@@ -1387,7 +1453,10 @@ bool DirStatCache::NeedTruncateProcessing() const
 //
 bool DirStatCache::IsExpiredHasLock() const
 {
-    if(GetNoTruncateHasLock()){
+    // [NOTE]
+    // If a notruncate flag exists in the children, can not expire the entry.
+    //
+    if(GetNoTruncateHasLock() || 0 < notruncate_cnt){
         // not truncate
         return false;
     }
@@ -1543,7 +1612,7 @@ void DirStatCache::DumpHasLock(const std::string& indent, bool detail, std::ostr
 //
 // Methods
 //
-SymlinkStatCache::SymlinkStatCache(const char* path) : StatCacheNode(path, objtype_t::SYMLINK)
+SymlinkStatCache::SymlinkStatCache(const char* path, const std::shared_ptr<StatCacheNode>& parentdir) : StatCacheNode(path, parentdir, objtype_t::SYMLINK)
 {
     StatCacheNode::IncrementCacheCount(objtype_t::SYMLINK);
 }
@@ -1565,7 +1634,7 @@ bool SymlinkStatCache::ClearHasLock()
 //
 // Methods
 //
-NegativeStatCache::NegativeStatCache(const char* path) : StatCacheNode(path, objtype_t::NEGATIVE)
+NegativeStatCache::NegativeStatCache(const char* path, const std::shared_ptr<StatCacheNode>& parentdir) : StatCacheNode(path, parentdir, objtype_t::NEGATIVE)
 {
     StatCacheNode::IncrementCacheCount(objtype_t::NEGATIVE);
 }

--- a/src/cache_node.h
+++ b/src/cache_node.h
@@ -95,6 +95,7 @@ class StatCacheNode : public std::enable_shared_from_this<StatCacheNode>
         headers_t               meta       GUARDED_BY(StatCacheNode::cache_lock);          // meta list
         bool                    has_extval GUARDED_BY(StatCacheNode::cache_lock) = false;  // valid extra value flag
         std::string             extvalue   GUARDED_BY(StatCacheNode::cache_lock);          // extra value for key(ex. used for symlink)
+        std::weak_ptr<StatCacheNode> parent GUARDED_BY(StatCacheNode::cache_lock);         // parent(directory) object
 
     protected:
         static void IncrementCacheCount(objtype_t type);
@@ -134,10 +135,13 @@ class StatCacheNode : public std::enable_shared_from_this<StatCacheNode>
         bool HasStatHasLock() const REQUIRES(StatCacheNode::cache_lock);
         bool HasMetaHasLock() const REQUIRES(StatCacheNode::cache_lock);
         bool GetNoTruncateHasLock() const REQUIRES(StatCacheNode::cache_lock);
+        virtual void IncrementNoTruncateChildHasLock() REQUIRES(StatCacheNode::cache_lock);
+        virtual void DecrementNoTruncateChildHasLock() REQUIRES(StatCacheNode::cache_lock);
         virtual bool GetHasLock(headers_t* pmeta, struct stat* pst) REQUIRES(StatCacheNode::cache_lock);
         virtual std::optional<std::string> GetExtraHasLock() REQUIRES(StatCacheNode::cache_lock);
         virtual s3obj_type_map_t::size_type GetChildMapHasLock(s3obj_type_map_t& childmap) const REQUIRES(StatCacheNode::cache_lock);
         virtual bool GetS3ObjListHasLock(S3ObjList& list) const REQUIRES(StatCacheNode::cache_lock);
+        std::shared_ptr<StatCacheNode> GetParentHasLock() const REQUIRES(StatCacheNode::cache_lock);
 
         // Find
         virtual bool CheckETagValueHasLock(const char* petagval) const REQUIRES(StatCacheNode::cache_lock);
@@ -166,7 +170,7 @@ class StatCacheNode : public std::enable_shared_from_this<StatCacheNode>
         static bool ResumeExpireCheck();
 
         // Constructor/Destructor
-        explicit StatCacheNode(const char* path = nullptr, objtype_t type = objtype_t::UNKNOWN);
+        explicit StatCacheNode(const char* path = nullptr, const std::shared_ptr<StatCacheNode>& parentdir = nullptr, objtype_t type = objtype_t::UNKNOWN);
         virtual ~StatCacheNode();
 
         StatCacheNode(const StatCacheNode&) = delete;
@@ -232,7 +236,7 @@ using statcache_map_t = std::map<std::string, std::shared_ptr<StatCacheNode>>;
 class FileStatCache : public StatCacheNode
 {
     public:
-        explicit FileStatCache(const char* path = nullptr);
+        explicit FileStatCache(const char* path = nullptr, const std::shared_ptr<StatCacheNode>& parentdir = nullptr);
         ~FileStatCache() override;
 
         FileStatCache(const FileStatCache&) = delete;
@@ -260,6 +264,7 @@ class DirStatCache : public StatCacheNode
         statcache_map_t children        GUARDED_BY(dir_cache_lock);
         bool            has_s3obj       GUARDED_BY(dir_cache_lock) = false;
         S3ObjList       s3obj           GUARDED_BY(dir_cache_lock);
+        int             notruncate_cnt  GUARDED_BY(cache_lock) = 0;                         // number of children which have "no truncate" flag(includes directories).
 
     protected:
         bool ClearHasLock() override REQUIRES(StatCacheNode::cache_lock);
@@ -272,6 +277,8 @@ class DirStatCache : public StatCacheNode
         bool AddHasLock(const std::string& strpath, const struct stat* pstat, const headers_t* pmeta, objtype_t type, bool is_notruncate) override REQUIRES(StatCacheNode::cache_lock);
         bool AddS3ObjListHasLock(const std::string& strpath, const S3ObjList& list) override REQUIRES(StatCacheNode::cache_lock);
 
+        void IncrementNoTruncateChildHasLock() override REQUIRES(StatCacheNode::cache_lock);
+        void DecrementNoTruncateChildHasLock() override REQUIRES(StatCacheNode::cache_lock);
         s3obj_type_map_t::size_type GetChildMapHasLock(s3obj_type_map_t& childmap) const override REQUIRES(StatCacheNode::cache_lock);
         bool GetS3ObjListHasLock(S3ObjList& list) const override REQUIRES(StatCacheNode::cache_lock);
 
@@ -287,7 +294,7 @@ class DirStatCache : public StatCacheNode
         void DumpHasLock(const std::string& indent, bool detail, std::ostringstream& oss) override REQUIRES(StatCacheNode::cache_lock);
 
     public:
-        explicit DirStatCache(const char* path = nullptr, objtype_t type = objtype_t::DIR_NORMAL);
+        explicit DirStatCache(const char* path = nullptr, const std::shared_ptr<StatCacheNode>& parentdir = nullptr, objtype_t type = objtype_t::DIR_NORMAL);
         ~DirStatCache() override;
 
         DirStatCache(const DirStatCache&) = delete;
@@ -308,7 +315,7 @@ class SymlinkStatCache : public StatCacheNode
         bool ClearHasLock() override REQUIRES(StatCacheNode::cache_lock);
 
     public:
-        explicit SymlinkStatCache(const char* path = nullptr);
+        explicit SymlinkStatCache(const char* path = nullptr, const std::shared_ptr<StatCacheNode>& parentdir = nullptr);
         ~SymlinkStatCache() override;
 
         SymlinkStatCache(const SymlinkStatCache&) = delete;
@@ -328,7 +335,7 @@ class NegativeStatCache : public StatCacheNode
         bool IsExpiredHasLock() const override REQUIRES(StatCacheNode::cache_lock);
 
     public:
-        explicit NegativeStatCache(const char* path = nullptr);
+        explicit NegativeStatCache(const char* path = nullptr, const std::shared_ptr<StatCacheNode>& parentdir = nullptr);
         ~NegativeStatCache() override;
 
         NegativeStatCache(const NegativeStatCache&) = delete;

--- a/src/s3fs.cpp
+++ b/src/s3fs.cpp
@@ -123,7 +123,7 @@ static int create_directory_object(const char* path, mode_t mode, const struct t
 static int rename_object(const char* from, const char* to, bool update_ctime);
 static int rename_object_nocopy(const char* from, const char* to, bool update_ctime);
 static int clone_directory_object(const char* from, const char* to, bool update_ctime, const char* pxattrvalue);
-static int rename_directory(const char* from, const char* to);
+static int rename_directory(const char* from, const char* to, bool is_nested);
 static int update_mctime_parent_directory(const char* _path);
 static int remote_mountpath_exists(const char* path, bool compat_dir);
 static std::optional<std::string> get_meta_xattr_value(const char* path);
@@ -1387,23 +1387,44 @@ static int directory_empty(const char* path)
     int       result = 0;
     S3ObjList head;
 
-    // check s3objlist in cache
-    if(!StatCache::getStatCacheData()->GetS3ObjList(path, head)){
+    if(0 < StatCache::getStatCacheData()->GetCacheSize()){
+        // use stat cache
+        if(!StatCache::getStatCacheData()->GetS3ObjList(path, head)){
+            // [NOTE]
+            // Call list_bucket without restrictions(check_content_only=false).
+            // If you only need to verify the existence of files under a specific directory,
+            // calling it with restrictions(check_content_only=true) yields a faster response.
+            // However, calling it without restrictions causes S3Object instances to be cached,
+            // so we expect the cache to function effectively for subsequent calls.
+            //
+            if((result = list_bucket(path, head, "/")) != 0){
+                S3FS_PRN_ERR("list_bucket returns error.");
+                return result;
+            }
+
+            // [NOTE]
+            // It caches the result even when S3ObjList is empty.
+            // This effectively caches the fact that the directory is empty.
+            //
+            if(!StatCache::getStatCacheData()->AddS3ObjList(path, head)){
+                S3FS_PRN_WARN("failed to add s3objlist for %s, but continue...", path);
+            }
+        }
+    }else{
+        // not use stat cache
+        //
+        // If the stat cache is invalid, the S3Object cache is also unnecessary, so list_bucket
+        // is called with the restriction(check_content_only=true).
+        //
         if((result = list_bucket(path, head, "/", true)) != 0){
             S3FS_PRN_ERR("list_bucket returns error.");
             return result;
         }
-        if(!head.IsEmpty()){
-            if(!StatCache::getStatCacheData()->AddS3ObjList(path, head)){
-                S3FS_PRN_WARN("failed to add s3objlist for %s, but continue...", path);
-            }
-            result = -ENOTEMPTY;
-        }
-    }else{
-        if(!head.IsEmpty()){
-            result = -ENOTEMPTY;
-        }
     }
+    if(!head.IsEmpty()){
+        result = -ENOTEMPTY;
+    }
+
     return result;
 }
 
@@ -1850,13 +1871,13 @@ static int clone_directory_object(const char* from, const char* to, bool update_
     return result;
 }
 
-static int rename_directory(const char* from, const char* to)
+static int rename_directory(const char* from, const char* to, bool is_nested)
 {
     S3ObjList    head;
     s3obj_list_t headlist;
     std::string  strfrom  = from ? from : "";   // from is without "/".
     std::string  strto    = to ? to : "";       // to is without "/" too.
-    std::string  basepath = strfrom + "/";
+    std::string  basepath = ('/' == strfrom.back() ? strfrom : (strfrom + "/"));
     std::string  normpath;                      // normalized path for "from name"(not used)
     objtype_t    ObjType;
     bool         normdir;
@@ -1966,13 +1987,23 @@ static int rename_directory(const char* from, const char* to)
             auto xattrvalue = get_meta_xattr_value(mn_cur->old_path.c_str());
             const char* pxattrvalue = xattrvalue ? xattrvalue->c_str() : nullptr;
 
-            // [NOTE]
-            // The ctime is updated only for the top (from) directory.
-            // Other than that, it will not be updated.
-            //
-            if(0 != (result = clone_directory_object(mn_cur->old_path.c_str(), mn_cur->new_path.c_str(), (strfrom == mn_cur->old_path), pxattrvalue))){
-                S3FS_PRN_ERR("clone_directory_object returned an error(%d)", result);
-                return result;
+            if(strfrom == mn_cur->old_path){
+                // current directory for renaming
+                //
+                // [NOTE]
+                // The ctime is updated only for the top (from) directory.
+                // Other than that, it will not be updated.
+                //
+                if(0 != (result = clone_directory_object(mn_cur->old_path.c_str(), mn_cur->new_path.c_str(), !is_nested, pxattrvalue))){
+                    S3FS_PRN_ERR("clone_directory_object returned an error(%d)", result);
+                    return result;
+                }
+            }else{
+                // subdirectory to be renamed -> reentrant
+                if(0 != (result = rename_directory(mn_cur->old_path.c_str(), mn_cur->new_path.c_str(), true))){    // keep ctime
+                    S3FS_PRN_ERR("rename sub directory(reentrant) returned an error(%d)", result);
+                    return result;
+                }
             }
         }
     }
@@ -2067,7 +2098,7 @@ static int s3fs_rename(const char* _from, const char* _to, unsigned int flags)
 
     // files larger than 5GB must be modified via the multipart interface
     if(S_ISDIR(buf.st_mode)){
-        result = rename_directory(from, to);
+        result = rename_directory(from, to, false);             // update ctime for top directory
     }else if(!nomultipart && buf.st_size >= singlepart_copy_limit){
         result = rename_large_object(from, to);
     }else{

--- a/src/test_cache_node.cpp
+++ b/src/test_cache_node.cpp
@@ -72,20 +72,20 @@ static void test_common_prefix_type()
 //
 static void test_dir_subtype_heal()
 {
-    DirStatCache root("/");
+    auto         root = std::make_shared<DirStatCache>("/");
     struct stat  st   = make_dir_stat();
     headers_t    meta;
     meta["Content-Type"]       = "application/x-directory";
     meta["x-amz-meta-foreign"] = "keepme";
 
-    ASSERT_TRUE(root.Add("/dir/", &st, &meta, objtype_t::DIR_NOT_TERMINATE_SLASH, false));
-    std::shared_ptr<StatCacheNode> node = root.Find("/dir/");
+    ASSERT_TRUE(root->Add("/dir/", &st, &meta, objtype_t::DIR_NOT_TERMINATE_SLASH, false));
+    std::shared_ptr<StatCacheNode> node = root->Find("/dir/");
     ASSERT_TRUE(nullptr != node);
     ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NOT_TERMINATE_SLASH), static_cast<int>(node->GetType()));
 
     // Update to the modern "dir/" representation.
-    ASSERT_TRUE(root.Add("/dir/", &st, &meta, objtype_t::DIR_NORMAL, false));
-    node = root.Find("/dir/");
+    ASSERT_TRUE(root->Add("/dir/", &st, &meta, objtype_t::DIR_NORMAL, false));
+    node = root->Find("/dir/");
     ASSERT_TRUE(nullptr != node);
     ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NORMAL), static_cast<int>(node->GetType()));
 
@@ -97,14 +97,14 @@ static void test_dir_subtype_heal()
     ASSERT_TRUE(getmeta.cend() != getmeta.find("x-amz-meta-foreign"));
 
     // The object was deleted externally and only the path remains.
-    ASSERT_TRUE(root.Add("/dir/", &st, &meta, objtype_t::DIR_NOT_EXIST_OBJECT, false));
-    node = root.Find("/dir/");
+    ASSERT_TRUE(root->Add("/dir/", &st, &meta, objtype_t::DIR_NOT_EXIST_OBJECT, false));
+    node = root->Find("/dir/");
     ASSERT_TRUE(nullptr != node);
     ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NOT_EXIST_OBJECT), static_cast<int>(node->GetType()));
 
     // Re-adding with the same sub-type keeps the node untouched.
-    ASSERT_TRUE(root.Add("/dir/", &st, &meta, objtype_t::DIR_NOT_EXIST_OBJECT, false));
-    node = root.Find("/dir/");
+    ASSERT_TRUE(root->Add("/dir/", &st, &meta, objtype_t::DIR_NOT_EXIST_OBJECT, false));
+    node = root->Find("/dir/");
     ASSERT_TRUE(nullptr != node);
     ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NOT_EXIST_OBJECT), static_cast<int>(node->GetType()));
 }
@@ -115,17 +115,17 @@ static void test_dir_subtype_heal()
 //
 static void test_nested_dir_subtype_heal()
 {
-    DirStatCache root("/");
-    struct stat  st = make_dir_stat();
+    auto         root = std::make_shared<DirStatCache>("/");
+    struct stat  st   = make_dir_stat();
 
-    ASSERT_TRUE(root.Add("/dir/", &st, nullptr, objtype_t::DIR_NORMAL, false));
-    ASSERT_TRUE(root.Add("/dir/sub/", &st, nullptr, objtype_t::DIR_NOT_TERMINATE_SLASH, false));
-    std::shared_ptr<StatCacheNode> node = root.Find("/dir/sub/");
+    ASSERT_TRUE(root->Add("/dir/", &st, nullptr, objtype_t::DIR_NORMAL, false));
+    ASSERT_TRUE(root->Add("/dir/sub/", &st, nullptr, objtype_t::DIR_NOT_TERMINATE_SLASH, false));
+    std::shared_ptr<StatCacheNode> node = root->Find("/dir/sub/");
     ASSERT_TRUE(nullptr != node);
     ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NOT_TERMINATE_SLASH), static_cast<int>(node->GetType()));
 
-    ASSERT_TRUE(root.Add("/dir/sub/", &st, nullptr, objtype_t::DIR_NORMAL, false));
-    node = root.Find("/dir/sub/");
+    ASSERT_TRUE(root->Add("/dir/sub/", &st, nullptr, objtype_t::DIR_NORMAL, false));
+    node = root->Find("/dir/sub/");
     ASSERT_TRUE(nullptr != node);
     ASSERT_EQUALS(static_cast<int>(objtype_t::DIR_NORMAL), static_cast<int>(node->GetType()));
 }
@@ -135,16 +135,16 @@ static void test_nested_dir_subtype_heal()
 //
 static void test_file_type_unchanged()
 {
-    DirStatCache root("/");
-    struct stat  st = make_file_stat();
+    auto         root = std::make_shared<DirStatCache>("/");
+    struct stat  st   = make_file_stat();
 
-    ASSERT_TRUE(root.Add("/file", &st, nullptr, objtype_t::FILE, false));
-    std::shared_ptr<StatCacheNode> node = root.Find("/file");
+    ASSERT_TRUE(root->Add("/file", &st, nullptr, objtype_t::FILE, false));
+    std::shared_ptr<StatCacheNode> node = root->Find("/file");
     ASSERT_TRUE(nullptr != node);
     ASSERT_EQUALS(static_cast<int>(objtype_t::FILE), static_cast<int>(node->GetType()));
 
-    ASSERT_TRUE(root.Add("/file", &st, nullptr, objtype_t::FILE, false));
-    node = root.Find("/file");
+    ASSERT_TRUE(root->Add("/file", &st, nullptr, objtype_t::FILE, false));
+    node = root->Find("/file");
     ASSERT_TRUE(nullptr != node);
     ASSERT_EQUALS(static_cast<int>(objtype_t::FILE), static_cast<int>(node->GetType()));
 }


### PR DESCRIPTION
### Relevant Issue (if applicable)
#2929, #2960, #2961

### Issue
When a newly created file has not yet been flushed, its metadata exists solely within the StatCache because the file has not yet been uploaded to the server.
If the parent directory's StatCache is cached out (evicted) in this state, rebuilding the directory's file list from the server causes an inconsistency, as the un-uploaded file will not be included.

### Solution
Objects that have not yet been uploaded to the server have a `no_truncate` flag set in their StatCache.
Therefore, when eviction of a parent directory's cache is requested, eviction is now prevented if the directory contains any child objects with the `no_truncate` flag.

Additionally, when utilizing the StatCache during `directory_empty` checks, the behavior has been updated to list all files(S3Objects) in the directory and cache them.
(Previously, it did not perform a full listing.)
In typical use cases, checking whether a directory is empty is often followed by operations that retrieve the file list, so performing a full listing during `directory_empty` should be fine.

### Context / Notes
This PR demonstrates an alternative approach to #2929, #2960, and #2961.
While the approach in the original set of PRs also resolves the issue, I believe leveraging the StatCache effectively(especially for newly created files) is a better direction.

This work originally started as an effort to fix slow performance when renaming directories containing a large number of files.
I decided to create this PR thinking it would be best to address the issues raised in #2929, #2960, and #2961 at the same time.
Thanks to many hints from those PRs, I arrived at the conclusion that updating `StatCache` itself might be the best solution.

### Future Work (Backlog)
I discovered a separate issue in `StatCache` unrelated to this PR or #2929, #2960, and #2961.
I plan to work on a fix for that issue soon.

@gaul 
Could you please compare this PR with #2929, #2960, and #2961 and let me know your thoughts?

